### PR TITLE
retrieve ParentInstance in GetOrchestrationStateAsync

### DIFF
--- a/src/DurableTask.SqlServer/DurableTask.SqlServer.csproj
+++ b/src/DurableTask.SqlServer/DurableTask.SqlServer.csproj
@@ -21,7 +21,7 @@
   </ItemGroup>
   
   <ItemGroup>
-    <PackageReference Include="Microsoft.Azure.DurableTask.Core" Version="2.6.*" />
+    <PackageReference Include="Microsoft.Azure.DurableTask.Core" Version="2.8.0" />
     <PackageReference Include="Microsoft.Data.SqlClient" Version="3.0.0" />
     <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="3.1.*" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="3.1.*" />

--- a/src/DurableTask.SqlServer/Scripts/logic.sql
+++ b/src/DurableTask.SqlServer/Scripts/logic.sql
@@ -987,7 +987,7 @@ BEGIN
         I.[LastUpdatedTime],
         I.[CompletedTime],
         I.[RuntimeStatus],
-		I.[ParentInstanceID],
+        I.[ParentInstanceID],
         (SELECT TOP 1 [Text] FROM Payloads P WHERE
             P.[TaskHub] = @TaskHub AND
             P.[InstanceID] = I.[InstanceID] AND
@@ -1031,7 +1031,7 @@ BEGIN
         I.[LastUpdatedTime],
         I.[CompletedTime],
         I.[RuntimeStatus],
-		I.[ParentInstanceID],
+        I.[ParentInstanceID],
         (SELECT TOP 1 [Text] FROM Payloads P WHERE
             P.[TaskHub] = @TaskHub AND
             P.[InstanceID] = I.[InstanceID] AND

--- a/src/DurableTask.SqlServer/Scripts/logic.sql
+++ b/src/DurableTask.SqlServer/Scripts/logic.sql
@@ -987,6 +987,7 @@ BEGIN
         I.[LastUpdatedTime],
         I.[CompletedTime],
         I.[RuntimeStatus],
+		I.[ParentInstanceID],
         (SELECT TOP 1 [Text] FROM Payloads P WHERE
             P.[TaskHub] = @TaskHub AND
             P.[InstanceID] = I.[InstanceID] AND
@@ -1030,6 +1031,7 @@ BEGIN
         I.[LastUpdatedTime],
         I.[CompletedTime],
         I.[RuntimeStatus],
+		I.[ParentInstanceID],
         (SELECT TOP 1 [Text] FROM Payloads P WHERE
             P.[TaskHub] = @TaskHub AND
             P.[InstanceID] = I.[InstanceID] AND

--- a/src/DurableTask.SqlServer/SqlUtils.cs
+++ b/src/DurableTask.SqlServer/SqlUtils.cs
@@ -184,6 +184,18 @@ namespace DurableTask.SqlServer
 
         public static OrchestrationState GetOrchestrationState(this DbDataReader reader)
         {
+            ParentInstance? parentInstance = null;
+            string? parentInstanceId = GetParentInstanceId(reader);
+            if (parentInstanceId != null)
+            {
+                parentInstance = new ParentInstance
+                {
+                    OrchestrationInstance = new OrchestrationInstance
+                    {
+                        InstanceId = parentInstanceId
+                    }
+                };
+            }
             return new OrchestrationState
             {
                 CompletedTime = reader.GetUtcDateTimeOrNull(reader.GetOrdinal("CompletedTime")) ?? default,
@@ -202,6 +214,7 @@ namespace DurableTask.SqlServer
                     GetStringOrNull(reader, reader.GetOrdinal("RuntimeStatus"))),
                 Output = GetStringOrNull(reader, reader.GetOrdinal("OutputText")),
                 Status = GetStringOrNull(reader, reader.GetOrdinal("CustomStatusText")),
+                ParentInstance = parentInstance
             };
         }
 


### PR DESCRIPTION
Hello
Here is a PR to retrieve the ParentInstance in GetOrchestrationStateAsync.
I noticed that this property is always null. This PR resolves the issue mentionned in this [link ](https://github.com/Azure/durabletask/issues/618) for mssql provider