### PR TITLE
Automatically Create Database if Not Present

### DIFF
--- a/src/DurableTask.SqlServer/Identifier.cs
+++ b/src/DurableTask.SqlServer/Identifier.cs
@@ -1,0 +1,40 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+namespace DurableTask.SqlServer
+{
+    using System;
+    using System.Text;
+
+    static class Identifier
+    {
+        public static string Escape(string value)
+        {
+            if (value == null)
+            {
+                throw new ArgumentNullException(nameof(value));
+            }
+
+            if (value == "")
+            {
+                throw new ArgumentException("Value cannot be empty.", nameof(value));
+            }
+
+            StringBuilder builder = new StringBuilder();
+
+            builder.Append('[');
+            foreach (char c in value)
+            {
+                if (c == ']')
+                {
+                    builder.Append(']');
+                }
+
+                builder.Append(c);
+            }
+            builder.Append(']');
+
+            return builder.ToString();
+        }
+    }
+}

--- a/src/DurableTask.SqlServer/LogHelper.cs
+++ b/src/DurableTask.SqlServer/LogHelper.cs
@@ -44,7 +44,7 @@ namespace DurableTask.SqlServer
             var logEvent = new LogEvents.AcquiredAppLockEvent(
                 statusCode,
                 latencyStopwatch.ElapsedMilliseconds);
-            
+
             this.WriteLog(logEvent);
         }
 
@@ -109,6 +109,23 @@ namespace DurableTask.SqlServer
                 userId,
                 purgedInstanceCount,
                 latencyStopwatch.ElapsedMilliseconds);
+            this.WriteLog(logEvent);
+        }
+
+        public void CommandCompleted(string commandText, Stopwatch latencyStopwatch, int retryCount, string? instanceId)
+        {
+            var logEvent = new LogEvents.CommandCompletedEvent(
+                commandText,
+                latencyStopwatch.ElapsedMilliseconds,
+                retryCount,
+                instanceId);
+
+            this.WriteLog(logEvent);
+        }
+
+        public void CreatedDatabase(string databaseName)
+        {
+            var logEvent = new LogEvents.CreatedDatabaseEvent(databaseName);
             this.WriteLog(logEvent);
         }
 

--- a/src/DurableTask.SqlServer/Logging/DefaultEventSource.cs
+++ b/src/DurableTask.SqlServer/Logging/DefaultEventSource.cs
@@ -232,5 +232,39 @@ namespace DurableTask.SqlServer.Logging
                 AppName,
                 ExtensionVersion);
         }
+
+        [Event(EventIds.CommandCompleted, Level = EventLevel.Verbose)]
+        public void CommandCompleted(
+            string? InstanceId,
+            string CommandText,
+            long LatencyMs,
+            int RetryCount,
+            string AppName,
+            string ExtensionVersion)
+        {
+            // TODO: Switch to WriteEventCore for better performance
+            this.WriteEvent(
+                EventIds.CommandCompleted,
+                InstanceId ?? string.Empty,
+                CommandText,
+                LatencyMs,
+                RetryCount,
+                AppName,
+                ExtensionVersion);
+        }
+
+        [Event(EventIds.CreatedDatabase, Level = EventLevel.Informational)]
+        internal void CreatedDatabase(
+            string DatabaseName,
+            string AppName,
+            string ExtensionVersion)
+        {
+            // TODO: Use WriteEventCore for better performance
+            this.WriteEvent(
+                EventIds.CreatedDatabase,
+                DatabaseName,
+                AppName,
+                ExtensionVersion);
+        }
     }
 }

--- a/src/DurableTask.SqlServer/Logging/EventIds.cs
+++ b/src/DurableTask.SqlServer/Logging/EventIds.cs
@@ -20,5 +20,7 @@ namespace DurableTask.SqlServer.Logging
         public const int TransientDatabaseFailure = 308;
         public const int ReplicaCountChangeRecommended = 309;
         public const int PurgedInstances = 310;
+        public const int CommandCompleted = 311;
+        public const int CreatedDatabase = 312;
     }
 }

