### PR TITLE
Remove netstandard2.1 TFM

### DIFF
--- a/src/DurableTask.SqlServer.AzureFunctions/DurableTask.SqlServer.AzureFunctions.csproj
+++ b/src/DurableTask.SqlServer.AzureFunctions/DurableTask.SqlServer.AzureFunctions.csproj
@@ -4,7 +4,7 @@
   <Import Project="../common.props" />
   
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.1;netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0</TargetFrameworks>
   </PropertyGroup>
   
   <!-- NuGet package settings -->

--- a/src/DurableTask.SqlServer/DurableTask.SqlServer.csproj
+++ b/src/DurableTask.SqlServer/DurableTask.SqlServer.csproj
@@ -4,7 +4,7 @@
   <Import Project="../common.props" />
   
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.1;netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0</TargetFrameworks>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
 


### PR DESCRIPTION
There was no reason for us to target .NET Standard 2.1, so for the GA release we want to remove this target and only support .NET Standard 2.0. This gives us maximum compatibility with a smaller package size and less opportunity for surprises.