### PR TITLE
Add .NET Core 2.1 support for build signing pipeline

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -6,6 +6,12 @@ pool:
 
 steps:
 - task: UseDotNet@2
+  displayName: 'Use the .NET Core 2.1 SDK (required for building signing)'
+  inputs:
+    packageType: 'sdk'
+    version: '2.1.x'
+
+- task: UseDotNet@2
   displayName: 'Use the .NET 6 SDK'
   inputs:
     packageType: 'sdk'


### PR DESCRIPTION
This is to support the ESRP code signing pipeline we use for official releases. Our product doesn't depend on .NET Core 2.1, but the ESRP infrastructure we depend on unfortunately does. This change ensures we have both installed side-by-side.