### PR TITLE
Add support for .NET Standard 2.0 for Azure Functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## v0.11.1-beta
+
+### Updates
+
+* Added .NET Standard 2.0 support to Microsoft.DurableTask.SqlServer.AzureFunctions ([#63](https://github.com/microsoft/durabletask-mssql/pull/63))
+
 ## v0.11.0-beta
 
 ### New

--- a/src/DurableTask.SqlServer.AzureFunctions/DurableTask.SqlServer.AzureFunctions.csproj
+++ b/src/DurableTask.SqlServer.AzureFunctions/DurableTask.SqlServer.AzureFunctions.csproj
@@ -4,7 +4,7 @@
   <Import Project="../common.props" />
   
   <PropertyGroup>
-    <TargetFramework>netstandard2.1</TargetFramework>
+    <TargetFrameworks>netstandard2.1;netstandard2.0</TargetFrameworks>
   </PropertyGroup>
   
   <!-- NuGet package settings -->

--- a/src/common.props
+++ b/src/common.props
@@ -16,7 +16,7 @@
   <!-- Version settings: https://andrewlock.net/version-vs-versionsuffix-vs-packageversion-what-do-they-all-mean/ -->
   <PropertyGroup>
     <MajorVersion>0</MajorVersion>
-    <VersionPrefix>$(MajorVersion).11.0</VersionPrefix>
+    <VersionPrefix>$(MajorVersion).11.1</VersionPrefix>
     <VersionSuffix>beta</VersionSuffix>
     <AssemblyVersion>$(MajorVersion).0.0.0</AssemblyVersion>
     <BuildSuffix Condition="'$(GITHUB_RUN_NUMBER)' != ''">.$(GITHUB_RUN_NUMBER)</BuildSuffix>


### PR DESCRIPTION
Fixes https://github.com/microsoft/durabletask-mssql/issues/62

This PR simply adds `netstandard2.0` as a target for the Azure Functions extension. The DTFx package already supported `netstandard2.0`. No code changes were required.