### PR TITLE
fix the build issue of the Sample dockerfile for upgrading to sdk 6.0

### DIFF
--- a/test/PerformanceTests/Dockerfile
+++ b/test/PerformanceTests/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/dotnet/core/sdk:3.1 AS installer-env
+FROM mcr.microsoft.com/dotnet/sdk:6.0 AS installer-env
 
 COPY . /durabletask-mssql
 RUN cd /durabletask-mssql/test/PerformanceTests && \
@@ -7,7 +7,7 @@ RUN cd /durabletask-mssql/test/PerformanceTests && \
 
 # To enable ssh & remote debugging on app service change the base image to the one below
 # FROM mcr.microsoft.com/azure-functions/dotnet:3.0-appservice
-FROM mcr.microsoft.com/azure-functions/dotnet:3.0.15885
+FROM mcr.microsoft.com/azure-functions/dotnet:4.1.3
 ENV AzureWebJobsScriptRoot=/home/site/wwwroot \
     AzureFunctionsJobHost__Logging__Console__IsEnabled=true
 


### PR DESCRIPTION
The current sample Dockerfile doesn't work since the  PerformanceTest app is updgrade to the sdk 6.0. 