### PR TITLE
Add extension methods for registering the SQL durability provider

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## v0.9.1-beta
+
+### New
+
+* Added extension method for Azure Functions service registration ([#31](https://github.com/microsoft/durabletask-mssql/pull/31))
+
+### Updates
+
+* Updated [Microsoft.Azure.WebJobs.Extensions.DurableTask](https://www.nuget.org/packages/Microsoft.Azure.WebJobs.Extensions.DurableTask) dependency to [v2.5.0](https://github.com/Azure/azure-functions-durable-extension/releases/tag/v2.5.0).
+* Updated [Microsoft.Azure.DurableTask.Core](https://www.nuget.org/packages/Microsoft.Azure.DurableTask.Core) dependency to [v2.5.5](https://github.com/Azure/durabletask/releases/tag/durabletask.core-v2.5.5).
+
 ## v0.9.0-beta
 
 ### New

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -21,7 +21,7 @@ dotnet add package Microsoft.DurableTask.SqlServer.AzureFunctions --prerelease
 JavaScript, Python, and PowerShell projects can add the [Microsoft.DurableTask.SqlServer.AzureFunction](https://www.nuget.org/packages/Microsoft.DurableTask.SqlServer.AzureFunctions) package by running the following `func` CLI command. Note that in addition to the Azure Functions Core Tools, you must also have a recent [.NET SDK](https://dotnet.microsoft.com/download/dotnet-core/3.1) installed locally.
 
 ```bash
-func extensions install -p Microsoft.DurableTask.SqlServer.AzureFunctions -v 0.9.0-beta
+func extensions install -p Microsoft.DurableTask.SqlServer.AzureFunctions -v 0.9.1-beta
 ```
 
 ?> Check [here](https://www.nuget.org/packages/Microsoft.DurableTask.SqlServer.AzureFunctions) to see if newer versions of the SQL provider package are available, and update the above command to reference the latest available version.
@@ -74,6 +74,8 @@ To enable diagnostic logging, you can also add the following `logging` configura
 ```
 
 It is recommended to always configure the `DurableTask.*` log categories to at least `Warning` to ensure you have visibility into issues that might impact reliability and runtime performance.
+
+?> By default, task hub names configured in host.json are ignored. Instead, the task hub name is inferred from the SQL database login username. For more information, see the [Task Hubs](taskhubs.md) documentation.
 
 ## Self-hosted .NET apps
 

--- a/docs/sidebar.md
+++ b/docs/sidebar.md
@@ -1,5 +1,5 @@
 * [Introduction](introduction.md "Durable Task SQL Provider")
-* [Getting started](quickstart.md)
+* [Getting Started](quickstart.md)
 * [Architecture](architecture.md)
 * [Scaling](scaling.md)
 * [Task Hubs](taskhubs.md)

--- a/src/DurableTask.SqlServer.AzureFunctions/AssemblyInfo.cs
+++ b/src/DurableTask.SqlServer.AzureFunctions/AssemblyInfo.cs
@@ -1,6 +1,0 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the MIT License. See LICENSE in the project root for license information.
-
-using System.Runtime.CompilerServices;
-
-[assembly: InternalsVisibleTo("DurableTask.SqlServer.AzureFunctions.Tests, PublicKey=0024000004800000940000000602000000240000525341310004000001000100fd8328dce03cd2e3033a411da400c391864fb4896f1265b2e46914ae677f9268e57ce00fe5ab144bf1746670c16798821c1e821dc3bc0ebce8374c20de809e7ae1b613b71a0a2a5680782e0458cec6c520bc77a90b2c5b00425da400b611d110a43219a9db52e89ce52705e8d11e68ca536f9d5dbe1de8c054d4f70161984de3")]

--- a/src/DurableTask.SqlServer.AzureFunctions/DurableTask.SqlServer.AzureFunctions.csproj
+++ b/src/DurableTask.SqlServer.AzureFunctions/DurableTask.SqlServer.AzureFunctions.csproj
@@ -17,7 +17,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Azure.Functions.Extensions" Version="1.0.0" />
-    <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.DurableTask" Version="2.4.3" />
+    <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.DurableTask" Version="2.5.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/DurableTask.SqlServer.AzureFunctions/SqlDurabilityProviderExtensions.cs
+++ b/src/DurableTask.SqlServer.AzureFunctions/SqlDurabilityProviderExtensions.cs
@@ -1,0 +1,23 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+namespace DurableTask.SqlServer.AzureFunctions
+{
+    using Microsoft.Azure.WebJobs.Extensions.DurableTask;
+    using Microsoft.Extensions.DependencyInjection;
+
+    /// <summary>
+    /// Extension methods for the Microsoft SQL Durable Task storage provider.
+    /// </summary>
+    public static class SqlDurabilityProviderExtensions
+    {
+        /// <summary>
+        /// Adds Durable Task SQL storage provider services to the specified <see cref="IServiceCollection"/>.
+        /// </summary>
+        /// <param name="services">The <see cref="IServiceCollection"/> for adding services.</param>
+        public static void AddDurableTaskSqlProvider(this IServiceCollection services)
+        {
+            services.AddSingleton<IDurabilityProviderFactory, SqlDurabilityProviderFactory>();
+        }
+    }
+}

--- a/src/DurableTask.SqlServer.AzureFunctions/SqlDurabilityProviderFactory.cs
+++ b/src/DurableTask.SqlServer.AzureFunctions/SqlDurabilityProviderFactory.cs
@@ -11,6 +11,9 @@ namespace DurableTask.SqlServer.AzureFunctions
     using Microsoft.Extensions.Options;
     using Newtonsoft.Json;
 
+    /// <summary>
+    /// Microsoft SQL <see cref="IDurabilityProviderFactory"/> implementation for Durable Tasks in Azure Functions.
+    /// </summary>
     class SqlDurabilityProviderFactory : IDurabilityProviderFactory
     {
         readonly Dictionary<string, DurabilityProvider> clientProviders =
@@ -25,7 +28,15 @@ namespace DurableTask.SqlServer.AzureFunctions
         SqlOrchestrationService? service;
         SqlDurabilityProvider? defaultProvider;
 
-        // Called by the Azure Functions runtime dependency injection infrastructure
+        /// <summary>
+        /// Initializes a new instance of the <see cref="SqlDurabilityProviderFactory"/> class.
+        /// </summary>
+        /// <remarks>
+        /// Intended to be called by the Azure Functions runtime dependency injection infrastructure.
+        /// </remarks>
+        /// <param name="extensionOptions">Durable task extension configuration options.</param>
+        /// <param name="loggerFactory">Logger factory registered with the Azure Functions runtime.</param>
+        /// <param name="connectionStringResolver">Resolver service for fetching Durable Task connection string information.</param>
         public SqlDurabilityProviderFactory(
             IOptions<DurableTaskOptions> extensionOptions,
             ILoggerFactory loggerFactory,

--- a/src/DurableTask.SqlServer/DurableTask.SqlServer.csproj
+++ b/src/DurableTask.SqlServer/DurableTask.SqlServer.csproj
@@ -22,7 +22,7 @@
   
   <ItemGroup>
     <PackageReference Include="Azure.Identity" Version="1.4.0" />
-    <PackageReference Include="Microsoft.Azure.DurableTask.Core" Version="2.5.1" />
+    <PackageReference Include="Microsoft.Azure.DurableTask.Core" Version="2.5.5" />
     <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="3.1.*" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="3.1.*" />
     <PackageReference Include="Microsoft.SqlServer.SqlManagementObjects" Version="161.46041.41" />

--- a/src/common.props
+++ b/src/common.props
@@ -16,7 +16,7 @@
   <!-- Version settings: https://andrewlock.net/version-vs-versionsuffix-vs-packageversion-what-do-they-all-mean/ -->
   <PropertyGroup>
     <MajorVersion>0</MajorVersion>
-    <VersionPrefix>$(MajorVersion).9.0</VersionPrefix>
+    <VersionPrefix>$(MajorVersion).9.1</VersionPrefix>
     <VersionSuffix>beta</VersionSuffix>
     <AssemblyVersion>$(MajorVersion).0.0.0</AssemblyVersion>
     <BuildSuffix Condition="'$(GITHUB_RUN_NUMBER)' != ''">.$(GITHUB_RUN_NUMBER)</BuildSuffix>

--- a/test/DurableTask.SqlServer.AzureFunctions.Tests/IntegrationTestBase.cs
+++ b/test/DurableTask.SqlServer.AzureFunctions.Tests/IntegrationTestBase.cs
@@ -48,7 +48,7 @@ namespace DurableTask.SqlServer.AzureFunctions.Tests
                     {
                         webJobsBuilder.AddDurableTask(options =>
                         {
-                            options.StorageProvider["type"] = SqlDurabilityProvider.Name;
+                            options.StorageProvider["type"] = "mssql";
                         });
                     })
                 .ConfigureServices(
@@ -57,7 +57,7 @@ namespace DurableTask.SqlServer.AzureFunctions.Tests
                         services.AddSingleton<INameResolver>(this.settingsResolver);
                         services.AddSingleton<IConnectionStringResolver>(this.settingsResolver);
                         services.AddSingleton<ITypeLocator>(this.typeLocator);
-                        services.AddSingleton<IDurabilityProviderFactory, SqlDurabilityProviderFactory>();
+                        services.AddDurableTaskSqlProvider();
                     })
                 .Build();
 


### PR DESCRIPTION
Resolves #30

This PR adds an extension method to register the Durable Task SQL storage provider for Azure Functions (and Azure Web Jobs).

Here is an example of how we register the SQL provider in our integration tests.

```csharp
this.functionsHost = new HostBuilder()
    .ConfigureLogging(
        loggingBuilder =>
        {
            loggingBuilder.AddProvider(this.logProvider);
            loggingBuilder.SetMinimumLevel(LogLevel.Information);
        })
    .ConfigureWebJobs(
        webJobsBuilder =>
        {
            webJobsBuilder.AddDurableTask(options =>
            {
                options.StorageProvider["type"] = "mssql";
            });
        })
    .ConfigureServices(
        services =>
        {
            services.AddSingleton<INameResolver>(this.settingsResolver);
            services.AddSingleton<IConnectionStringResolver>(this.settingsResolver);
            services.AddSingleton<ITypeLocator>(this.typeLocator);
            services.AddDurableTaskSqlProvider();
        })
    .Build();
```

Also in this PR:
- Increment version to v0.9.1-beta
- Update dependencies
- Minor doc updates