### PR TITLE
Improvements to perf-testing code and extension version tracing

### DIFF
--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -21,7 +21,7 @@ dotnet add package Microsoft.DurableTask.SqlServer.AzureFunctions --prerelease
 JavaScript, Python, and PowerShell projects can add the [Microsoft.DurableTask.SqlServer.AzureFunction](https://www.nuget.org/packages/Microsoft.DurableTask.SqlServer.AzureFunctions) package by running the following `func` CLI command. Note that in addition to the Azure Functions Core Tools, you must also have a recent [.NET SDK](https://dotnet.microsoft.com/download/dotnet-core/3.1) installed locally.
 
 ```bash
-func extensions install -p Microsoft.DurableTask.SqlServer.AzureFunctions -v 0.7.0-alpha
+func extensions install -p Microsoft.DurableTask.SqlServer.AzureFunctions -v 0.8.0-beta
 ```
 
 ?> Check [here](https://www.nuget.org/packages/Microsoft.DurableTask.SqlServer.AzureFunctions) to see if newer versions of the SQL provider package are available, and update the above command to reference the latest available version.

--- a/src/DurableTask.SqlServer/DTUtils.cs
+++ b/src/DurableTask.SqlServer/DTUtils.cs
@@ -13,7 +13,7 @@ namespace DurableTask.SqlServer
     static class DTUtils
     {
         public static readonly SemanticVersion ExtensionVersion = GetExtensionVersion();
-        public static readonly string ExtensionVersionString = ExtensionVersion.ToString();
+        public static readonly string ExtensionVersionString = GetExtensionVersionForLogging(ExtensionVersion);
 
         // DurableTask.Core has a public static variable that contains the app name
         public static readonly string AppName = DurableTask.Core.Common.Utils.AppName;
@@ -25,6 +25,30 @@ namespace DurableTask.SqlServer
             string productVersion = FileVersionInfo.GetVersionInfo(
                 typeof(SqlOrchestrationService).Assembly.Location).ProductVersion;
             return SemanticVersion.Parse(productVersion);
+        }
+
+        static string GetExtensionVersionForLogging(SemanticVersion version)
+        {
+            var builder = new StringBuilder();
+            builder
+                .Append(version.Major)
+                .Append('.')
+                .Append(version.Minor)
+                .Append('.')
+                .Append(version.Patch);
+
+            if (!string.IsNullOrEmpty(version.Prerelease))
+            {
+                builder.Append('-').Append(version.Prerelease);
+            }
+#if DEBUG
+            // Include the build information only in debug builds
+            if (!string.IsNullOrEmpty(version.Build))
+            {
+                builder.Append('+').Append(version.Build);
+            }
+#endif
+            return builder.ToString();
         }
 
         public static int GetTaskEventId(HistoryEvent historyEvent)

--- a/test/PerformanceTests/Common.cs
+++ b/test/PerformanceTests/Common.cs
@@ -17,13 +17,15 @@ namespace PerformanceTests
     {
         public static async Task<string> ScheduleManyInstances(
             IDurableOrchestrationClient client,
+            ILogger log,
             string orchestrationName,
             int count,
-            ILogger log)
+            string prefix)
         {
-            log.LogWarning($"Scheduling {count} orchestration(s)...");
             DateTime utcNow = DateTime.UtcNow;
-            string prefix = utcNow.ToString("yyyyMMdd-hhmmss");
+            prefix += utcNow.ToString("yyyyMMdd-hhmmss");
+
+            log.LogWarning($"Scheduling {count} orchestration(s) with a prefix of '{prefix}'...");
 
             await Enumerable.Range(0, count).ParallelForEachAsync(200, i =>
             {

--- a/test/PerformanceTests/ManyMixedOrchestrations.cs
+++ b/test/PerformanceTests/ManyMixedOrchestrations.cs
@@ -25,8 +25,10 @@ namespace PerformanceTests
                 return new BadRequestObjectResult("A 'count' query string parameter is required and it must contain a positive number.");
             }
 
-            string prefix = await Common.ScheduleManyInstances(starter, nameof(MixedOrchestration), count, log);
-            return new OkObjectResult($"Scheduled {count} orchestrations prefixed with '{prefix}'.");
+            string initialPrefix = (string)req.Query["prefix"] ?? string.Empty;
+
+            string finalPrefix = await Common.ScheduleManyInstances(starter, log, nameof(MixedOrchestration), count, initialPrefix);
+            return new OkObjectResult($"Scheduled {count} orchestrations prefixed with '{finalPrefix}'.");
         }
 
         [FunctionName(nameof(MixedOrchestration))]

--- a/test/PerformanceTests/ManySequences.cs
+++ b/test/PerformanceTests/ManySequences.cs
@@ -28,8 +28,10 @@ namespace PerformanceTests
                 return new BadRequestObjectResult("A 'count' query string parameter is required and it must contain a positive number.");
             }
 
-            string prefix = await Common.ScheduleManyInstances(starter, nameof(HelloSequence), count, log);
-            return new OkObjectResult($"Scheduled {count} orchestrations prefixed with '{prefix}'.");
+            string initialPrefix = (string)req.Query["prefix"] ?? string.Empty;
+
+            string finalPrefix = await Common.ScheduleManyInstances(starter, log, nameof(HelloSequence), count, initialPrefix);
+            return new OkObjectResult($"Scheduled {count} orchestrations prefixed with '{finalPrefix}'.");
         }
 
         [FunctionName(nameof(HelloSequence))]

--- a/test/PerformanceTests/PurgeOrchestrationData.cs
+++ b/test/PerformanceTests/PurgeOrchestrationData.cs
@@ -1,0 +1,58 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+namespace PerformanceTests
+{
+    using System;
+    using System.Diagnostics;
+    using System.Threading.Tasks;
+    using Microsoft.AspNetCore.Http;
+    using Microsoft.AspNetCore.Mvc;
+    using Microsoft.Azure.WebJobs;
+    using Microsoft.Azure.WebJobs.Extensions.DurableTask;
+    using Microsoft.Azure.WebJobs.Extensions.Http;
+    using Microsoft.Extensions.Logging;
+
+    public static class PurgeOrchestrationData
+    {
+        [FunctionName("PurgeOrchestrationData")]
+        public static async Task<IActionResult> Run(
+            [HttpTrigger(AuthorizationLevel.Function, "post", Route = null)] HttpRequest req,
+            [DurableClient] IDurableClient client,
+            ILogger log)
+        {
+            log.LogWarning("Purging all orchestration data from the database");
+
+            int totalDeleted = 0;
+            bool finished = false;
+
+            // Stop after 25 seconds to avoid a client-side timeout
+            var sw = Stopwatch.StartNew();
+            while (sw.Elapsed < TimeSpan.FromSeconds(25))
+            {
+                // Purge all completed instances, dating back to the year 2000
+                PurgeHistoryResult result = await client.PurgeInstanceHistoryAsync(
+                    createdTimeFrom: new DateTime(2000, 1, 1),
+                    createdTimeTo: null,
+                    runtimeStatus: null);
+
+                totalDeleted += result.InstancesDeleted;
+
+                // The SQL provider only deletes at most 1000 instances per call
+                if (result.InstancesDeleted < 1000)
+                {
+                    finished = true;
+                    break;
+                }
+            }
+
+            log.LogWarning($"Purge of {totalDeleted} instance(s) completed after {sw.Elapsed}. Finished = {finished}.");
+
+            return new OkObjectResult(new
+            {
+                totalDeleted,
+                finished,
+            });
+        }
+    }
+}


### PR DESCRIPTION
Extension version tracing is changed such that we only include the commit hash in debug mode. This is mainly to make traces less noisy for production scenarios. The commit hash also becomes less useful in those cases since the release will be properly tagged.

Regarding the performance test code, this PR adds a new function that purges all the orchestration from the database. This is useful for ensuring that each test starts from a clean slate in terms of how much data is in the database (which could otherwise impact things like query plans depending on in what order the tests are run). I've also added the ability to add a custom prefix to each of the created orchestration instances, making them easier to distinguish and query when running multiple tests in succession.

Lastly, updated the documentation to refer to v0.8.0-beta.