### PR TITLE
Mitigate datediff overflow issue

### DIFF
--- a/src/DurableTask.SqlServer/Scripts/logic.sql
+++ b/src/DurableTask.SqlServer/Scripts/logic.sql
@@ -547,7 +547,7 @@ BEGIN
         P.[Reason],
         P.[Text] AS [PayloadText],
         P.[PayloadID],
-        DATEDIFF(millisecond, [Timestamp], @now) AS [WaitTime],
+        DATEDIFF(SECOND, [Timestamp], @now) AS [WaitTime],
         @parentInstanceID as [ParentInstanceID],
         @version as [Version]
     FROM NewEvents N
@@ -1103,7 +1103,7 @@ BEGIN
             P.[TaskHub] = @TaskHub AND
             P.[InstanceID] = N.[InstanceID] AND
             P.[PayloadID] = N.[PayloadID]) AS [PayloadText],
-        DATEDIFF(millisecond, [Timestamp], @now) AS [WaitTime]
+        DATEDIFF(SECOND, [Timestamp], @now) AS [WaitTime]
     FROM NewTasks N
     WHERE [TaskHub] = @TaskHub AND [SequenceNumber] = @SequenceNumber
 

--- a/src/DurableTask.SqlServer/SqlOrchestrationService.cs
+++ b/src/DurableTask.SqlServer/SqlOrchestrationService.cs
@@ -158,6 +158,8 @@ namespace DurableTask.SqlServer
                             eventPayloadMappings.Add(message.Event, payloadId.Value);
                         }
 
+                        // TODO: We're not currently using this value for anything. Ideally it would be included
+                        //       in some logging that still needs to be introduced.
                         longestWaitTime = Math.Max(longestWaitTime, reader.GetInt32("WaitTime"));
                     }
 

--- a/test/DurableTask.SqlServer.AzureFunctions.Tests/DurableTask.SqlServer.AzureFunctions.Tests.csproj
+++ b/test/DurableTask.SqlServer.AzureFunctions.Tests/DurableTask.SqlServer.AzureFunctions.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <IsPackable>false</IsPackable>
     <SignAssembly>true</SignAssembly>
     <LangVersion>9.0</LangVersion>

--- a/test/DurableTask.SqlServer.Tests/DurableTask.SqlServer.Tests.csproj
+++ b/test/DurableTask.SqlServer.Tests/DurableTask.SqlServer.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <IsPackable>false</IsPackable>
     <SignAssembly>true</SignAssembly>
     <LangVersion>9.0</LangVersion>


### PR DESCRIPTION
Resolves https://github.com/microsoft/durabletask-mssql/issues/69

The only relevant change is to logic.sql.  The others can be ignored.

With this very minimal fix, rows in the `dt.NewEvents` and `dt.NewTasks` tables can be as old as 68 _years_ (a significant improvement from 24 days).