### PR TITLE
Include more payload IDs in history table

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -196,3 +196,6 @@ dotnet_naming_style.begins_with_i.required_prefix = I
 dotnet_naming_style.begins_with_i.required_suffix = 
 dotnet_naming_style.begins_with_i.word_separator = 
 dotnet_naming_style.begins_with_i.capitalization = pascal_case
+
+# https://marketplace.visualstudio.com/items?itemName=PaulHarrington.EditorGuidelinesPreview
+guidelines = 120

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,12 +5,14 @@
 ### New
 
 * Support for purging data with filters ([#80](https://github.com/microsoft/durabletask-mssql/pull/80)) - contributed by [@usemam](https://github.com/usemam)
+* Support for new multi-instance query interface ([#88](https://github.com/microsoft/durabletask-mssql/pull/80)) - contributed by [@usemam](https://github.com/usemam)
 
 ### Updates
 
 * Removed unnecessary .NET Standard 2.1 target ([#82](https://github.com/microsoft/durabletask-mssql/pull/82))
 * Fixed problem terminating orchestration with running activity ([#83](https://github.com/microsoft/durabletask-mssql/pull/83))
 * Fixed payload data leak for completed activities (same PR as above)
+* Activity payload IDs are now consistently saved to the history table ([#89](https://github.com/microsoft/durabletask-mssql/issues/89))
 
 ### Breaking changes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@
 * Removed unnecessary .NET Standard 2.1 target ([#82](https://github.com/microsoft/durabletask-mssql/pull/82))
 * Fixed problem terminating orchestration with running activity ([#83](https://github.com/microsoft/durabletask-mssql/pull/83))
 * Fixed payload data leak for completed activities (same PR as above)
-* Activity payload IDs are now consistently saved to the history table ([#89](https://github.com/microsoft/durabletask-mssql/issues/89))
+* Activity payload IDs are now consistently saved to the history table ([#90](https://github.com/microsoft/durabletask-mssql/issues/90))
 
 ### Breaking changes
 

--- a/src/DurableTask.SqlServer/DTUtils.cs
+++ b/src/DurableTask.SqlServer/DTUtils.cs
@@ -132,6 +132,11 @@ namespace DurableTask.SqlServer
             return payloadText != null;
         }
 
+        public static bool HasPayload(HistoryEvent e)
+        {
+            return TryGetPayloadText(e, out string? text) && !string.IsNullOrEmpty(text);
+        }
+
         public static string? GetName(HistoryEvent historyEvent)
         {
             return historyEvent.EventType switch

--- a/src/DurableTask.SqlServer/EventPayloadMap.cs
+++ b/src/DurableTask.SqlServer/EventPayloadMap.cs
@@ -1,0 +1,77 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+namespace DurableTask.SqlServer
+{
+    using System;
+    using System.Collections.Generic;
+    using DurableTask.Core;
+    using DurableTask.Core.History;
+
+    class EventPayloadMap
+    {
+        readonly Dictionary<(EventType, int), Guid> payloadIdsByEventId;
+        readonly Dictionary<HistoryEvent, Guid> payloadIdsByEventReference;
+
+        readonly byte[] timestamp = BitConverter.GetBytes(DateTime.UtcNow.Ticks);
+        short sequenceNumber;
+
+        public EventPayloadMap(int capacity)
+        {
+            this.payloadIdsByEventId = new Dictionary<(EventType, int), Guid>(capacity);
+            this.payloadIdsByEventReference = new Dictionary<HistoryEvent, Guid>(capacity);
+        }
+
+        public void Add(HistoryEvent e, Guid payloadId)
+        {
+            if (CanTrackByReference(e))
+            {
+                this.payloadIdsByEventReference.Add(e, payloadId);
+            }
+            else
+            {
+                var key = ValueTuple.Create(e.EventType, DTUtils.GetTaskEventId(e));
+                this.payloadIdsByEventId.Add(key, payloadId);
+            }
+        }
+
+        public void Add(IList<TaskMessage> outboundMessages)
+        {
+            for (int i = 0; i < outboundMessages.Count; i++)
+            {
+                HistoryEvent e = outboundMessages[i].Event;
+                if (DTUtils.HasPayload(e))
+                {
+                    this.Add(e, this.NewPayloadId(e));
+                }
+            }
+        }
+
+        public bool TryGetPayloadId(HistoryEvent e, out Guid payloadId)
+        {
+            if (CanTrackByReference(e))
+            {
+                return this.payloadIdsByEventReference.TryGetValue(e, out payloadId);
+            }
+            else
+            {
+                var key = ValueTuple.Create(e.EventType, DTUtils.GetTaskEventId(e));
+                return this.payloadIdsByEventId.TryGetValue(key, out payloadId);
+            }
+        }
+
+        static bool CanTrackByReference(HistoryEvent e)
+        {
+            // DTFx sometimes creates different object references between messages and history events, which
+            // means we have to use some other mechanism for tracking.
+            return e.EventType != EventType.TaskScheduled && e.EventType != EventType.SubOrchestrationInstanceCreated;
+        }
+
+        Guid NewPayloadId(HistoryEvent e)
+        {
+            // Sequential GUIDs are simply to make reading slightly easier. They don't have any other purpose.
+            // Example: 00000001-0004-0000-ca2b-694a052ada08
+            return new Guid(DTUtils.GetTaskEventId(e), (short)e.EventType, this.sequenceNumber++, this.timestamp);
+        }
+    }
+}

--- a/src/DurableTask.SqlServer/Scripts/logic.sql
+++ b/src/DurableTask.SqlServer/Scripts/logic.sql
@@ -1228,14 +1228,6 @@ BEGIN
     IF @@ROWCOUNT <> (SELECT COUNT(*) FROM @CompletedTasks)
         THROW 50002, N'Failed to delete the completed task events(s). They may have been deleted by another worker, in which case the current execution is likely a duplicate. Any results or pending side-effects of this task activity execution will be discarded.', 1;
 
-    -- Remove the payload (if any) associated with the deleted activity task
-    DELETE FROM Payloads
-    FROM Payloads P WITH (FORCESEEK(PK_Payloads(TaskHub, InstanceID)))
-        INNER JOIN @payloadsToDelete D ON
-            P.[TaskHub] = @TaskHub AND
-            P.[InstanceID] = @existingInstanceID AND
-            P.[PayloadID] = D.[PayloadID]
-
     COMMIT TRANSACTION
 END
 GO

--- a/src/DurableTask.SqlServer/Utils/NetFxCompat.cs
+++ b/src/DurableTask.SqlServer/Utils/NetFxCompat.cs
@@ -1,15 +1,10 @@
-﻿#if NETSTANDARD2_0 // These .NET Standard 2.1 methods are not available in .NET Standard 2.0
+﻿#if NETSTANDARD2_0 // These methods are not available in .NET Standard 2.0
 namespace DurableTask.SqlServer
 {
-    using System;
     using System.Collections.Generic;
-    using System.Data;
     using System.Data.Common;
     using System.Linq;
-    using System.Threading;
     using System.Threading.Tasks;
-    using System.Text;
-    using Microsoft.Data.SqlClient;
 
     public static class NetFxCompat
     {


### PR DESCRIPTION
Resolves #85 
Resolves #84 

This PR ensures that we always add a payload ID to the history table for events created by the orchestration. Previously, by default, these payload IDs were tracked temporarily in the NewEvents and NewTasks table, but then would get deleted, leaving behind orphan payloads in the database.  A previous PR cleaned up the orphan payloads (adding to the I/O cost of activity execution), but this PR reverts that change and does what I preferred to do, which is keep them there but ensure they are linked from the history table.

This also fixes an issue related to duplicate payloads being saved when input tracking is enabled on the TaskHubWorker.