--- a/src/DurableTask.SqlServer/Logging/LogEvents.cs
+++ b/src/DurableTask.SqlServer/Logging/LogEvents.cs
@@ -415,5 +415,71 @@ namespace DurableTask.SqlServer.Logging
                     DTUtils.AppName,
                     DTUtils.ExtensionVersionString);
         }
+
+        internal class CommandCompletedEvent : StructuredLogEvent, IEventSourceEvent
+        {
+            public CommandCompletedEvent(string commandText, long latencyMs, int retryCount, string? instanceId)
+            {
+                this.CommandText = commandText;
+                this.LatencyMs = latencyMs;
+                this.RetryCount = retryCount;
+                this.InstanceId = instanceId;
+            }
+
+            [StructuredLogField]
+            public string CommandText { get; }
+
+            [StructuredLogField]
+            public long LatencyMs { get; }
+
+            [StructuredLogField]
+            public int RetryCount { get; }
+
+            [StructuredLogField]
+            public string? InstanceId { get; }
+
+            public override LogLevel Level => LogLevel.Debug;
+
+            public override EventId EventId => new EventId(
+                EventIds.CommandCompleted,
+                nameof(EventIds.CommandCompleted));
+
+            protected override string CreateLogMessage() =>
+                string.IsNullOrEmpty(this.InstanceId) ?
+                    $"Executed SQL statement(s) '{this.CommandText}' in {this.LatencyMs}ms" :
+                    $"{this.InstanceId}: Executed SQL statement(s) '{this.CommandText}' in {this.LatencyMs}ms";
+
+            void IEventSourceEvent.WriteEventSource() =>
+                DefaultEventSource.Log.CommandCompleted(
+                    this.InstanceId,
+                    this.CommandText,
+                    this.LatencyMs,
+                    this.RetryCount,
+                    DTUtils.AppName,
+                    DTUtils.ExtensionVersionString);
+        }
+
+        internal class CreatedDatabaseEvent : StructuredLogEvent, IEventSourceEvent
+        {
+            public CreatedDatabaseEvent(string databaseName) =>
+                this.DatabaseName = databaseName;
+
+            [StructuredLogField]
+            public string DatabaseName { get; }
+
+            public override EventId EventId => new EventId(
+                EventIds.CreatedDatabase,
+                nameof(EventIds.CreatedDatabase));
+
+            public override LogLevel Level => LogLevel.Information;
+
+            protected override string CreateLogMessage() => $"Created database '{this.DatabaseName}'.";
+
+            void IEventSourceEvent.WriteEventSource() =>
+                DefaultEventSource.Log.CreatedDatabase(
+                    this.DatabaseName,
+                    DTUtils.AppName,
+                    DTUtils.ExtensionVersionString);
+        }
     }
 }

--- a/src/DurableTask.SqlServer/SqlDbManager.cs
+++ b/src/DurableTask.SqlServer/SqlDbManager.cs
@@ -30,8 +30,28 @@ namespace DurableTask.SqlServer
 
         public async Task CreateOrUpgradeSchemaAsync(bool recreateIfExists)
         {
+            // Note that we may not be able to connect to the DB, let alone obtain the lock,
+            // if the database does not exist yet. So we obtain a connection to the 'master' database for now.
+            SqlConnection connection = this.settings.CreateConnection("master");
+            await connection.OpenAsync();
+
+            if (!await this.DoesDatabaseExistAsync(this.settings.DatabaseName, connection))
+            {
+                if (!this.settings.CreateDatabaseIfNotExists)
+                {
+                    throw new InvalidOperationException($"Database '{this.settings.DatabaseName}' does not exist.");
+                }
+
+                await this.CreateDatabaseAsync(this.settings.DatabaseName, connection);
+            }
+
             // Prevent other create or delete operations from executing at the same time.
-            await using DatabaseLock dbLock = await this.AcquireDatabaseLockAsync();
+#if NETSTANDARD2_0
+            connection.ChangeDatabase(this.settings.DatabaseName);
+#else
+            await connection.ChangeDatabaseAsync(this.settings.DatabaseName);
+#endif
+            await using DatabaseLock dbLock = await this.AcquireDatabaseLockAsync(connection);
 
             var currentSchemaVersion = new SemanticVersion(0, 0, 0);
             if (recreateIfExists)
@@ -136,6 +156,11 @@ namespace DurableTask.SqlServer
             SqlConnection connection = this.settings.CreateConnection();
             await connection.OpenAsync();
 
+            return await this.AcquireDatabaseLockAsync(connection);
+        }
+
+        async Task<DatabaseLock> AcquireDatabaseLockAsync(SqlConnection connection)
+        {
             // It's possible that more than one worker may attempt to execute this creation logic at the same
             // time. To avoid update conflicts, we use an app lock + a transaction to ensure only a single worker
             // can perform an upgrade at a time. All other workers will wait for the first one to complete.
@@ -169,6 +194,32 @@ namespace DurableTask.SqlServer
             }
 
             return new DatabaseLock(connection, lockTransaction);
