### PR TITLE
Use same precision for queries than for storage

### DIFF
--- a/src/DurableTask.SqlServer/SqlOrchestrationService.cs
+++ b/src/DurableTask.SqlServer/SqlOrchestrationService.cs
@@ -780,8 +780,8 @@ namespace DurableTask.SqlServer
                 throw new ArgumentOutOfRangeException(nameof(query), $"{nameof(query.PageNumber)} must be between 0 and {short.MaxValue} (inclusive).");
             }
 
-            SqlDateTime createdTimeFrom = query.CreatedTimeFrom.ToSqlUtcDateTime(SqlDateTime.MinValue);
-            SqlDateTime createdTimeTo = query.CreatedTimeTo.ToSqlUtcDateTime(SqlDateTime.MaxValue);
+            DateTime createdTimeFrom = query.CreatedTimeFrom.ToSqlUtcDateTime(DateTime.MinValue);
+            DateTime createdTimeTo = query.CreatedTimeTo.ToSqlUtcDateTime(DateTime.MaxValue);
 
             using SqlConnection connection = await this.GetAndOpenConnectionAsync(cancellationToken);
             using SqlCommand command = this.GetSprocCommand(connection, "dt._QueryManyOrchestrations");
@@ -790,8 +790,8 @@ namespace DurableTask.SqlServer
             command.Parameters.Add("@PageNumber", SqlDbType.SmallInt).Value = query.PageNumber;
             command.Parameters.Add("@FetchInput", SqlDbType.Bit).Value = query.FetchInput;
             command.Parameters.Add("@FetchOutput", SqlDbType.Bit).Value = query.FetchOutput;
-            command.Parameters.Add("@CreatedTimeFrom", SqlDbType.DateTime).Value = createdTimeFrom;
-            command.Parameters.Add("@CreatedTimeTo", SqlDbType.DateTime).Value = createdTimeTo;
+            command.Parameters.Add("@CreatedTimeFrom", SqlDbType.DateTime2).Value = createdTimeFrom;
+            command.Parameters.Add("@CreatedTimeTo", SqlDbType.DateTime2).Value = createdTimeTo;
             command.Parameters.Add("@InstanceIDPrefix", SqlDbType.VarChar, size: 100).Value = query.InstanceIdPrefix ?? SqlString.Null;
 
             if (query.StatusFilter?.Count > 0)

--- a/src/DurableTask.SqlServer/SqlUtils.cs
+++ b/src/DurableTask.SqlServer/SqlUtils.cs
@@ -469,19 +469,11 @@ namespace DurableTask.SqlServer
             }
         }
 
-        public static SqlDateTime ToSqlUtcDateTime(this DateTime dateTime, SqlDateTime defaultValue)
+        public static DateTime ToSqlUtcDateTime(this DateTime dateTime, DateTime defaultValue)
         {
             if (dateTime == default)
             {
                 return defaultValue;
-            }
-            else if (dateTime > SqlDateTime.MaxValue)
-            {
-                return SqlDateTime.MaxValue;
-            }
-            else if (dateTime < SqlDateTime.MinValue)
-            {
-                return SqlDateTime.MinValue;
             }
             else if (dateTime.Kind == DateTimeKind.Utc)
             {


### PR DESCRIPTION
I think the underlying issue of #86 was that the provider is issuing queries against the database using `datetime` parameters on `datetime2` fields, leading to a loss of precision in the queries for both purge and queries scenarii.  As sql server `datetime` is rounding at 0, 0.003, 0.007 seconds, while `datetime2` has a precision of 100ns (matching c# `DateTime` one), this leads to tests failing sometimes, but IMHO, it is also an actual issue in the provider code (even if probably a very small one).

I also made sure a delay of 20ms was left at each point in time capture in tests to ensure they are reliable (to compare with 100ns precision of `DateTime`/`datetime2`, ability of the OS to wait for such a low level of time accurately, and 1s which was previously used)

I was able to reproduce the #86 issue in around 20 seconds of running the `MultiInstancePurge` & `MultiInstanceQueries` test in a loop on my machine. With this PR code, no failing test has been reported after 2 hours.
