### PR TITLE
Fix problem terminating orchestration with running activity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,9 @@
 
 ### Updates
 
-None
+* Removed unnecessary .NET Standard 2.1 target ([#82](https://github.com/microsoft/durabletask-mssql/pull/82))
+* Fixed problem terminating orchestration with running activity ([#83](https://github.com/microsoft/durabletask-mssql/pull/83))
+* Fixed payload data leak for completed activities (same PR as above)
 
 ### Breaking changes
 


### PR DESCRIPTION
Resolves #81

We were incorrectly raising an error from SQL if an activity task completes for an instance that's no longer running (e.g., a terminated instance). Because of this, we'd never delete the task-scheduled message, and it would re-execute continuously. This PR updates the `_CompleteTasks` sproc to handle this case correctly by ensuring we always delete the task-scheduled message.

While testing the fix, I also found an issue where we don't delete the task-scheduled message payloads after an activity completes (successfully or not), resulting in unreferenced payload data in the database (until the instance is purged). This is also fixed in this PR.