+        }
+
+        async Task<bool> DoesDatabaseExistAsync(string databaseName, SqlConnection connection)
+        {
+            using SqlCommand command = connection.CreateCommand();
+            command.CommandText = "SELECT 1 FROM sys.databases WHERE name = @databaseName";
+            command.Parameters.AddWithValue("@databaseName", databaseName);
+
+            bool exists = (int?)await SqlUtils.ExecuteScalarAsync(command, this.traceHelper) == 1;
+            return exists;
+        }
+
+        async Task CreateDatabaseAsync(string databaseName, SqlConnection connection)
+        {
+            using SqlCommand command = connection.CreateCommand();
+            command.CommandText = $"CREATE DATABASE {Identifier.Escape(databaseName)} COLLATE Latin1_General_100_BIN2_UTF8";
+
+            try
+            {
+                await SqlUtils.ExecuteNonQueryAsync(command, this.traceHelper);
+                this.traceHelper.CreatedDatabase(databaseName);
+            }
+            catch (SqlException e) when (e.Number == 1801 /* Database already exists */)
+            {
+                // Ignore
+            }
         }
 
         async Task ExecuteSqlScriptAsync(string scriptName, DatabaseLock dbLock)

--- a/test/DurableTask.SqlServer.Tests/Integration/DatabaseManagement.cs
+++ b/test/DurableTask.SqlServer.Tests/Integration/DatabaseManagement.cs
@@ -69,24 +69,34 @@ namespace DurableTask.SqlServer.Tests.Integration
         /// that the CreateItNotExist API doesn't attempt to create it again,
         /// and then that the schema can be subsequently deleted.
         /// </summary>
