### PR TITLE
Initial support for auto-scale in Azure Functions Elastic Premium plans

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,15 +5,17 @@
 ### New
 
 * Added `dt.GetScaleMetric` SQL function for use with the [MSSQL KEDA Scaler](https://keda.sh/docs/scalers/mssql/).
+* Added `dt.GetScaleRecommendation` SQL function and `IScaleProvider` implementation for VNET scaling in Azure Functions.
 * Added versioning support for task activities ([#14](https://github.com/microsoft/durabletask-mssql/pull/14)) - contributed by [@usemam](https://github.com/usemam)
 
 ### Updates
 
-* Switched default task hub mode back to multitenant, since it simplifies certain test setups
+* Switched default task hub mode back to multitenant to simplify testing
+* Updated [Microsoft.Azure.WebJobs.Extensions.DurableTask](https://www.nuget.org/packages/Microsoft.Azure.WebJobs.Extensions.DurableTask) dependency to [v2.4.2](https://github.com/Azure/azure-functions-durable-extension/releases/tag/v2.4.2).
 
 ### Breaking changes
 
-* None
+* Changed `SqlDurabilityProviderFactory` and `SqlDurabilityOptions` classes from `public` to `internal`.
 
 ## v0.6.0-alpha
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -74,6 +74,8 @@ Multiple DTFx workers can be configured to use the same SQL database connection 
 
 The provider works by having a single worker take a lock on a particular orchestration instance (or entity) and then process all events for that orchestration instance. When it is done executing a particular step in the orchestration, the lock is released and other workers will have an opportunity to lock the instance if there are more events that need to be processed. Similarly, activities are distributed across all worker instances in a competing-consumer way. However, activity execution does not require taking a lock on an orchestration instance, allowing multiple workers can process activities concurrently.
 
+For more detailed information on scalability, see the [Scaling](scaling.md) topic.
+
 ### Polling
 
 The Durable SQL provider regularly polls the `dt.NewEvents` and `dt.NewTasks` tables for new events and tasks. Initially, there is a 0 to 50ms delay in between polling attempts. If no events are found, the SQL provider will slowly increase the amount of time in between polling intervals up to a maximum of **3 seconds**. This means that a mostly idle app could see up to 3 seconds delay between the time an execution is scheduled and when it is detected and executed.

--- a/docs/scaling.md
+++ b/docs/scaling.md
@@ -1,0 +1,112 @@
+# Scaling
+
+The Microsoft SQL Provider for the Durable Task Framework (DTFx) and Durable Functions is designed to run in elastic compute environments where nodes can be added or removed on-demand without introducing downtime. This article describes how scaling works and various options for configuring auto-scale.
+
+## Terminology
+
+Throughout this article, we'll use the term _worker_ to refer to a single replica of the DTFx backend. If you are building an app using DTFx directly, then _worker_ refers to an instance of the `TaskHubWorker` class. If you are building an app on the Azure Functions hosted service, then a _worker_ refers to a single instance of a function app. In the context of Kubernetes, a _worker_ typically corresponds to a deployment replica.
+
+## Load balancing
+
+The Durable SQL provider distributes orchestration and activity executions evenly across all workers that are configured for a particular [task hub](taskhubs.md). Each worker independently polls the database for work and will take on as much work as allowed by its [concurrency configuration settings](#concurrency-configuration) using a [competing consumer](https://docs.microsoft.com/azure/architecture/patterns/competing-consumers) load distribution strategy.
+
+![Scale-out](media/arch-diagram.png)
+
+Each worker replica is identical and capable of running _any_ orchestrator or activity task that it can fetch from the database. Assigning specific orchestrations or activities to specific workers is not supported. There's no hard limit to the number of workers that can be added to a task hub. The maximum number of workers is limited only by the amount of concurrent load that the SQL database can handle. If any worker fails or becomes unavailable, work will be automatically redistributed across the existing set of active workers within a few minutes.
+
+?> If you're familiar with the Azure Storage backend for DTFx and Durable Functions, one key difference with SQL provider is that orchestration executions can theoretically scale-out to any number of workers. There is no concept of partitions or leases.
+
+## Concurrency configuration
+
+Each task hub worker can execute multiple orchestration events and activity tasks concurrently. The actual number of events or tasks that execute concurrently is configurable and is one of the key factors that impacts scalability. For in-process .NET apps, you can specify concurrency settings in the `SqlOrchestrationServiceSettings` class. The following example code configures both the maximum number of concurrent activity tasks and orchestrator events to be the number of cores on the VM.
+
+```csharp
+var settings = new SqlOrchestrationServiceSettings
+{
+    MaxConcurrentActivities = Environment.ProcessorCount,
+    MaxActiveOrchestrations = Environment.ProcessorCount,
+};
+
+var service = new SqlOrchestrationService(settings);
+var worker = new TaskHubWorker(service);
+```
+
+When using Azure Functions, these values inferred from the existing `maxConcurrentOrchestratorFunctions` and `maxConcurrentActivityFunctions` settings in the [host.json file](https://docs.microsoft.com/azure/azure-functions/durable/durable-functions-bindings#host-json), as shown in the following example:
+
+```json
+{
+  "version": "2.0",
+  "extensions": {
+    "durableTask": {
+      "maxConcurrentOrchestratorFunctions": 8,
+      "maxConcurrentActivityFunctions": 8,
+      "storageProvider": {
+        "type": "MicrosoftSQL",
+        "connectionStringName": "SQLDB_Connection"
+      }
+    }
+  }
+}
+```
+
+The values you select will vary depending on your expected workload. For example, if your activities are CPU-intensive or consume lots of memory, then you'll likely want to configure a smaller value for activity concurrency. Similarly, if your orchestrations have large history payloads (because of large inputs, outputs, etc.) then you should consider smaller orchestration concurrency configuration values. Choosing this configuration carefully is important to ensure your app has the right balance of performance and reliability.
+
+?> Future versions of the Durable SQL provider may support automatic concurrency configuration based on available CPU, memory, and other metrics. However, until this support is available, it is recommended that you use performance and scale testing to determine the right concurrency configuration values for your expected workload.
+
+## Worker auto-scale
+
+The Durable SQL provider makes worker scale-out and scale-in recommendations based on the number of active and pending orchestration and activity tasks at any given time. The recommended number of workers is determined by dividing the current task backlog by the configured maximum per-worker concurrency settings. The basic formula looks like the following pseudocode:
+
+```pseudocode
+live_activities = rowcount(dt.Activities)
+live_orchestrators = rowcount(dt.Instances WHERE #events > 0)
+recommended_activity_workers = ceil(live_activities / max_concurrent_activities)
+recommended_orchestrator_workers = ceil(live_orchestrators / max_concurrent_orchestrators)
+recommended_worker_count = recommended_activity_workers + recommended_orchestrator_workers
+```
+
+Here are the English definitions of the variables mentioned in this algorithm:
+
+| Variable | Description |
+|-|-|
+| *live_activities* | The number of rows in the `dt.NewTasks` table. This represents both activity tasks being actively processed and those waiting to be processed. |
+| *max_concurrent_activities* | The maximum number of activities that can run concurrently on a single worker. This number is [configurable](#concurrency-configuration). |
+| *recommended_activity_workers* | The number of worker replicas needed to handle all active and pending activities (i.e. `live_activities`). |
+| *live_orchestrators* | The number of orchestration instances that are either active in memory or have events pending in the `dt.NewEvents` table. This does not include timer events scheduled in the future. |
+| *max_concurrent_orchestrators* | The maximum number of orchestrations that can run concurrently (i.e. active in memory, not idle) on a single worker. This number is [configurable](#concurrency-configuration). |
+| *recommended_orchestrator_workers* | The number of worker replicas needed to handle all active and pending orchestrator events (i.e. `live_orchestrators`). Each orchestrator must run on a single worker at a time so the actual number of events per orchestrator does not matter. |
+| *recommended_worker_count* | The total number of workers needed to handle all activity tasks and orchestrator events. |
+
+This value can be calculated automatically using either the `dt.GetScaleRecommendation` SQL function, which takes concurrency settings as parameters, or the `SqlOrchestrationService.GetScaleRecommendation` .NET API, which discovers the concurrency settings from configuration. The final number can then be given to an auto-scale compute component to change the number of allocated worker replicas.
+
+If you're using the Durable SQL provider with [Azure Durable Functions](https://docs.microsoft.com/azure/azure-functions/durable) running on the [Elastic Premium Plan](https://docs.microsoft.com/azure/azure-functions/functions-premium-plan), then auto-scaling the number of app instances is managed automatically if you enable runtime scale monitoring as described [here](https://docs.microsoft.com/azure/azure-functions/functions-networking-options#premium-plan-with-virtual-network-triggers). Note that this doesn't require you to configure any virtual networking features.
+
+!> The Azure Functions Consumption plan does not yet support Durable Functions apps configured with the Durable SQL provider.
+
+If you are running your app in Kubernetes and have [KEDA](https://keda.sh) installed in your cluster, you can use the [MSSQL](https://keda.sh/docs/scalers/mssql/) scaler to automatically scale your app deployment instances. The following is an example `ScaledObject` configuration that can be used.
+
+```yml
+apiVersion: keda.sh/v1alpha1
+kind: ScaledObject
+metadata:
+  name: mssql-scaledobject
+spec:
+  scaleTargetRef:
+    name: durabletask-mssql-app
+  triggers:
+  - type: mssql
+    metadata:
+      connectionStringFromEnv: SQLDB_Connection
+      targetValue: "1"
+      query: "SELECT dt.GetScaleRecommendation(8, 8)"
+```
+
+?> Note that the two parameters for the `dt.GetScaleRecommendation` SQL function are values for `@MaxOrchestrationsPerWorker` and `@MaxActivitiesPerWorker` respectively.
+
+The `targetValue` should always be `"1"` when using the `dt.GetScaleRecommendation` SQL function in the `query` property. This ensures there is a 1:1 mapping between workers and deployment replicas.
+
+!> Make sure that the database credentials used by the `ScaledObject` are the same as those used by the app. Otherwise the `dt.GetScaledRecommendation` might return incorrect recommendations. See the [Multitenancy](multitenancy.md) topic for more information about how database credentials are mapped to task hubs.
+
+## SQL database scale-out
+
+The current version of the Durable SQL provider supports connecting to a single database instance. In many cases, the database will be the primary performance bottleneck. The recommended way to scale-out the database compute capacity is to increase the number of cores allocated to the SQL Server instance. Instructions for scaling up a SQL Server instance is out of scope for this article. However, if you are using [Azure SQL Database](https://docs.microsoft.com/azure/azure-sql/database/sql-database-paas-overview), you have the option of using the [Serverless tier](https://docs.microsoft.com/azure/azure-sql/database/serverless-tier-overview), which auto-scales the database based on CPU usage.

--- a/docs/sidebar.md
+++ b/docs/sidebar.md
@@ -1,5 +1,6 @@
 * [Introduction](introduction.md "Durable Task SQL Provider")
 * [Getting started](quickstart.md)
 * [Architecture](architecture.md)
+* [Scaling](scaling.md)
 * [Task Hubs](taskhubs.md)
 * [Multitenancy](multitenancy.md)

--- a/docs/taskhubs.md
+++ b/docs/taskhubs.md
@@ -12,7 +12,9 @@ Task hubs are also the primary unit of isolation within a database. Each table i
 
 ## Configuring task hub names
 
-Tasks hubs can be configured explicitly in the SQL provider configuration or can be inferred by details of the SQL connection string. For self-hosted DTFx apps, you can configure the task hub directly in the `SqlProviderOptions` class.
+Tasks hubs can be configured explicitly in the SQL provider configuration or can be inferred by details of the SQL connection string. By default, the name of a task hub is the name of the database user. For more information, see the [Multitenancy](multitenancy.md) topic.
+
+For self-hosted DTFx apps that opt-out of multitenant mode, you can configure the task hub directly in the `SqlProviderOptions` class.
 
 ```csharp
 var options = new SqlProviderOptions
@@ -22,7 +24,7 @@ var options = new SqlProviderOptions
 };
 ```
 
-For Durable Functions apps, the task hub name can be configured in the `extensions/durableTask/hubName` property of the **host.json** file.
+For Durable Functions apps, explicit task hub names are configured in the `extensions/durableTask/hubName` property of the **host.json** file.
 
 ```json
 {
@@ -39,9 +41,7 @@ For Durable Functions apps, the task hub name can be configured in the `extensio
 }
 ```
 
-Task hub names can alternatively be inferred from database user credentials. For more information, see [Multitenancy](multitenancy.md).
-
-?> Task hub names are limited to 50 characters. If the specified task hub name exceeds 50 characters, the configured task hub name will be truncated and suffixed with an MD5 hash of the full task hub name to keep it within 50 characters.
+?> Task hub names are limited to 50 characters. If the specified task hub name exceeds 50 characters, it will be truncated and suffixed with an MD5 hash of the full task hub name to keep it within 50 characters. This behavior applies both to task hubs inferred from database usernames and explicitly configured task hub names.
 
 ## Case sensitivity
 

--- a/src/DurableTask.SqlServer.AzureFunctions/AssemblyInfo.cs
+++ b/src/DurableTask.SqlServer.AzureFunctions/AssemblyInfo.cs
@@ -1,0 +1,6 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using System.Runtime.CompilerServices;
+
+[assembly: InternalsVisibleTo("DurableTask.SqlServer.AzureFunctions.Tests, PublicKey=0024000004800000940000000602000000240000525341310004000001000100fd8328dce03cd2e3033a411da400c391864fb4896f1265b2e46914ae677f9268e57ce00fe5ab144bf1746670c16798821c1e821dc3bc0ebce8374c20de809e7ae1b613b71a0a2a5680782e0458cec6c520bc77a90b2c5b00425da400b611d110a43219a9db52e89ce52705e8d11e68ca536f9d5dbe1de8c054d4f70161984de3")]

--- a/src/DurableTask.SqlServer.AzureFunctions/DurableTask.SqlServer.AzureFunctions.csproj
+++ b/src/DurableTask.SqlServer.AzureFunctions/DurableTask.SqlServer.AzureFunctions.csproj
@@ -17,7 +17,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Azure.Functions.Extensions" Version="1.0.0" />
-    <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.DurableTask" Version="2.4.1" />
+    <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.DurableTask" Version="2.4.2" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/DurableTask.SqlServer.AzureFunctions/SqlDurabilityOptions.cs
+++ b/src/DurableTask.SqlServer.AzureFunctions/SqlDurabilityOptions.cs
@@ -10,7 +10,7 @@ namespace DurableTask.SqlServer.AzureFunctions
     using Microsoft.Extensions.Logging.Abstractions;
     using Newtonsoft.Json;
 
-    public class SqlDurabilityOptions
+    class SqlDurabilityOptions
     {
         [JsonProperty("connectionStringName")]
         public string ConnectionStringName { get; set; } = "SQLDB_Connection";
@@ -27,6 +27,7 @@ namespace DurableTask.SqlServer.AzureFunctions
         internal ILoggerFactory LoggerFactory { get; set; } = NullLoggerFactory.Instance;
         
         internal SqlOrchestrationServiceSettings GetOrchestrationServiceSettings(
+            DurableTaskOptions extensionOptions,
             IConnectionStringResolver connectionStringResolver)
         {
             if (connectionStringResolver == null)
@@ -57,6 +58,16 @@ namespace DurableTask.SqlServer.AzureFunctions
                 WorkItemLockTimeout = this.TaskEventLockTimeout,
                 WorkItemBatchSize = this.TaskEventBatchSize,
             };
+
+            if (extensionOptions.MaxConcurrentActivityFunctions.HasValue)
+            {
+                settings.MaxConcurrentActivities = extensionOptions.MaxConcurrentActivityFunctions.Value;
+            }
+
+            if (extensionOptions.MaxConcurrentOrchestratorFunctions.HasValue)
+            {
+                settings.MaxActiveOrchestrations = extensionOptions.MaxConcurrentOrchestratorFunctions.Value;
+            }
 
             return settings;
         }

--- a/src/DurableTask.SqlServer.AzureFunctions/SqlScaleMetric.cs
+++ b/src/DurableTask.SqlServer.AzureFunctions/SqlScaleMetric.cs
@@ -1,0 +1,12 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+namespace DurableTask.SqlServer.AzureFunctions
+{
+    using Microsoft.Azure.WebJobs.Host.Scale;
+
+    class SqlScaleMetric : ScaleMetrics
+    {
+        public int RecommendedReplicaCount { get; set; }
+    }
+}

--- a/src/DurableTask.SqlServer.AzureFunctions/SqlScaleMonitor.cs
+++ b/src/DurableTask.SqlServer.AzureFunctions/SqlScaleMonitor.cs
@@ -1,0 +1,76 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+namespace DurableTask.SqlServer.AzureFunctions
+{
+    using System;
+    using System.Linq;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Microsoft.Azure.WebJobs.Host.Scale;
+
+    /// <summary>
+    /// Azure Functions scale monitor implementation for the Durable Functions SQL backend.
+    /// </summary>
+    class SqlScaleMonitor : IScaleMonitor
+    {
+        static readonly ScaleStatus ScaleInVote = new ScaleStatus { Vote = ScaleVote.ScaleIn };
+        static readonly ScaleStatus NoScaleVote = new ScaleStatus { Vote = ScaleVote.None };
+        static readonly ScaleStatus ScaleOutVote = new ScaleStatus { Vote = ScaleVote.ScaleOut };
+
+        readonly SqlOrchestrationService service;
+
+        int? previousWorkerCount = -1;
+
+        public SqlScaleMonitor(SqlOrchestrationService service, string taskHubName)
+        {
+            this.service = service ?? throw new ArgumentNullException(nameof(service));
+            this.Descriptor = new ScaleMonitorDescriptor($"DurableTask-SqlServer:{taskHubName ?? "default"}");
+        }
+
+        /// <inheritdoc />
+        public ScaleMonitorDescriptor Descriptor { get; }
+
+        /// <inheritdoc />
+        public async Task<ScaleMetrics> GetMetricsAsync()
+        {
+            // GetRecommendedReplicaCountAsync will write a trace if the recommendation results
+            // in a worker count that is different from the worker count we pass in as an argument.
+            int recommendedReplicaCount = await this.service.GetRecommendedReplicaCountAsync(
+                this.previousWorkerCount,
+                CancellationToken.None);
+
+            return new SqlScaleMetric { RecommendedReplicaCount = recommendedReplicaCount };
+        }
+
+        /// <inheritdoc />
+        public ScaleStatus GetScaleStatus(ScaleStatusContext context)
+        {
+            SqlScaleMetric? mostRecentMetric = context.Metrics.LastOrDefault() as SqlScaleMetric;
+            if (mostRecentMetric == null)
+            {
+                return NoScaleVote;
+            }
+
+            this.previousWorkerCount = context.WorkerCount;
+
+            if (mostRecentMetric.RecommendedReplicaCount > context.WorkerCount)
+            {
+                return ScaleOutVote;
+            }
+            else if (mostRecentMetric.RecommendedReplicaCount < context.WorkerCount)
+            {
+                return ScaleInVote;
+            }
+            else
+            {
+                return NoScaleVote;
+            }
+        }
+
+        class SqlScaleMetric : ScaleMetrics
+        {
+            public int RecommendedReplicaCount { get; set; }
+        }
+    }
+}

--- a/src/DurableTask.SqlServer.AzureFunctions/SqlScaleMonitor.cs
+++ b/src/DurableTask.SqlServer.AzureFunctions/SqlScaleMonitor.cs
@@ -4,6 +4,7 @@
 namespace DurableTask.SqlServer.AzureFunctions
 {
     using System;
+    using System.Collections.Generic;
     using System.Linq;
     using System.Threading;
     using System.Threading.Tasks;
@@ -12,7 +13,7 @@ namespace DurableTask.SqlServer.AzureFunctions
     /// <summary>
     /// Azure Functions scale monitor implementation for the Durable Functions SQL backend.
     /// </summary>
-    class SqlScaleMonitor : IScaleMonitor
+    class SqlScaleMonitor : IScaleMonitor<SqlScaleMetric>
     {
         static readonly ScaleStatus ScaleInVote = new ScaleStatus { Vote = ScaleVote.ScaleIn };
         static readonly ScaleStatus NoScaleVote = new ScaleStatus { Vote = ScaleVote.None };
@@ -32,7 +33,10 @@ namespace DurableTask.SqlServer.AzureFunctions
         public ScaleMonitorDescriptor Descriptor { get; }
 
         /// <inheritdoc />
-        public async Task<ScaleMetrics> GetMetricsAsync()
+        async Task<ScaleMetrics> IScaleMonitor.GetMetricsAsync() => await this.GetMetricsAsync();
+
+        /// <inheritdoc />
+        public async Task<SqlScaleMetric> GetMetricsAsync()
         {
             // GetRecommendedReplicaCountAsync will write a trace if the recommendation results
             // in a worker count that is different from the worker count we pass in as an argument.
@@ -44,21 +48,28 @@ namespace DurableTask.SqlServer.AzureFunctions
         }
 
         /// <inheritdoc />
-        public ScaleStatus GetScaleStatus(ScaleStatusContext context)
+        ScaleStatus IScaleMonitor.GetScaleStatus(ScaleStatusContext context) => 
+            this.GetScaleStatusCore(context.WorkerCount, context.Metrics.Cast<SqlScaleMetric>());
+
+        /// <inheritdoc />
+        public ScaleStatus GetScaleStatus(ScaleStatusContext<SqlScaleMetric> context) =>
+            this.GetScaleStatusCore(context.WorkerCount, context.Metrics);
+
+        ScaleStatus GetScaleStatusCore(int currentWorkerCount, IEnumerable<SqlScaleMetric> metrics)
         {
-            SqlScaleMetric? mostRecentMetric = context.Metrics.LastOrDefault() as SqlScaleMetric;
+            SqlScaleMetric? mostRecentMetric = metrics.LastOrDefault();
             if (mostRecentMetric == null)
             {
                 return NoScaleVote;
             }
 
-            this.previousWorkerCount = context.WorkerCount;
+            this.previousWorkerCount = currentWorkerCount;
 
-            if (mostRecentMetric.RecommendedReplicaCount > context.WorkerCount)
+            if (mostRecentMetric.RecommendedReplicaCount > currentWorkerCount)
             {
                 return ScaleOutVote;
             }
-            else if (mostRecentMetric.RecommendedReplicaCount < context.WorkerCount)
+            else if (mostRecentMetric.RecommendedReplicaCount < currentWorkerCount)
             {
                 return ScaleInVote;
             }
@@ -66,11 +77,6 @@ namespace DurableTask.SqlServer.AzureFunctions
             {
                 return NoScaleVote;
             }
-        }
-
-        class SqlScaleMetric : ScaleMetrics
-        {
-            public int RecommendedReplicaCount { get; set; }
         }
     }
 }

--- a/src/DurableTask.SqlServer/LogHelper.cs
+++ b/src/DurableTask.SqlServer/LogHelper.cs
@@ -70,7 +70,6 @@ namespace DurableTask.SqlServer
             this.WriteLog(logEvent);
         }
 
-
         public void CheckpointCompleted(OrchestrationState state, Stopwatch latencyStopwatch)
         {
             var logEvent = new LogEvents.CheckpointCompletedEvent(
@@ -93,6 +92,14 @@ namespace DurableTask.SqlServer
         public void TransientDatabaseFailure(Exception e, string? instanceId, int retryCount)
         {
             var logEvent = new LogEvents.TransientDatabaseFailure(e, instanceId, retryCount);
+            this.WriteLog(logEvent);
+        }
+
+        public void ReplicaCountChangeRecommended(int currentCount, int recommendedCount)
+        {
+            var logEvent = new LogEvents.ReplicaCountChangeRecommended(
+                currentCount,
+                recommendedCount);
             this.WriteLog(logEvent);
         }
 

--- a/src/DurableTask.SqlServer/Logging/DefaultEventSource.cs
+++ b/src/DurableTask.SqlServer/Logging/DefaultEventSource.cs
@@ -198,5 +198,21 @@ namespace DurableTask.SqlServer.Logging
                 AppName,
                 ExtensionVersion);
         }
+
+        [Event(EventIds.ReplicaCountChangeRecommended, Level = EventLevel.Informational)]
+        internal void ReplicaCountChangeRecommended(
+            int CurrentCount,
+            int RecommendedCount,
+            string AppName,
+            string ExtensionVersion)
+        {
+            // TODO: Use WriteEventCore for better performance
+            this.WriteEvent(
+                EventIds.ReplicaCountChangeRecommended,
+                CurrentCount,
+                RecommendedCount,
+                AppName,
+                ExtensionVersion);
+        }
     }
 }

--- a/src/DurableTask.SqlServer/Logging/EventIds.cs
+++ b/src/DurableTask.SqlServer/Logging/EventIds.cs
@@ -18,5 +18,6 @@ namespace DurableTask.SqlServer.Logging
         public const int CheckpointCompleted = 306;
         public const int DuplicateExecutionDetected = 307;
         public const int TransientDatabaseFailure = 308;
+        public const int ReplicaCountChangeRecommended = 309;
     }
 }

--- a/src/DurableTask.SqlServer/Logging/LogEvents.cs
+++ b/src/DurableTask.SqlServer/Logging/LogEvents.cs
@@ -348,5 +348,36 @@ namespace DurableTask.SqlServer.Logging
                     DTUtils.AppName,
                     DTUtils.ExtensionVersionString);
         }
+
+        internal class ReplicaCountChangeRecommended : StructuredLogEvent, IEventSourceEvent
+        {
+            public ReplicaCountChangeRecommended(int currentCount, int recommendedCount)
+            {
+                this.CurrentCount = currentCount;
+                this.RecommendedCount = recommendedCount;
+            }
+
+            [StructuredLogField]
+            public int CurrentCount { get; }
+
+            [StructuredLogField]
+            public int RecommendedCount { get; }
+
+            public override EventId EventId => new EventId(
+                EventIds.ReplicaCountChangeRecommended,
+                nameof(EventIds.ReplicaCountChangeRecommended));
+
+            public override LogLevel Level => LogLevel.Information;
+
+            protected override string CreateLogMessage() =>
+                $"Recommending a replica count change from {this.CurrentCount} to {this.RecommendedCount}.";
+
+            void IEventSourceEvent.WriteEventSource() =>
+                DefaultEventSource.Log.ReplicaCountChangeRecommended(
+                    this.CurrentCount,
+                    this.RecommendedCount,
+                    DTUtils.AppName,
+                    DTUtils.ExtensionVersionString);
+        }
     }
 }

--- a/src/DurableTask.SqlServer/Scripts/drop-schema.sql
+++ b/src/DurableTask.SqlServer/Scripts/drop-schema.sql
@@ -4,6 +4,7 @@
 -- Functions
 DROP FUNCTION IF EXISTS dt.CurrentTaskHub
 DROP FUNCTION IF EXISTS dt.GetScaleMetric
+DROP FUNCTION IF EXISTS dt.GetScaleRecommendation
 
 -- Views
 DROP VIEW IF EXISTS dt.vHistory

--- a/src/DurableTask.SqlServer/Scripts/permissions.sql
+++ b/src/DurableTask.SqlServer/Scripts/permissions.sql
@@ -15,6 +15,7 @@ END
 
 -- Functions 
 GRANT EXECUTE ON OBJECT::dt.GetScaleMetric TO dt_runtime
+GRANT EXECUTE ON OBJECT::dt.GetScaleRecommendation TO dt_runtime
 
 -- Public sprocs
 GRANT EXECUTE ON OBJECT::dt.CreateInstance TO dt_runtime

--- a/src/DurableTask.SqlServer/Scripts/schema-0.2.0.sql
+++ b/src/DurableTask.SqlServer/Scripts/schema-0.2.0.sql
@@ -115,7 +115,7 @@ BEGIN
         [InstanceID] varchar(100) NOT NULL,
 		[ExecutionID] varchar(50) NOT NULL CONSTRAINT DF_Instances_ExecutionID DEFAULT (NEWID()), -- expected to be system generated
         [Name] varchar(300) NOT NULL, -- the type name of the orchestration or entity
-        [Version] varchar(100) NOT NULL, -- the version of the orchestration
+        [Version] varchar(100) NULL, -- the version of the orchestration (optional)
 		[CreatedTime] datetime2 NOT NULL CONSTRAINT DF_Instances_CreatedTime DEFAULT SYSUTCDATETIME(),
 		[LastUpdatedTime] datetime2 NULL,
         [CompletedTime] datetime2 NULL,

--- a/src/DurableTask.SqlServer/SqlOrchestrationServiceSettings.cs
+++ b/src/DurableTask.SqlServer/SqlOrchestrationServiceSettings.cs
@@ -63,6 +63,23 @@ namespace DurableTask.SqlServer
         public string AppName { get; set; } = Environment.MachineName;
 
         /// <summary>
+        /// Gets or sets the maximum number of work items that can be processed concurrently by a single worker.
+        /// The default value is the value of <see cref="Environment.ProcessorCount"/>.
+        /// </summary>
+        [JsonProperty("maxConcurrentActivities")]
+        public int MaxConcurrentActivities { get; set; } = Environment.ProcessorCount;
+
+        /// <summary>
+        /// Gets or sets the maximum number of orchestrations that can be loaded in memory at a time by a single worker.
+        /// The default value is the value of <see cref="Environment.ProcessorCount"/>.
+        /// </summary>
+        /// <remarks>
+        /// Orchestrations that are idle and waiting for inputs are unloaded from memory and do not count against this limit.
+        /// </remarks>
+        [JsonProperty("maxActiveOrchestrations")]
+        public int MaxActiveOrchestrations { get; set; } = Environment.ProcessorCount;
+
+        /// <summary>
         /// Gets a SQL connection string associated with the configured task hub.
         /// </summary>
         [JsonIgnore]

--- a/test/DurableTask.SqlServer.AzureFunctions.Tests/IntegrationTestBase.cs
+++ b/test/DurableTask.SqlServer.AzureFunctions.Tests/IntegrationTestBase.cs
@@ -41,7 +41,14 @@ namespace DurableTask.SqlServer.AzureFunctions.Tests
                         loggingBuilder.AddProvider(this.logProvider);
                         loggingBuilder.SetMinimumLevel(LogLevel.Information);
                     })
-                .ConfigureWebJobs(webJobsBuilder => webJobsBuilder.AddDurableTask())
+                .ConfigureWebJobs(
+                    webJobsBuilder =>
+                    {
+                        webJobsBuilder.AddDurableTask(options =>
+                        {
+                            options.StorageProvider["type"] = SqlDurabilityProvider.Name;
+                        });
+                    })
                 .ConfigureServices(
                     services =>
                     {

--- a/test/DurableTask.SqlServer.Tests/Integration/Orchestrations.cs
+++ b/test/DurableTask.SqlServer.Tests/Integration/Orchestrations.cs
@@ -165,9 +165,10 @@ namespace DurableTask.SqlServer.Tests.Integration
         [InlineData(100)]
         public async Task ActivityChain(int parallelCount)
         {
-            List<TestInstance<string>> instances = await this.testService.RunOrchestrations<int, string>(
+            IReadOnlyList<TestInstance<string>> instances = await this.testService.RunOrchestrations<int, string>(
                 parallelCount,
-                _ => null,
+                instanceIdGenerator: _ => Guid.NewGuid().ToString("N"),
+                inputGenerator: _ => null,
                 orchestrationName: "OrchestrationsWithActivityChain",
                 version: string.Empty,
                 implementation: async (ctx, _) =>

--- a/test/DurableTask.SqlServer.Tests/Integration/PurgeTests.cs
+++ b/test/DurableTask.SqlServer.Tests/Integration/PurgeTests.cs
@@ -39,8 +39,9 @@ namespace DurableTask.SqlServer.Tests.Integration
             var events = new ConcurrentDictionary<string, TaskCompletionSource<bool>>();
 
             // Waits for an external event and then either completes or fails depending on that event
-            List<TestInstance<string>> instances = await this.testService.RunOrchestrations(
+            IReadOnlyList<TestInstance<string>> instances = await this.testService.RunOrchestrations(
                 count: 30, // ideally some multiple of 3
+                instanceIdGenerator: i => $"InstanceToPurge_{i:00}",
                 inputGenerator: i=> $"Hello, world {i}",
                 orchestrationName: "SimpleDelay",
                 version: string.Empty,

--- a/test/DurableTask.SqlServer.Tests/Integration/ScaleTests.cs
+++ b/test/DurableTask.SqlServer.Tests/Integration/ScaleTests.cs
@@ -1,0 +1,472 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+namespace DurableTask.SqlServer.Tests.Integration
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Text;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using DurableTask.Core;
+    using DurableTask.SqlServer.Logging;
+    using DurableTask.SqlServer.Tests.Logging;
+    using DurableTask.SqlServer.Tests.Utils;
+    using Moq;
+    using Xunit;
+    using Xunit.Abstractions;
+
+    public class ScaleTests : IAsyncLifetime
+    {
+        readonly TestService testService;
+
+        public ScaleTests(ITestOutputHelper output)
+        {
+            this.testService = new TestService(output);
+        }
+
+        Task IAsyncLifetime.InitializeAsync() => this.testService.InitializeAsync(startWorker: false);
+
+        Task IAsyncLifetime.DisposeAsync() => this.testService.DisposeAsync();
+
+        /// <summary>
+        /// Validates the scale recommendation behavior when scheduling new orchestration instances.
+        /// </summary>
+        [Fact]
+        public async Task ScaleRecommendation_PendingOrchestrationStarts()
+        {
+            // Block the orchestration dispatch loop so that we can queue orchestrations without running them
+            this.testService.OrchestrationServiceMock.Setup(
+                svc => svc.LockNextTaskOrchestrationWorkItemAsync(
+                    It.IsAny<TimeSpan>(),
+                    It.IsAny<CancellationToken>()))
+                .Returns(() => Task.Delay(100).ContinueWith(t => default(TaskOrchestrationWorkItem)));
+
+            // We can influence the recommended replica count by modifying concurrency settings
+            this.testService.OrchestrationServiceOptions.MaxActiveOrchestrations = 1;
+            await this.testService.StartWorkerAsync();
+
+            SqlOrchestrationService orchestrationService = this.testService.OrchestrationServiceMock.Object;
+
+            // Initial scale recommendation should be zero
+            int recommendation = await orchestrationService.GetRecommendedReplicaCountAsync();
+            Assert.Equal(0, recommendation);
+
+            for (int i = 1; i <= 10; i++)
+            {
+                // Schedule an orchestration (it won't run, see above)
+                await this.testService.RunOrchestration(
+                    null as string,
+                    $"EmptyOrchestration{i:00}",
+                    implementation: (ctx, input) => Task.FromResult(input));
+
+                // Scale recommendation increments with every new scheduled orchestration.
+                // We pass in the previous recommendation to generate a log statement about the change.
+                recommendation = await orchestrationService.GetRecommendedReplicaCountAsync(recommendation);
+                Assert.Equal(i, recommendation);
+            }
+
+            // Validate the logs
+            IReadOnlyList<LogEntry> recommendationChangeLogs = this.GetRecommendationChangeLogs();
+            Assert.Equal(10, recommendationChangeLogs.Count);
+
+            for (int i = 0; i < recommendationChangeLogs.Count; i++)
+            {
+                LogEntry log = recommendationChangeLogs[i];
+                LogAssert.FieldEquals(log, "CurrentCount", i);
+                LogAssert.FieldEquals(log, "RecommendedCount", i + 1);
+            }
+        }
+
+        /// <summary>
+        /// Validates the scale recommendation behavior when scheduling activities.
+        /// </summary>
+        /// <param name="activityCount">The number of activities to schedule.</param>
+        /// <param name="expectedRecommendation">The expected scale recommendation.</param>
+        [Theory]
+        [InlineData(01, 01)]
+        [InlineData(10, 04)]
+        [InlineData(99, 33)]
+        public async Task ScaleRecommendation_PendingActivities(int activityCount, int expectedRecommendation)
+        {
+            // Block the activity dispatch loop so that we can queue activities without running them
+            this.testService.OrchestrationServiceMock.Setup(
+                svc => svc.LockNextTaskActivityWorkItem(
+                    It.IsAny<TimeSpan>(),
+                    It.IsAny<CancellationToken>()))
+                .Returns(() => Task.Delay(100).ContinueWith(t => default(TaskActivityWorkItem)));
+
+            // We can influence the recommended replica count by modifying concurrency settings
+            this.testService.OrchestrationServiceOptions.MaxConcurrentActivities = 3;
+            await this.testService.StartWorkerAsync();
+
+            SqlOrchestrationService orchestrationService = this.testService.OrchestrationServiceMock.Object;
+
+            // Initial scale recommendation should be zero
+            int recommendation = await orchestrationService.GetRecommendedReplicaCountAsync();
+            Assert.Equal(0, recommendation);
+
+            TestInstance<string> instance = await this.testService.RunOrchestration<string[], string>(
+                null,
+                orchestrationName: "OrchestrationWithActivityFanOut",
+                implementation: (ctx, _) =>
+                {
+                    return Task.WhenAll(Enumerable.Range(0, activityCount).Select(i => ctx.ScheduleTask<string>("ToString", "", i)).ToArray());
+                },
+                activities: new[] {
+                    ("ToString", TestService.MakeActivity((TaskContext ctx, int input) => input.ToString())),
+                });
+
+            // All activities should be scheduled when the instances transitions into the Running state.
+            // Also, the orchestration will be unloaded and not count towards the recommendation.
+            await instance.WaitForStart();
+
+            // The next recommendation should suggest 1 worker for every 3 pending activities
+            recommendation = await orchestrationService.GetRecommendedReplicaCountAsync(currentReplicaCount: 0);
+            Assert.Equal(expectedRecommendation, recommendation);
+
+            // Validate the logs
+            IReadOnlyList<LogEntry> recommendationChangeLogs = this.GetRecommendationChangeLogs();
+            LogEntry log = Assert.Single(recommendationChangeLogs);
+            LogAssert.FieldEquals(log, "CurrentCount", 0);
+            LogAssert.FieldEquals(log, "RecommendedCount", expectedRecommendation);
+        }
+
+        /// <summary>
+        /// Validates the scale recommendation behavior when scheduling timers.
+        /// </summary>
+        /// <param name="expectedRecommendation">The number of concurrent orchestrations waiting on timers.</param>
+        [Theory]
+        [InlineData(1)]
+        [InlineData(10)]
+        public async Task ScaleRecommendation_PendingTimers(int expectedRecommendation)
+        {
+            await this.testService.StartWorkerAsync();
+
+            SqlOrchestrationService orchestrationService = this.testService.OrchestrationServiceMock.Object;
+
+            // Initial scale recommendation should be zero
+            int recommendation = await orchestrationService.GetRecommendedReplicaCountAsync();
+            Assert.Equal(0, recommendation);
+
+            IReadOnlyList<TestInstance<string>> instances = await this.testService.RunOrchestrations<string, string>(
+                expectedRecommendation,
+                instanceIdGenerator: null,
+                inputGenerator: null,
+                orchestrationName: "SingleTimer",
+                version: null,
+                implementation: (ctx, _) =>
+                {
+                    // Schedule into the distant future
+                    return ctx.CreateTimer(ctx.CurrentUtcDateTime.AddDays(1), "done!");
+                });
+
+            // All timers should be scheduled when the instances transitions into the Running state.
+            // Also, the orchestration will be unloaded and not count towards the recommendation.
+            await Task.WhenAll(instances.Select(i => i.WaitForStart()));
+
+            // The next recommendation should suggest 0 workers since all pending events are just distant timers
+            recommendation = await orchestrationService.GetRecommendedReplicaCountAsync(currentReplicaCount: 0);
+            Assert.Equal(0, recommendation);
+
+            // Validate the logs (there should be none)
+            IReadOnlyList<LogEntry> recommendationChangeLogs = this.GetRecommendationChangeLogs();
+            Assert.Equal(0, recommendationChangeLogs.Count);
+        }
+
+        /// <summary>
+        /// Validates the scale recommendation behavior when timers have expired.
+        /// </summary>
+        [Theory]
+        [InlineData(1)]
+        [InlineData(10)]
+        public async Task ScaleRecommendation_ExpiredTimers(int timerCount)
+        {
+            const int MaxOrchestrationConcurrency = 5;
+            int expectedRecommendation = (int)Math.Ceiling(timerCount / (double)MaxOrchestrationConcurrency);
+
+            // Later in the test we'll block orchestrations from starting to simulate a scaled-to-zero app.
+            var orchestrationExecutionGate = new SemaphoreSlim(initialCount: 0, maxCount: timerCount);
+            this.testService.OrchestrationServiceMock.Setup(
+                svc => svc.LockNextTaskOrchestrationWorkItemAsync(
+                    It.IsAny<TimeSpan>(),
+                    It.IsAny<CancellationToken>()))
+                .Callback(() => orchestrationExecutionGate.Wait());
+
+            this.testService.OrchestrationServiceOptions.MaxActiveOrchestrations = MaxOrchestrationConcurrency;
+            this.testService.OrchestrationServiceOptions.WorkItemBatchSize = timerCount;
+
+            await this.testService.StartWorkerAsync();
+
+            SqlOrchestrationService orchestrationService = this.testService.OrchestrationServiceMock.Object;
+
+            // Initial scale recommendation should be zero
+            int recommendation = await orchestrationService.GetRecommendedReplicaCountAsync();
+            Assert.Equal(0, recommendation);
+
+            TimeSpan delay = TimeSpan.FromSeconds(3);
+
+            IReadOnlyList<TestInstance<string>> instances = await this.testService.RunOrchestrations<string, string>(
+                timerCount,
+                instanceIdGenerator: null,
+                inputGenerator: null,
+                orchestrationName: "SingleTimer",
+                version: null,
+                implementation: (ctx, _) => ctx.CreateTimer(ctx.CurrentUtcDateTime.Add(delay), "done!"));
+
+            // Allow the start messages to get processed. Each unblocked thread will process exactly one orchestration start.
+            // After that, this semaphore gate will expire blocking subsequent orchestration dispatch, helping us ensure
+            // that expired timers don't get processed before we have a chance to run the test logic below.
+            orchestrationExecutionGate.Release(timerCount);
+
+            // All timers should be scheduled when the instances transitions into the Running state.
+            // Also, the orchestration will be unloaded and not count towards the recommendation.
+            await Task.WhenAll(instances.Select(i => i.WaitForStart()));
+
+            // Now delay so that the timers can expire and have their expiration events added to the orchestration queue.
+            await Task.Delay(delay + TimeSpan.FromMilliseconds(500));
+
+            // The next recommendation should suggest N workers since all pending events are expired timers
+            recommendation = await orchestrationService.GetRecommendedReplicaCountAsync(currentReplicaCount: 0);
+            Assert.Equal(expectedRecommendation, recommendation);
+
+            // Validate the logs (there should be one)
+            IReadOnlyList<LogEntry> recommendationChangeLogs = this.GetRecommendationChangeLogs();
+            LogEntry log = Assert.Single(recommendationChangeLogs);
+            LogAssert.FieldEquals(log, "CurrentCount", 0);
+            LogAssert.FieldEquals(log, "RecommendedCount", expectedRecommendation);
+        }
+
+        /// <summary>
+        /// Validates the scale recommendation behavior when activities are actively executing.
+        /// </summary>
+        [Fact]
+        public async Task ScaleRecommendation_ActiveActivities()
+        {
+            // We can influence the recommended replica count by modifying concurrency settings
+            this.testService.OrchestrationServiceOptions.MaxConcurrentActivities = 1;
+            await this.testService.StartWorkerAsync();
+
+            SqlOrchestrationService orchestrationService = this.testService.OrchestrationServiceMock.Object;
+
+            // Initial scale recommendation should be zero
+            int recommendation = await orchestrationService.GetRecommendedReplicaCountAsync();
+            Assert.Equal(0, recommendation);
+
+            using var activityStartedGate = new ManualResetEventSlim(initialState: false);
+            using var activityCompleteGate = new ManualResetEventSlim(initialState: false);
+
+            TestInstance<string> instance = await this.testService.RunOrchestration<bool, string>(
+                null,
+                orchestrationName: "SingleActivity",
+                implementation: (ctx, _) =>
+                {
+                    return ctx.ScheduleTask<bool>("WaitForSignal", "", 30);
+                },
+                activities: new[]
+                {
+                    ("WaitForSignal", TestService.MakeActivity(
+                        (TaskContext ctx, int input) =>
+                        {
+                            activityStartedGate.Set();
+                            return activityCompleteGate.Wait(TimeSpan.FromSeconds(input));
+                        })),
+                });
+
+            // Wait for all activities to start
+            Assert.True(activityStartedGate.Wait(TimeSpan.FromSeconds(30).AdjustForDebugging()));
+
+            // The next recommendation should suggest 1 worker for every active activity
+            recommendation = await orchestrationService.GetRecommendedReplicaCountAsync(currentReplicaCount: 0);
+            Assert.Equal(1, recommendation);
+
+            // Allow the activities to complete
+            activityCompleteGate.Set();
+            await instance.WaitForCompletion(expectedOutput: true);
+
+            // Recommendation should return back to zero now that everything is complete
+            recommendation = await orchestrationService.GetRecommendedReplicaCountAsync(currentReplicaCount: recommendation);
+            Assert.Equal(0, recommendation);
+
+            // Validate the logs
+            IReadOnlyList<LogEntry> recommendationChangeLogs = this.GetRecommendationChangeLogs();
+            Assert.Equal(2, recommendationChangeLogs.Count);
+
+            // Initial scale-out to N
+            LogAssert.FieldEquals(recommendationChangeLogs[0], "CurrentCount", 0);
+            LogAssert.FieldEquals(recommendationChangeLogs[0], "RecommendedCount", 1);
+
+            // Scale-in back to zero
+            LogAssert.FieldEquals(recommendationChangeLogs[1], "CurrentCount", 1);
+            LogAssert.FieldEquals(recommendationChangeLogs[1], "RecommendedCount", 0);
+        }
+
+        /// <summary>
+        /// Validates the scale recommendation calculation when a single orchestration has
+        /// multiple events pending (only one worker should be recommended).
+        /// </summary>
+        [Theory]
+        [InlineData(1)]
+        [InlineData(10)]
+        public async Task ScaleRecommendation_BackloggedOrchestration(int orchestrationCount)
+        {
+            const int ActivityCount = 10;
+            int totalActivities = orchestrationCount * ActivityCount;
+
+            // Let N orchestrations start but prevent them from responding to activity results
+            using var orchestrationExecutionGate = new SemaphoreSlim(initialCount: orchestrationCount);
+            this.testService.OrchestrationServiceMock.Setup(
+                svc => svc.LockNextTaskOrchestrationWorkItemAsync(
+                    It.IsAny<TimeSpan>(),
+                    It.IsAny<CancellationToken>()))
+                .Callback(() => orchestrationExecutionGate.Wait());
+
+            // Block activities from starting until all orchestrations have had a chance to run
+            using var activityExecutionGate = new ManualResetEventSlim(initialState: false);
+            this.testService.OrchestrationServiceMock.Setup(
+                svc => svc.LockNextTaskActivityWorkItem(
+                    It.IsAny<TimeSpan>(),
+                    It.IsAny<CancellationToken>()))
+                .Callback(() => activityExecutionGate.Wait());
+
+            // Signal the test to resume once all the activities finish executing
+            using var activityCompletionCountdown = new CountdownEvent(initialCount: totalActivities);
+            this.testService.OrchestrationServiceMock.Setup(
+                svc => svc.CompleteTaskActivityWorkItemAsync(
+                    It.IsAny<TaskActivityWorkItem>(),
+                    It.IsAny<TaskMessage>()))
+                .CallBase()
+                .Callback(() => activityCompletionCountdown.Signal()); // NOTE: This callback happens mid-execution of CompleteTaskActivityWorkItemAsync
+
+            this.testService.OrchestrationServiceOptions.MaxActiveOrchestrations = 1;
+            this.testService.OrchestrationServiceOptions.MaxConcurrentActivities = totalActivities;
+
+            await this.testService.StartWorkerAsync();
+
+            SqlOrchestrationService orchestrationService = this.testService.OrchestrationServiceMock.Object;
+
+            // Initial scale recommendation should be zero
+            int recommendation = await orchestrationService.GetRecommendedReplicaCountAsync();
+            Assert.Equal(0, recommendation);
+
+            using var activityCountdown = new CountdownEvent(initialCount: totalActivities);
+
+            IReadOnlyList<TestInstance<string>> instances = await this.testService.RunOrchestrations<string[], string>(
+                orchestrationCount,
+                instanceIdGenerator: null,
+                inputGenerator: null,
+                orchestrationName: "OrchestrationWithActivityFanOut",
+                version: null,
+                implementation: (ctx, _) =>
+                {
+                    return Task.WhenAll(Enumerable.Range(0, ActivityCount).Select(i => ctx.ScheduleTask<string>("ToString", "", i)).ToArray());
+                },
+                activities: new[]
+                {
+                    ("ToString", TestService.MakeActivity((TaskContext ctx, int input) => input.ToString())),
+                });
+
+            await Task.WhenAll(instances.Select(i => i.WaitForStart()));
+
+            // Unblock the activities now that the orchestrations have all started
+            activityExecutionGate.Set();
+
+            // Wait for all activities to complete and enqueue their responses
+            Assert.True(activityCompletionCountdown.Wait(TimeSpan.FromSeconds(10).AdjustForDebugging()));
+
+            // Need to wait a little longer since not all database transactions will have completed yet
+            await Task.Delay(TimeSpan.FromSeconds(1));
+
+            // The next recommendation should suggest 1 worker for each pending orchestration, regardless
+            // of how many activity responses there are.
+            recommendation = await orchestrationService.GetRecommendedReplicaCountAsync(currentReplicaCount: 0);
+            Assert.Equal(orchestrationCount, recommendation);
+
+            // Validate the logs (there should be one)
+            IReadOnlyList<LogEntry> recommendationChangeLogs = this.GetRecommendationChangeLogs();
+            LogEntry log = Assert.Single(recommendationChangeLogs);
+            LogAssert.FieldEquals(log, "CurrentCount", 0);
+            LogAssert.FieldEquals(log, "RecommendedCount", orchestrationCount);
+        }
+
+        [Theory]
+        [InlineData(1, 1, 1, 1, 2)]
+        [InlineData(1, 10, 100, 1, 11)]
+        [InlineData(5, 10, 100, 1, 11)]
+        public async Task ScaleRecommendation_MixedLoad(
+            int pendingOrchestrations,
+            int pendingActivities,
+            int maxPendingOrchestrations,
+            int maxPendingActivities,
+            int expectedRecommendation)
+        {
+            // Allow just one orchestration to start and schedule all the activities. Subsequent orchestration
+            // executions will be blocked so we can acrue pending orchestration counts.
+            var orchestrationExecutionGate = new SemaphoreSlim(initialCount: 1);
+            this.testService.OrchestrationServiceMock.Setup(
+                svc => svc.LockNextTaskOrchestrationWorkItemAsync(
+                    It.IsAny<TimeSpan>(),
+                    It.IsAny<CancellationToken>()))
+                .Callback(() => orchestrationExecutionGate.Wait());
+
+            // Block the activity dispatch loop so that we can queue activities without running them.
+            this.testService.OrchestrationServiceMock.Setup(
+                svc => svc.LockNextTaskActivityWorkItem(
+                    It.IsAny<TimeSpan>(),
+                    It.IsAny<CancellationToken>()))
+                .Returns(() => Task.Delay(100).ContinueWith(t => default(TaskActivityWorkItem)));
+
+            this.testService.OrchestrationServiceOptions.MaxActiveOrchestrations = maxPendingOrchestrations;
+            this.testService.OrchestrationServiceOptions.MaxConcurrentActivities = maxPendingActivities;
+
+            await this.testService.StartWorkerAsync();
+
+            SqlOrchestrationService orchestrationService = this.testService.OrchestrationServiceMock.Object;
+
+            // Initial scale recommendation should be zero
+            int recommendation = await orchestrationService.GetRecommendedReplicaCountAsync();
+            Assert.Equal(0, recommendation);
+
+            // This one orchestration is responsible for scheduling all the activities. It then goes idle indefinitely.
+            TestInstance<string> instance = await this.testService.RunOrchestration<string[], string>(
+                null,
+                orchestrationName: "OrchestrationWithActivityFanOut",
+                implementation: (ctx, _) =>
+                {
+                    return Task.WhenAll(Enumerable.Range(0, pendingActivities).Select(i => ctx.ScheduleTask<string>("ToString", "", i)).ToArray());
+                },
+                activities: new[]
+                {
+                    ("ToString", TestService.MakeActivity((TaskContext ctx, int input) => input.ToString())),
+                });
+
+            // We know all the activities are scheduled once the instance is in a "Running" state.
+            await instance.WaitForStart();
+
+            // Finally, schedule all the pending orchestrations, as simple no-ops. None of them should actually start running and
+            // should therefore be included in our scale recommendation calculation.
+            IReadOnlyList<TestInstance<string>> instances = await this.testService.RunOrchestrations<string, string>(
+                pendingOrchestrations,
+                instanceIdGenerator: null,
+                inputGenerator: null,
+                orchestrationName: "NoOp",
+                version: null,
+                implementation: (ctx, _) => Task.FromResult("done!"));
+
+            // Verify final scale recommendation
+            recommendation = await orchestrationService.GetRecommendedReplicaCountAsync(currentReplicaCount: recommendation);
+            Assert.Equal(expectedRecommendation, recommendation);
+
+            // Validate the logs (there should be one)
+            IReadOnlyList<LogEntry> recommendationChangeLogs = this.GetRecommendationChangeLogs();
+            LogEntry log = Assert.Single(recommendationChangeLogs);
+            LogAssert.FieldEquals(log, "CurrentCount", 0);
+            LogAssert.FieldEquals(log, "RecommendedCount", expectedRecommendation);
+        }
+
+        IReadOnlyList<LogEntry> GetRecommendationChangeLogs() => this.testService.GetAndValidateLogs()
+            .Where(log => log.EventId == EventIds.ReplicaCountChangeRecommended)
+            .ToList();
+    }
+}

--- a/test/DurableTask.SqlServer.Tests/Logging/LogAssert.cs
+++ b/test/DurableTask.SqlServer.Tests/Logging/LogAssert.cs
@@ -154,9 +154,25 @@ namespace DurableTask.SqlServer.Tests.Logging
                     Assert.True(fields.ContainsKey("InstanceId"));
                     Assert.True(fields.ContainsKey("ExecutionId"));
                     break;
+                case EventIds.ReplicaCountChangeRecommended:
+                    Assert.Contains("CurrentCount", fields);
+                    Assert.Contains("RecommendedCount", fields);
+                    break;
                 default:
                     throw new ArgumentException($"Log event {log.EventId} is not known. Does it need to be added to the log validator?", nameof(log));
             }
+        }
+
+        public static T FieldEquals<T>(LogEntry logEntry, string fieldName, T expectedValue)
+        {
+            var structuredEvent = logEntry.State as IReadOnlyDictionary<string, object>;
+            Assert.NotNull(structuredEvent);
+
+            IReadOnlyDictionary<string, object> eventData = Assert.IsAssignableFrom<IReadOnlyDictionary<string, object>>(logEntry.State);
+            object fieldValue = Assert.Contains(fieldName, eventData);
+            T convertedValue = Assert.IsType<T>(fieldValue);
+            Assert.Equal(expectedValue, convertedValue);
+            return convertedValue;
         }
     }
 }

--- a/test/DurableTask.SqlServer.Tests/Utils/SharedTestHelpers.cs
+++ b/test/DurableTask.SqlServer.Tests/Utils/SharedTestHelpers.cs
@@ -4,6 +4,10 @@
 namespace DurableTask.SqlServer.Tests.Utils
 {
     using System;
+    using System.Collections.Generic;
+    using System.Diagnostics;
+    using System.Threading;
+    using System.Threading.Tasks;
     using Microsoft.Data.SqlClient;
 
     public static class SharedTestHelpers
@@ -28,6 +32,59 @@ namespace DurableTask.SqlServer.Tests.Utils
             };
 
             return builder.ToString();
+        }
+
+        public static TimeSpan AdjustForDebugging(this TimeSpan timeout)
+        {
+            if (timeout == default)
+            {
+                timeout = TimeSpan.FromSeconds(10);
+            }
+
+            if (Debugger.IsAttached)
+            {
+                TimeSpan debuggingTimeout = TimeSpan.FromMinutes(5);
+                if (debuggingTimeout > timeout)
+                {
+                    timeout = debuggingTimeout;
+                }
+            }
+
+            return timeout;
+        }
+
+        public static async Task ParallelForEachAsync<T>(this IEnumerable<T> items, int maxConcurrency, Func<T, Task> action)
+        {
+            List<Task> tasks;
+            if (items is ICollection<T> itemCollection)
+            {
+                tasks = new List<Task>(itemCollection.Count);
+            }
+            else
+            {
+                tasks = new List<Task>();
+            }
+
+            using var semaphore = new SemaphoreSlim(maxConcurrency);
+            foreach (T item in items)
+            {
+                tasks.Add(InvokeThrottledAction(item, action, semaphore));
+            }
+
+            await Task.WhenAll(tasks);
+        }
+
+        static async Task InvokeThrottledAction<T>(T item, Func<T, Task> action, SemaphoreSlim semaphore)
+        {
+            await semaphore.WaitAsync();
+            try
+            {
+                await action(item);
+            }
+            finally
+            {
+                semaphore.Release();
+            }
         }
     }
 }

--- a/test/DurableTask.SqlServer.Tests/Utils/TestInstance.cs
+++ b/test/DurableTask.SqlServer.Tests/Utils/TestInstance.cs
@@ -30,6 +30,10 @@ namespace DurableTask.SqlServer.Tests.Utils
             this.input = input;
         }
 
+        public string InstanceId => this.instance?.InstanceId;
+
+        public string ExecutionId => this.instance?.ExecutionId;
+
         OrchestrationInstance GetInstanceForAnyExecution() => new OrchestrationInstance
         {
             InstanceId = this.instance.InstanceId,
@@ -87,14 +91,8 @@ namespace DurableTask.SqlServer.Tests.Utils
             Assert.NotNull(state.OrchestrationInstance);
             Assert.Equal(this.instance.InstanceId, state.OrchestrationInstance.InstanceId);
 
-            if (continuedAsNew)
-            {
-                Assert.NotEqual(this.instance.ExecutionId, state.OrchestrationInstance.ExecutionId);
-            }
-            else
-            {
-                Assert.Equal(this.instance.ExecutionId, state.OrchestrationInstance.ExecutionId);
-            }
+            // Make sure there is an ExecutionId, but don't require it to match any particular value
+            Assert.NotNull(state.OrchestrationInstance.ExecutionId);
 
             if (expectedOutput != null)
             {
@@ -137,19 +135,7 @@ namespace DurableTask.SqlServer.Tests.Utils
 
         static void AdjustTimeout(ref TimeSpan timeout)
         {
-            if (timeout == default)
-            {
-                timeout = TimeSpan.FromSeconds(10);
-            }
-
-            if (Debugger.IsAttached)
-            {
-                TimeSpan debuggingTimeout = TimeSpan.FromMinutes(5);
-                if (debuggingTimeout > timeout)
-                {
-                    timeout = debuggingTimeout;
-                }
-            }
+            timeout = timeout.AdjustForDebugging();
         }
     }
 }

--- a/test/PerformanceTests/ManyEntities.cs
+++ b/test/PerformanceTests/ManyEntities.cs
@@ -27,8 +27,10 @@ namespace PerformanceTests
 
         public int Get() => this.CurrentValue;
 
+#pragma warning disable DF0307 // DispatchAsync must be used with the entity name, equal to the name of the function it's used in.
         [FunctionName(EntityName)]
         public static Task Run([EntityTrigger] IDurableEntityContext ctx) => ctx.DispatchAsync<ManyEntities>();
+#pragma warning restore DF0307 // DispatchAsync must be used with the entity name, equal to the name of the function it's used in.
 
         [FunctionName(nameof(StartManyEntities))]
         public static async Task<IActionResult> StartManyEntities(


### PR DESCRIPTION
This PR adds the following:

* An `IScaleProivder` implementation for use in the Azure Functions Elastic Premium plan
* A new `dt.GetScaleRecommendation()` SQL function for more accurate auto-scale recommendations
* Configuration settings for max concurrent orchestration and activity executions
* New documentation topic for scaling
* Various misc. changes (see CHANGELOG.md)

TODO before merging:
- [x] Scale testing in the Azure Functions Elastic Premium plan.