### PR TITLE
Removed foreign key constraints from all tables

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -33,6 +33,6 @@ jobs:
       run: test/setup.ps1
       shell: pwsh
     - name: Durable framework tests
-      run: dotnet test --no-build --verbosity normal ./test/DurableTask.SqlServer.Tests/DurableTask.SqlServer.Tests.csproj
+      run: dotnet test --no-build --verbosity normal --filter Category!=Stress ./test/DurableTask.SqlServer.Tests/DurableTask.SqlServer.Tests.csproj
     - name: Functions runtime tests
       run: dotnet test --no-build --verbosity normal ./test/DurableTask.SqlServer.AzureFunctions.Tests/DurableTask.SqlServer.AzureFunctions.Tests.csproj

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## v0.10.1-beta
+
+### Updates
+
+* Removed foreign key constraints from all tables to dramatically improve performance and eliminate common sources of deadlocks ([#46](https://github.com/microsoft/durabletask-mssql/pull/46))
+* Added documentation for how to work around native dependency issues in Azure Functions.
+* Added documentation about the taskEventLockTimeout setting in the Azure Functions host.json file.
+
 ## v0.10.0-beta
 
 ### Updates

--- a/src/DurableTask.SqlServer/Scripts/logic.sql
+++ b/src/DurableTask.SqlServer/Scripts/logic.sql
@@ -416,10 +416,11 @@ BEGIN
     BEGIN TRANSACTION
 
     DELETE FROM NewEvents WHERE [TaskHub] = @TaskHub AND [InstanceID] IN (SELECT [InstanceID] FROM @InstanceIDs)
+    DELETE FROM NewTasks  WHERE [TaskHub] = @TaskHub AND [InstanceID] IN (SELECT [InstanceID] FROM @InstanceIDs)
     DELETE FROM Instances WHERE [TaskHub] = @TaskHub AND [InstanceID] IN (SELECT [InstanceID] FROM @InstanceIDs)
     DECLARE @deletedInstances int = @@ROWCOUNT
+    DELETE FROM History  WHERE [TaskHub] = @TaskHub AND [InstanceID] IN (SELECT [InstanceID] FROM @InstanceIDs)
     DELETE FROM Payloads WHERE [TaskHub] = @TaskHub AND [InstanceID] IN (SELECT [InstanceID] FROM @InstanceIDs)
-    -- Other relevant tables are expected to be cleaned up via cascade deletes
 
     COMMIT TRANSACTION
 

--- a/src/common.props
+++ b/src/common.props
@@ -16,7 +16,7 @@
   <!-- Version settings: https://andrewlock.net/version-vs-versionsuffix-vs-packageversion-what-do-they-all-mean/ -->
   <PropertyGroup>
     <MajorVersion>0</MajorVersion>
-    <VersionPrefix>$(MajorVersion).10.0</VersionPrefix>
+    <VersionPrefix>$(MajorVersion).10.1</VersionPrefix>
     <VersionSuffix>beta</VersionSuffix>
     <AssemblyVersion>$(MajorVersion).0.0.0</AssemblyVersion>
     <BuildSuffix Condition="'$(GITHUB_RUN_NUMBER)' != ''">.$(GITHUB_RUN_NUMBER)</BuildSuffix>

--- a/test/DurableTask.SqlServer.Tests/Integration/StressTests.cs
+++ b/test/DurableTask.SqlServer.Tests/Integration/StressTests.cs
@@ -15,6 +15,7 @@ namespace DurableTask.SqlServer.Tests.Integration
     /// These tests are expected to take longer to complete compared to functional integration
     /// tests and therefore may not be appropriate for all CI or rapid testing scenarios.
     /// </summary>
+    [Trait("Category", "Stress")]
     public class StressTests : IAsyncLifetime
     {
         readonly TestService testService;
@@ -68,8 +69,8 @@ namespace DurableTask.SqlServer.Tests.Integration
                 });
 
             // On a fast Windows desktop machine, a 2000 sub-orchestration test should complete in 30-40 seconds.
-            // Extra time is provided to accomodate slower CI machines.
-            await testInstance.WaitForCompletion(TimeSpan.FromMinutes(2));
+            // On slower CI machines, this test could take several minutes to complete.
+            await testInstance.WaitForCompletion(TimeSpan.FromMinutes(5));
         }
     }
 }

