### PR TITLE
Fix purge history threshold check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## v0.10.0-beta
+
+### Breaking changes
+
+* Fixed backwards purge history threshold check ([#39](https://github.com/microsoft/durabletask-mssql/pull/39)) - contributed by [Jaah](https://github.com/Jaah)
+
 ## v0.9.1-beta
 
 ### New

--- a/src/DurableTask.SqlServer/Scripts/logic.sql
+++ b/src/DurableTask.SqlServer/Scripts/logic.sql
@@ -443,14 +443,14 @@ BEGIN
         INSERT INTO @instanceIDs
             SELECT [InstanceID] FROM Instances
             WHERE [TaskHub] = @TaskHub AND [RuntimeStatus] IN ('Completed', 'Terminated', 'Failed')
-                AND [CreatedTime] >= @ThresholdTime
+                AND [CreatedTime] <= @ThresholdTime
     END
     ELSE IF @FilterType = 1 -- completed time
     BEGIN
         INSERT INTO @instanceIDs
             SELECT [InstanceID] FROM Instances
             WHERE [TaskHub] = @TaskHub AND [RuntimeStatus] IN ('Completed', 'Terminated', 'Failed')
-                AND [CompletedTime] >= @ThresholdTime
+                AND [CompletedTime] <= @ThresholdTime
     END
     ELSE
     BEGIN

--- a/src/DurableTask.SqlServer/SqlOrchestrationService.cs
+++ b/src/DurableTask.SqlServer/SqlOrchestrationService.cs
@@ -585,13 +585,13 @@ namespace DurableTask.SqlServer
         }
 
         public override async Task PurgeOrchestrationHistoryAsync(
-            DateTime thresholdDateTimeUtc,
+            DateTime maxThresholdDateTimeUtc,
             OrchestrationStateTimeRangeFilterType timeRangeFilterType)
         {
             using SqlConnection connection = await this.GetAndOpenConnectionAsync();
             using SqlCommand command = this.GetSprocCommand(connection, "dt.PurgeInstanceStateByTime");
 
-            command.Parameters.Add("@ThresholdTime", SqlDbType.DateTime2).Value = thresholdDateTimeUtc;
+            command.Parameters.Add("@ThresholdTime", SqlDbType.DateTime2).Value = maxThresholdDateTimeUtc;
             command.Parameters.Add("@FilterType", SqlDbType.TinyInt).Value = (int)timeRangeFilterType;
 
             await SqlUtils.ExecuteNonQueryAsync(command, this.traceHelper);

--- a/test/DurableTask.SqlServer.Tests/Integration/PurgeTests.cs
+++ b/test/DurableTask.SqlServer.Tests/Integration/PurgeTests.cs
@@ -34,8 +34,6 @@ namespace DurableTask.SqlServer.Tests.Integration
         [InlineData(OrchestrationStateTimeRangeFilterType.OrchestrationCompletedTimeFilter)]
         public async Task PurgesInstancesByStatus(OrchestrationStateTimeRangeFilterType filterType)
         {
-            DateTime startTime = DateTime.UtcNow;
-
             var events = new ConcurrentDictionary<string, TaskCompletionSource<bool>>();
 
             // Waits for an external event and then either completes or fails depending on that event
@@ -66,7 +64,7 @@ namespace DurableTask.SqlServer.Tests.Integration
             await Task.WhenAll(instances.Select(instance => instance.WaitForStart()));
 
             // Try to purge the instance and check that it still exists
-            await this.testService.PurgeAsync(startTime, filterType);
+            await this.testService.PurgeAsync(DateTime.MaxValue, filterType);
             foreach (TestInstance<string> instance in instances)
             {
                 OrchestrationState runningState = await instance.GetStateAsync();
@@ -108,7 +106,7 @@ namespace DurableTask.SqlServer.Tests.Integration
             await Task.WhenAll(tasks);
 
             // This time-based purge should remove all the instances
-            await this.testService.PurgeAsync(startTime, filterType);
+            await this.testService.PurgeAsync(DateTime.MaxValue, filterType);
             foreach (TestInstance<string> instance in instances)
             {
                 OrchestrationState purgedState = await instance.GetStateAsync();
@@ -116,7 +114,7 @@ namespace DurableTask.SqlServer.Tests.Integration
             }
 
             // One more purge, just to make sure there are no failures when there is nothing left to purge
-            await this.testService.PurgeAsync(startTime, filterType);
+            await this.testService.PurgeAsync(DateTime.MaxValue, filterType);
         }
     }
 }

--- a/test/DurableTask.SqlServer.Tests/Utils/TestService.cs
+++ b/test/DurableTask.SqlServer.Tests/Utils/TestService.cs
@@ -73,10 +73,10 @@ namespace DurableTask.SqlServer.Tests.Utils
 
         public Task StartWorkerAsync() => this.worker?.StartAsync() ?? Task.CompletedTask;
 
-        public Task PurgeAsync(DateTime minimumThreshold, OrchestrationStateTimeRangeFilterType filterType)
+        public Task PurgeAsync(DateTime maximumThreshold, OrchestrationStateTimeRangeFilterType filterType)
         {
             return this.client.PurgeOrchestrationInstanceHistoryAsync(
-                minimumThreshold,
+                maximumThreshold,
                 filterType);
         }
 


### PR DESCRIPTION
The documentation for `PurgeOrchestrationHistoryAsync` says it should be purging instances that are older than the given threshold. However it seems that the stored procedure used to retrieve these is currently retrieving instances _newer_ than the given threshold.

This will PR fixes the `PurgeInstanceStateByTime` stored procedure to retrieve instances that are _older_ than the given threshold time.