-        [Fact]
-        public async Task CanCreateAndDropSchema()
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public async Task CanCreateAndDropSchema(bool isDatabaseMissing)
         {
-            using TestDatabase testDb = this.CreateTestDb();
+            using TestDatabase testDb = this.CreateTestDb(!isDatabaseMissing);
             IOrchestrationService service = this.CreateServiceWithTestDb(testDb);
 
             // Create the DB schema for the first time
             await service.CreateAsync(recreateInstanceStore: true);
 
             LogAssert.NoWarningsOrErrors(this.logProvider);
-            LogAssert.Sequence(
-                this.logProvider,
-                LogAssert.AcquiredAppLock(),
-                LogAssert.ExecutedSqlScript("drop-schema.sql"),
-                LogAssert.ExecutedSqlScript("schema-0.2.0.sql"),
-                LogAssert.ExecutedSqlScript("logic.sql"),
-                LogAssert.ExecutedSqlScript("permissions.sql"),
-                LogAssert.SprocCompleted("dt._UpdateVersion"));
+            LogAssert
+                .For(this.logProvider)
+                .Expect(
+                    LogAssert.CheckedDatabase())
+                .ExpectIf(
+                    isDatabaseMissing,
+                    LogAssert.CommandCompleted($"CREATE DATABASE [{testDb.Name}]"),
+                    LogAssert.CreatedDatabase(testDb.Name))
+                .Expect(
+                    LogAssert.AcquiredAppLock(),
+                    LogAssert.ExecutedSqlScript("drop-schema.sql"),
+                    LogAssert.ExecutedSqlScript("schema-0.2.0.sql"),
+                    LogAssert.ExecutedSqlScript("logic.sql"),
+                    LogAssert.ExecutedSqlScript("permissions.sql"),
+                    LogAssert.SprocCompleted("dt._UpdateVersion"))
+                .EndOfLog();
 
             ValidateDatabaseSchema(testDb);
 
@@ -100,6 +110,7 @@ namespace DurableTask.SqlServer.Tests.Integration
             LogAssert.NoWarningsOrErrors(this.logProvider);
             LogAssert.Sequence(
                 this.logProvider,
+                LogAssert.CheckedDatabase(),
                 LogAssert.AcquiredAppLock(),
                 LogAssert.SprocCompleted("dt._GetVersions"));
 
@@ -122,23 +133,33 @@ namespace DurableTask.SqlServer.Tests.Integration
         /// DB schema. The previous test covered CreateAsync from scratch. This one covers
         /// CreateIfNotExistsAsync from scratch.
         /// </summary>
-        [Fact]
-        public async Task CanCreateIfNotExists()
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public async Task CanCreateIfNotExists(bool isDatabaseMissing)
         {
-            using TestDatabase testDb = this.CreateTestDb();
+            using TestDatabase testDb = this.CreateTestDb(!isDatabaseMissing);
             IOrchestrationService service = this.CreateServiceWithTestDb(testDb);
 
             await service.CreateIfNotExistsAsync();
 
             LogAssert.NoWarningsOrErrors(this.logProvider);
-            LogAssert.Sequence(
-                this.logProvider,
-                LogAssert.AcquiredAppLock(),
-                LogAssert.SprocCompleted("dt._GetVersions"),
-                LogAssert.ExecutedSqlScript("schema-0.2.0.sql"),
-                LogAssert.ExecutedSqlScript("logic.sql"),
-                LogAssert.ExecutedSqlScript("permissions.sql"),
-                LogAssert.SprocCompleted("dt._UpdateVersion"));
+            LogAssert
+                .For(this.logProvider)
+                .Expect(
+                    LogAssert.CheckedDatabase())
+                .ExpectIf(
+                    isDatabaseMissing,
+                    LogAssert.CommandCompleted($"CREATE DATABASE [{testDb.Name}]"),
+                    LogAssert.CreatedDatabase(testDb.Name))
+                .Expect(
+                    LogAssert.AcquiredAppLock(),
+                    LogAssert.SprocCompleted("dt._GetVersions"),
+                    LogAssert.ExecutedSqlScript("schema-0.2.0.sql"),
+                    LogAssert.ExecutedSqlScript("logic.sql"),
+                    LogAssert.ExecutedSqlScript("permissions.sql"),
+                    LogAssert.SprocCompleted("dt._UpdateVersion"))
+                .EndOfLog();
 
             ValidateDatabaseSchema(testDb);
         }
@@ -147,10 +168,12 @@ namespace DurableTask.SqlServer.Tests.Integration
         /// Verifies that CreateIfNotExistsAsync is thread-safe.
         /// </summary>
         /// <returns></returns>
-        [Fact]
-        public void SchemaCreationIsSerializedAndIdempotent()
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public void SchemaCreationIsSerializedAndIdempotent(bool isDatabaseMissing)
         {
-            using TestDatabase testDb = this.CreateTestDb();
+            using TestDatabase testDb = this.CreateTestDb(!isDatabaseMissing);
             IOrchestrationService service = this.CreateServiceWithTestDb(testDb);
 
             // Simulate 4 workers starting up concurrently and trying to initialize
@@ -163,30 +186,49 @@ namespace DurableTask.SqlServer.Tests.Integration
             ValidateDatabaseSchema(testDb);
 
             // Operations are expected to be serialized, making the log output deterministic.
-            LogAssert.Sequence(
-                this.logProvider,
-                // 1st
-                LogAssert.AcquiredAppLock(statusCode: 0),
-                LogAssert.SprocCompleted("dt._GetVersions"),
-                LogAssert.ExecutedSqlScript("schema-0.2.0.sql"),
-                LogAssert.ExecutedSqlScript("logic.sql"),
-                LogAssert.ExecutedSqlScript("permissions.sql"),
-                LogAssert.SprocCompleted("dt._UpdateVersion"),
-                // 2nd
-                LogAssert.AcquiredAppLock(statusCode: 1),
-                LogAssert.SprocCompleted("dt._GetVersions"),
-                // 3rd
-                LogAssert.AcquiredAppLock(statusCode: 1),
-                LogAssert.SprocCompleted("dt._GetVersions"),
-                // 4th
-                LogAssert.AcquiredAppLock(statusCode: 1),
-                LogAssert.SprocCompleted("dt._GetVersions"));
+            LogAssert
+                .For(this.logProvider)
+                .Expect(
+                    // At least 1 worker will check the database first
+                    LogAssert.CheckedDatabase())
+                .Contains(
+                    // The other 3 workers will check in some non-deterministic order
+                    LogAssert.CheckedDatabase(),
+                    LogAssert.CheckedDatabase(),
+                    LogAssert.CheckedDatabase())
+                .ContainsIf(
+                    // One worker may obtain the lock after another worker created the database.
+                    isDatabaseMissing,
+                    LogAssert.CommandCompleted($"CREATE DATABASE [{testDb.Name}]"),
+                    LogAssert.CreatedDatabase(testDb.Name))
+                .Expect(
+                    // 1st
+                    LogAssert.AcquiredAppLock(statusCode: 0),
+                    LogAssert.SprocCompleted("dt._GetVersions"),
+                    LogAssert.ExecutedSqlScript("schema-0.2.0.sql"),
+                    LogAssert.ExecutedSqlScript("logic.sql"),
+                    LogAssert.ExecutedSqlScript("permissions.sql"),
+                    LogAssert.SprocCompleted("dt._UpdateVersion"),
+                    // 2nd
+                    LogAssert.AcquiredAppLock(),
+                    LogAssert.SprocCompleted("dt._GetVersions"),
+                    // 3rd
+                    LogAssert.AcquiredAppLock(),
+                    LogAssert.SprocCompleted("dt._GetVersions"),
+                    // 4th
+                    LogAssert.AcquiredAppLock(),
+                    LogAssert.SprocCompleted("dt._GetVersions"))
+                .EndOfLog();
         }
 
-        TestDatabase CreateTestDb()
+        TestDatabase CreateTestDb(bool initializeDatabase = true)
         {
             var testDb = new TestDatabase(this.output);
-            testDb.Create();
+            if (initializeDatabase)
+            {
+                testDb.Create();
+            }
+
             return testDb;
         }
 
@@ -194,6 +236,7 @@ namespace DurableTask.SqlServer.Tests.Integration
         {
             var options = new SqlOrchestrationServiceSettings(testDb.ConnectionString)
             {
+                CreateDatabaseIfNotExists = true,
                 LoggerFactory = LoggerFactory.Create(builder =>
                 {
                     builder.SetMinimumLevel(LogLevel.Trace);
@@ -295,41 +338,38 @@ namespace DurableTask.SqlServer.Tests.Integration
         sealed class TestDatabase : IDisposable
         {
             readonly Server server;
-            readonly Database testDb;
+            readonly Lazy<Database> testDb;
             readonly ITestOutputHelper output;
 
             public TestDatabase(ITestOutputHelper output)
             {
-                string databaseName = $"TestDB_{DateTime.UtcNow:yyyyMMddhhmmssfffffff}";
+                this.Name = $"TestDB_{DateTime.UtcNow:yyyyMMddhhmmssfffffff}";
 
-                this.server = new Server(new ServerConnection(new SqlConnection(SharedTestHelpers.GetDefaultConnectionString())));
-                this.testDb = new Database(this.server, databaseName)
-                {
-                    Collation = "Latin1_General_100_BIN2_UTF8",
-                };
+                string defaultConnectionString = SharedTestHelpers.GetDefaultConnectionString("master");
+                this.server = new Server(new ServerConnection(new SqlConnection(defaultConnectionString)));
+                this.testDb = new Lazy<Database>(
+                    () => new Database(this.server, this.Name) { Collation = "Latin1_General_100_BIN2_UTF8" });
 
-                this.ConnectionString = 
-                    new SqlConnectionStringBuilder(this.server.ConnectionContext.ConnectionString)
-                    {
-                        InitialCatalog = this.testDb.Name,
-                    }
-                    .ConnectionString;
+                this.ConnectionString =
+                    new SqlConnectionStringBuilder(SharedTestHelpers.GetDefaultConnectionString(this.Name)).ConnectionString;
 
                 this.output = output;
             }
 
             public string ConnectionString { get; }
 
+            public string Name { get; }
+
             public void Create()
             {
-                this.output.WriteLine($"Creating database: {this.server.Name}/{this.testDb.Name}");
-                this.testDb.Create();
+                this.output.WriteLine($"Creating database: {this.server.Name}/{this.Name}");
+                this.testDb.Value.Create();
             }
 
             public IEnumerable<string> GetSchemas()
             {
-                this.testDb.Schemas.Refresh();
-                foreach (Schema schema in this.testDb.Schemas)
+                this.testDb.Value.Schemas.Refresh();
+                foreach (Schema schema in this.testDb.Value.Schemas)
                 {
                     yield return schema.Name;
                 }
@@ -337,8 +377,8 @@ namespace DurableTask.SqlServer.Tests.Integration
 
             public IEnumerable<string> GetTables()
             {
-                this.testDb.Tables.Refresh();
-                foreach (Table table in this.testDb.Tables)
+                this.testDb.Value.Tables.Refresh();
+                foreach (Table table in this.testDb.Value.Tables)
                 {
                     // e.g. "dt.History"
                     yield return $"{table.Schema}.{table.Name}";
@@ -347,8 +387,8 @@ namespace DurableTask.SqlServer.Tests.Integration
 
             public IEnumerable<string> GetSprocs()
             {
-                this.testDb.StoredProcedures.Refresh();
-                foreach (StoredProcedure sproc in this.testDb.StoredProcedures)
+                this.testDb.Value.StoredProcedures.Refresh();
+                foreach (StoredProcedure sproc in this.testDb.Value.StoredProcedures)
                 {
                     if (sproc.Schema == "sys")
                     {
@@ -362,8 +402,8 @@ namespace DurableTask.SqlServer.Tests.Integration
 
             public IEnumerable<string> GetViews()
             {
-                this.testDb.Views.Refresh();
-                foreach (View view in this.testDb.Views)
+                this.testDb.Value.Views.Refresh();
+                foreach (View view in this.testDb.Value.Views)
                 {
                     if (view.Schema == "sys" || view.Schema == "INFORMATION_SCHEMA")
                     {
@@ -376,8 +416,8 @@ namespace DurableTask.SqlServer.Tests.Integration
 
             public IEnumerable<string> GetFunctions()
             {
-                this.testDb.UserDefinedFunctions.Refresh();
-                foreach (UserDefinedFunction function in this.testDb.UserDefinedFunctions)
+                this.testDb.Value.UserDefinedFunctions.Refresh();
+                foreach (UserDefinedFunction function in this.testDb.Value.UserDefinedFunctions)
                 {
                     if (function.Schema == "sys" || function.Schema == "INFORMATION_SCHEMA")
                     {
@@ -390,8 +430,8 @@ namespace DurableTask.SqlServer.Tests.Integration
 
             public void Dispose()
             {
-                this.output.WriteLine($"Dropping database: {this.server.Name}/{this.testDb.Name}");
-                this.server.KillDatabase(this.testDb.Name);
+                this.output.WriteLine($"Dropping database: {this.server.Name}/{this.Name}");
+                this.server.KillDatabase(this.Name);
             }
         }
     }

--- a/test/DurableTask.SqlServer.Tests/Logging/LogAssertExtensions.cs
+++ b/test/DurableTask.SqlServer.Tests/Logging/LogAssertExtensions.cs
@@ -1,0 +1,72 @@
+﻿namespace DurableTask.SqlServer.Tests.Logging
+{
+    using System.Collections.Generic;
+    using System.Linq;
+    using Xunit;
+
+    static class LogAssertExtensions
+    {
+        public static void AllowAdditionalLogs(this IEnumerable<LogEntry> logs) =>
+            logs.ToList(); // Resolve the enumerable
+
+        public static void EndOfLog(this IEnumerable<LogEntry> logs)
+        {
+            int count = logs.Count();
+            Assert.True(count == 0, $"Expected no additional logs but found {count}.");
+        }
+
+        public static IEnumerable<LogEntry> Contains(this IEnumerable<LogEntry> logs, params LogAssert[] asserts)
+        {
+            var remaining = new HashSet<LogAssert>(asserts);
+
+            foreach (LogEntry logEntry in logs)
+            {
+                LogAssert match = remaining.FirstOrDefault(assert =>
+                    string.Equals(assert.EventName, logEntry.EventId.Name) &&
+                    assert.EventId == logEntry.EventId.Id &&
+                    assert.Level == logEntry.LogLevel &&
+                    logEntry.Message.Contains(assert.MessageSubstring));
+
+                if (match != null)
+                {
+                    remaining.Remove(match);
+                }
+                else
+                {
+                    yield return logEntry;
+                }
+            }
+
+            Assert.Empty(remaining);
+        }
+
+        public static IEnumerable<LogEntry> ContainsIf(this IEnumerable<LogEntry> logs, bool predicate, params LogAssert[] asserts) =>
+            predicate ? logs.Contains(asserts) : logs;
+
+        public static IEnumerable<LogEntry> Expect(this IEnumerable<LogEntry> logs, params LogAssert[] asserts)
+        {
+            int i = 0;
+            foreach (LogEntry actual in logs)
+            {
+                if (asserts.Length > i)
+                {
+                    LogAssert expected = asserts[i++];
+
+                    Assert.Equal(expected.EventName, actual.EventId.Name);
+                    Assert.Equal(expected.EventId, actual.EventId.Id);
+                    Assert.Equal(expected.Level, actual.LogLevel);
+                    Assert.Contains(expected.MessageSubstring, actual.Message);
+
+                    LogAssert.ValidateStructuredLogFields(actual);
+                }
+                else
+                {
+                    yield return actual;
+                }
+            }
+        }
+
+        public static IEnumerable<LogEntry> ExpectIf(this IEnumerable<LogEntry> logs, bool predicate, params LogAssert[] asserts) =>
+            predicate ? logs.Expect(asserts) : logs;
+    }
+}

--- a/test/DurableTask.SqlServer.Tests/Utils/SharedTestHelpers.cs
+++ b/test/DurableTask.SqlServer.Tests/Utils/SharedTestHelpers.cs
@@ -25,10 +25,10 @@ namespace DurableTask.SqlServer.Tests.Utils
             return test.TestCase.TestMethod.Method.Name;
         }
 
-        public static string GetDefaultConnectionString()
+        public static string GetDefaultConnectionString(string database = "DurableDB")
         {
             // The default for local development on a Windows OS
-            string defaultConnectionString = "Server=localhost;Database=DurableDB;Trusted_Connection=True;";
+            string defaultConnectionString = $"Server=localhost;Database={database};Trusted_Connection=True;";
             var builder = new SqlConnectionStringBuilder(defaultConnectionString);
 
             // The use of SA_PASSWORD is intended for use with the mssql docker container


### PR DESCRIPTION
As per https://github.com/microsoft/durabletask-mssql/issues/48, this change allows the worker to create the database automatically if it doesn't exist. Because the worker must gracefully handle the possibility the DB hasn't been created, a few changes needed to be made:
- The initial connection to the SQL server must use another `Initial Catalog` or `Database` instead of the user-specified one. As such, the worker now initially connects to the system database `master`
- The lock for upgrading the schema was also previously obtained within the context of the user-specified `Database`, so now the lock is only obtained after the presence of the database has been verified.
  - Each worker now independently checks the existence of the database.
- New log events have been created for executing arbitrary SQL commands/statements and creating a database
- New log assertion APIs have been added to accommodate non-deterministic scenarios, such as the initial inspection of whether the database exists