--- a/test/DurableTask.SqlServer.Tests/Integration/StressTests.cs
+++ b/test/DurableTask.SqlServer.Tests/Integration/StressTests.cs
@@ -1,0 +1,75 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+namespace DurableTask.SqlServer.Tests.Integration
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Threading.Tasks;
+    using DurableTask.SqlServer.Tests.Utils;
+    using Xunit;
+    using Xunit.Abstractions;
+
+    /// <summary>
+    /// Integration tests that are intended to reveal issues related to load or concurrency.
+    /// These tests are expected to take longer to complete compared to functional integration
+    /// tests and therefore may not be appropriate for all CI or rapid testing scenarios.
+    /// </summary>
+    public class StressTests : IAsyncLifetime
+    {
+        readonly TestService testService;
+
+        public StressTests(ITestOutputHelper output)
+        {
+            this.testService = new TestService(output);
+        }
+
+        Task IAsyncLifetime.InitializeAsync() => this.testService.InitializeAsync();
+
+        Task IAsyncLifetime.DisposeAsync() => this.testService.DisposeAsync();
+
+        // This test has previously been used to uncover various deadlock issues by stressing the code paths
+        // related to foreign keys that point to the Instances and Payloads tables.
+        // Example: https://github.com/microsoft/durabletask-mssql/issues/45 
+        [Theory]
+        [InlineData(10)]
+        [InlineData(2000)]
+        public async Task ParallelSubOrchestrations(int subOrchestrationCount)
+        {
+            const string SubOrchestrationName = "SubOrchestration";
+
+            this.testService.RegisterInlineOrchestration<DateTime, string>(
+                orchestrationName: SubOrchestrationName,
+                version: "",
+                implementation: async (ctx, input) =>
+                {
+                    await ctx.CreateTimer(DateTime.MinValue, input);
+                    return ctx.CurrentUtcDateTime;
+                });
+
+            TestInstance<int> testInstance = await this.testService.RunOrchestration(
+                input: 1,
+                orchestrationName: nameof(ParallelSubOrchestrations),
+                implementation: async (ctx, input) =>
+                {
+                    var listInstances = new List<Task<DateTime>>();
+                    for (int i = 0; i < subOrchestrationCount; i++)
+                    {
+                        Task<DateTime> instance = ctx.CreateSubOrchestrationInstance<DateTime>(
+                            name: SubOrchestrationName,
+                            version: "",
+                            instanceId: $"suborchestration[{i}]",
+                            input: $"{i}");
+                        listInstances.Add(instance);
+                    }
+
+                    DateTime[] results = await Task.WhenAll(listInstances);
+                    return new List<DateTime>(results);
+                });
+
+            // On a fast Windows desktop machine, a 2000 sub-orchestration test should complete in 30-40 seconds.
+            // Extra time is provided to accomodate slower CI machines.
+            await testInstance.WaitForCompletion(TimeSpan.FromMinutes(2));
+        }
+    }
+}


### PR DESCRIPTION
This PR fixes a common source of SQL deadlocks by removing foreign key constraints from the core tables. Not only does this resolve deadlocks, but some tests are showing significant performance improvements, helping justify this potentially controversial change.  As an example, a 2,000 sub-orchestration stress test went from taking >150 seconds to <40 seconds after this change. Comments have been added to the SQL schema file explaining why there are no FK constraints.

Data consistency will be enforced through careful use of transactions across the various stored procedures.

Resolves #45 
Resolves #23

Also:

* Minor documentation updates
* Incremented version to v0.10.1-beta