### PR TITLE
Disable PR triggers in Azure Pipelines

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,4 +1,5 @@
 trigger: none
+pr: none
 
 pool:
   vmImage: 'windows-latest'


### PR DESCRIPTION
The Azure Pipelines trigger is only intended to be run manually. However, it's always being run when a PR is created, wasting time and resources. Specifying `trigger: none` was intended to address this, but it doesn't seem to be sufficient.

Trying to follow the guidelines here and add `pr: none` to azure-pipelines.yaml: https://docs.microsoft.com/en-us/azure/devops/pipelines/repos/github?view=azure-devops&tabs=yaml#opting-out-of-pr-validation
