### PR TITLE
Added dt.GetScaleMetrics scalar SQL function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,20 +1,34 @@
 # Changelog
 
+## v0.7.0-alpha
+
+### New
+
+* Added `dt.GetScaleMetric` SQL function for use with the [MSSQL KEDA Scaler](https://keda.sh/docs/scalers/mssql/).
+
+### Updates
+
+* Switched default task hub mode back to multitenant, since it simplifies certain test setups
+
+### Breaking changes
+
+* None
+
 ## v0.6.0-alpha
 
 ### New
 
 * Support for sub-orchestrations ([#7](https://github.com/microsoft/durabletask-mssql/pull/7)) - contributed by [@usemam](https://github.com/usemam)
-* Support for explicit task hub name configuration
-* Added `dt.GlobalSettings` table and `dt.SetGlobalSetting` stored procedure
-* Added new permissions.sql setup script for setting up databaes permissions
-* Added task hub documentation page
+* Support for explicit task hub name configuration ([#10](https://github.com/microsoft/durabletask-mssql/pull/10))
+* Added `dt.GlobalSettings` table and `dt.SetGlobalSetting` stored procedure ([#10](https://github.com/microsoft/durabletask-mssql/pull/10))
+* Added new permissions.sql setup script for setting up databaes permissions ([#10](https://github.com/microsoft/durabletask-mssql/pull/10))
+* Added task hub documentation page ([#10](https://github.com/microsoft/durabletask-mssql/pull/10))
 
-## Breaking changes
+### Breaking changes
 
-* Renamed `SqlProviderOptions` to `SqlOrchestrationServiceSettings` and added required constructor parameters
-* User-based multitenancy is now disabled by default
-* The `dt_runtime` role is now granted access to only specific stored procedures rather than all of them
+* Renamed `SqlProviderOptions` to `SqlOrchestrationServiceSettings` and added required constructor parameters ([#10](https://github.com/microsoft/durabletask-mssql/pull/10))
+* User-based multitenancy is now disabled by default ([#10](https://github.com/microsoft/durabletask-mssql/pull/10))
+* The `dt_runtime` role is now granted access to only specific stored procedures rather than all of them ([#10](https://github.com/microsoft/durabletask-mssql/pull/10))
 
 ## v0.5.0-alpha
 

--- a/src/DurableTask.SqlServer/Scripts/drop-schema.sql
+++ b/src/DurableTask.SqlServer/Scripts/drop-schema.sql
@@ -3,6 +3,7 @@
 
 -- Functions
 DROP FUNCTION IF EXISTS dt.CurrentTaskHub
+DROP FUNCTION IF EXISTS dt.GetScaleMetric
 
 -- Views
 DROP VIEW IF EXISTS dt.vHistory

--- a/src/DurableTask.SqlServer/Scripts/logic.sql
+++ b/src/DurableTask.SqlServer/Scripts/logic.sql
@@ -30,6 +30,33 @@ END
 GO
 
 
+CREATE OR ALTER FUNCTION dt.GetScaleMetric()
+    RETURNS varchar(50)
+    WITH EXECUTE AS CALLER
+AS
+BEGIN
+    DECLARE @taskHub varchar(50) = dt.CurrentTaskHub()
+    DECLARE @now datetime2 = SYSUTCDATETIME()
+
+    DECLARE @liveInstances int = 0
+    DECLARE @liveTasks int = 0
+
+    SELECT
+        @liveInstances = COUNT(DISTINCT E.[InstanceID]),
+        @liveTasks = COUNT(T.[InstanceID])
+    FROM dt.Instances I WITH (NOLOCK)
+        LEFT OUTER JOIN dt.NewEvents E WITH (NOLOCK) ON E.[TaskHub] = @taskHub AND E.[InstanceID] = I.[InstanceID]
+        LEFT OUTER JOIN dt.NewTasks T WITH (NOLOCK) ON T.[TaskHub] = @taskHub AND T.[InstanceID] = I.[InstanceID]
+    WHERE
+        I.[TaskHub] = @taskHub
+        AND I.[RuntimeStatus] IN ('Pending', 'Running')
+        AND (E.[VisibleTime] IS NULL OR E.[VisibleTime] < @now)
+
+    RETURN @liveInstances + @liveTasks
+END
+GO
+
+
 CREATE OR ALTER VIEW dt.vInstances
 AS
     SELECT

--- a/src/DurableTask.SqlServer/Scripts/permissions.sql
+++ b/src/DurableTask.SqlServer/Scripts/permissions.sql
@@ -13,6 +13,9 @@ END
 -- on the task hub since that is. that no
 -- database user can access data created by another database user.
 
+-- Functions 
+GRANT EXECUTE ON OBJECT::dt.GetScaleMetric TO dt_runtime
+
 -- Public sprocs
 GRANT EXECUTE ON OBJECT::dt.CreateInstance TO dt_runtime
 GRANT EXECUTE ON OBJECT::dt.GetInstanceHistory TO dt_runtime

--- a/src/DurableTask.SqlServer/Scripts/schema-0.2.0.sql
+++ b/src/DurableTask.SqlServer/Scripts/schema-0.2.0.sql
@@ -213,6 +213,7 @@ BEGIN
         [LastModifiedBy] nvarchar(128) NOT NULL CONSTRAINT DF_GlobalSettings_LastModifiedby DEFAULT USER_NAME()
     )
     
-    INSERT INTO dt.GlobalSettings ([Name], [Value]) VALUES ('TaskHubMode', 0)
+    -- Default task hub mode is 1, or "User ID"
+    INSERT INTO dt.GlobalSettings ([Name], [Value]) VALUES ('TaskHubMode', 1)
 END
 GO

--- a/src/common.props
+++ b/src/common.props
@@ -16,7 +16,7 @@
   <!-- Version settings: https://andrewlock.net/version-vs-versionsuffix-vs-packageversion-what-do-they-all-mean/ -->
   <PropertyGroup>
     <MajorVersion>0</MajorVersion>
-    <VersionPrefix>$(MajorVersion).6.0</VersionPrefix>
+    <VersionPrefix>$(MajorVersion).7.0</VersionPrefix>
     <VersionSuffix>alpha</VersionSuffix>
     <AssemblyVersion>$(MajorVersion).0.0.0</AssemblyVersion>
     <BuildSuffix Condition="'$(GITHUB_RUN_NUMBER)' != ''">.$(GITHUB_RUN_NUMBER)</BuildSuffix>


### PR DESCRIPTION
This is SQL function intended to be used by external scalers, like the [KEDA mssql scaler](https://keda.sh/docs/scalers/mssql/). The result represents the maximum number of instances needed to process the current workload (maximum assuming that each orchestration event and/or task activity needs to be handled by one instance).

Also:
- Updated package versions to 0.7.0
- Reverted default task hub behavior to use the user ID
- Fixed formatting bugs in CHANGELOG.md