### PR TITLE
add FetchParentInstancesOnly filter to fetch only parent instances if…

### DIFF
--- a/src/DurableTask.SqlServer/Scripts/logic.sql
+++ b/src/DurableTask.SqlServer/Scripts/logic.sql
@@ -1059,7 +1059,8 @@ CREATE OR ALTER PROCEDURE dt._QueryManyOrchestrations
     @CreatedTimeFrom datetime2 = NULL,
     @CreatedTimeTo datetime2 = NULL,
     @RuntimeStatusFilter varchar(200) = NULL,
-    @InstanceIDPrefix varchar(100) = NULL
+    @InstanceIDPrefix varchar(100) = NULL,
+	@FetchParentInstancesOnly bit = 0
 AS
 BEGIN
     DECLARE @TaskHub varchar(50) = dt.CurrentTaskHub()
@@ -1093,7 +1094,8 @@ BEGIN
         (@CreatedTimeFrom IS NULL OR I.[CreatedTime] >= @CreatedTimeFrom) AND
         (@CreatedTimeTo IS NULL OR I.[CreatedTime] <= @CreatedTimeTo) AND
         (@RuntimeStatusFilter IS NULL OR I.[RuntimeStatus] IN (SELECT [value] FROM string_split(@RuntimeStatusFilter, ','))) AND
-        (@InstanceIDPrefix IS NULL OR I.[InstanceID] LIKE @InstanceIDPrefix + '%')
+        (@InstanceIDPrefix IS NULL OR I.[InstanceID] LIKE @InstanceIDPrefix + '%') AND
+		(@FetchParentInstancesOnly = 0 OR I.ParentInstanceID IS NULL)
     ORDER BY
         I.[CreatedTime] OFFSET (@PageNumber * @PageSize) ROWS FETCH NEXT @PageSize ROWS ONLY
 END

--- a/src/DurableTask.SqlServer/Scripts/logic.sql
+++ b/src/DurableTask.SqlServer/Scripts/logic.sql
@@ -1095,7 +1095,7 @@ BEGIN
         (@CreatedTimeTo IS NULL OR I.[CreatedTime] <= @CreatedTimeTo) AND
         (@RuntimeStatusFilter IS NULL OR I.[RuntimeStatus] IN (SELECT [value] FROM string_split(@RuntimeStatusFilter, ','))) AND
         (@InstanceIDPrefix IS NULL OR I.[InstanceID] LIKE @InstanceIDPrefix + '%') AND
-		(@ExcludeSubOrchestrations = 0 OR I.ParentInstanceID IS NULL)
+        (@ExcludeSubOrchestrations = 0 OR I.ParentInstanceID IS NULL)
     ORDER BY
         I.[CreatedTime] OFFSET (@PageNumber * @PageSize) ROWS FETCH NEXT @PageSize ROWS ONLY
 END

--- a/src/DurableTask.SqlServer/Scripts/logic.sql
+++ b/src/DurableTask.SqlServer/Scripts/logic.sql
@@ -1060,7 +1060,7 @@ CREATE OR ALTER PROCEDURE dt._QueryManyOrchestrations
     @CreatedTimeTo datetime2 = NULL,
     @RuntimeStatusFilter varchar(200) = NULL,
     @InstanceIDPrefix varchar(100) = NULL,
-	@FetchParentInstancesOnly bit = 0
+    @ExcludeSubOrchestrations bit = 0
 AS
 BEGIN
     DECLARE @TaskHub varchar(50) = dt.CurrentTaskHub()
@@ -1095,7 +1095,7 @@ BEGIN
         (@CreatedTimeTo IS NULL OR I.[CreatedTime] <= @CreatedTimeTo) AND
         (@RuntimeStatusFilter IS NULL OR I.[RuntimeStatus] IN (SELECT [value] FROM string_split(@RuntimeStatusFilter, ','))) AND
         (@InstanceIDPrefix IS NULL OR I.[InstanceID] LIKE @InstanceIDPrefix + '%') AND
-		(@FetchParentInstancesOnly = 0 OR I.ParentInstanceID IS NULL)
+		(@ExcludeSubOrchestrations = 0 OR I.ParentInstanceID IS NULL)
     ORDER BY
         I.[CreatedTime] OFFSET (@PageNumber * @PageSize) ROWS FETCH NEXT @PageSize ROWS ONLY
 END

--- a/src/DurableTask.SqlServer/SqlOrchestrationQuery.cs
+++ b/src/DurableTask.SqlServer/SqlOrchestrationQuery.cs
@@ -53,5 +53,10 @@ namespace DurableTask.SqlServer
         /// Gets or sets an instance ID prefix to use for filtering orchestration instances.
         /// </summary>
         public string? InstanceIdPrefix { get; set; }
+
+        /// <summary>
+        /// Determines whether the query will retrieve only parent instances.
+        /// </summary>
+        public bool FetchParentInstancesOnly { get; set; } = false;
     }
 }

--- a/src/DurableTask.SqlServer/SqlOrchestrationQuery.cs
+++ b/src/DurableTask.SqlServer/SqlOrchestrationQuery.cs
@@ -57,6 +57,6 @@ namespace DurableTask.SqlServer
         /// <summary>
         /// Determines whether the query will retrieve only parent instances.
         /// </summary>
-        public bool FetchParentInstancesOnly { get; set; } = false;
+        public bool ExcludeSubOrchestrations { get; set; } = false;
     }
 }

--- a/src/DurableTask.SqlServer/SqlOrchestrationService.cs
+++ b/src/DurableTask.SqlServer/SqlOrchestrationService.cs
@@ -734,7 +734,8 @@ namespace DurableTask.SqlServer
                 FetchInput = query.FetchInputsAndOutputs,
                 FetchOutput = query.FetchInputsAndOutputs,
                 InstanceIdPrefix = query.InstanceIdPrefix,
-                PageSize = query.PageSize
+                PageSize = query.PageSize,
+                FetchParentInstancesOnly = query.FetchParentInstancesOnly,
             };
 
             if (query.RuntimeStatus?.Any() == true)
@@ -793,6 +794,7 @@ namespace DurableTask.SqlServer
             command.Parameters.Add("@CreatedTimeFrom", SqlDbType.DateTime).Value = createdTimeFrom;
             command.Parameters.Add("@CreatedTimeTo", SqlDbType.DateTime).Value = createdTimeTo;
             command.Parameters.Add("@InstanceIDPrefix", SqlDbType.VarChar, size: 100).Value = query.InstanceIdPrefix ?? SqlString.Null;
+            command.Parameters.Add("@FetchParentInstancesOnly", SqlDbType.SmallInt).Value = query.FetchParentInstancesOnly;
 
             if (query.StatusFilter?.Count > 0)
             {

--- a/src/DurableTask.SqlServer/SqlOrchestrationService.cs
+++ b/src/DurableTask.SqlServer/SqlOrchestrationService.cs
@@ -793,7 +793,7 @@ namespace DurableTask.SqlServer
             command.Parameters.Add("@CreatedTimeFrom", SqlDbType.DateTime).Value = createdTimeFrom;
             command.Parameters.Add("@CreatedTimeTo", SqlDbType.DateTime).Value = createdTimeTo;
             command.Parameters.Add("@InstanceIDPrefix", SqlDbType.VarChar, size: 100).Value = query.InstanceIdPrefix ?? SqlString.Null;
-            command.Parameters.Add("@FetchParentInstancesOnly", SqlDbType.SmallInt).Value = query.FetchParentInstancesOnly;
+            command.Parameters.Add("@ExcludeSubOrchestrations", SqlDbType.SmallInt).Value = query.ExcludeSubOrchestrations;
 
             if (query.StatusFilter?.Count > 0)
             {

--- a/src/DurableTask.SqlServer/SqlOrchestrationService.cs
+++ b/src/DurableTask.SqlServer/SqlOrchestrationService.cs
@@ -735,7 +735,6 @@ namespace DurableTask.SqlServer
                 FetchOutput = query.FetchInputsAndOutputs,
                 InstanceIdPrefix = query.InstanceIdPrefix,
                 PageSize = query.PageSize,
-                FetchParentInstancesOnly = query.FetchParentInstancesOnly,
             };
 
             if (query.RuntimeStatus?.Any() == true)

--- a/test/DurableTask.SqlServer.Tests/Integration/Orchestrations.cs
+++ b/test/DurableTask.SqlServer.Tests/Integration/Orchestrations.cs
@@ -458,7 +458,7 @@ namespace DurableTask.SqlServer.Tests.Integration
                 });
 
             // Act: query orchestration instances to retrieve only parent instances
-            var filter = new SqlOrchestrationQuery { FetchParentInstancesOnly = true };
+            var filter = new SqlOrchestrationQuery { ExcludeSubOrchestrations = true };
             IReadOnlyCollection<OrchestrationState> list = await this.testService.OrchestrationServiceMock.Object.GetManyOrchestrationsAsync(filter, CancellationToken.None);
 
             // Assert: total number of started orchestrations is 2 but we expect to have only one main orchestration

--- a/test/DurableTask.SqlServer.Tests/Integration/Orchestrations.cs
+++ b/test/DurableTask.SqlServer.Tests/Integration/Orchestrations.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
 namespace DurableTask.SqlServer.Tests.Integration
@@ -440,7 +440,7 @@ namespace DurableTask.SqlServer.Tests.Integration
         [Fact]
         public async Task ListParentOrchestrationsOnly()
         {
-            // Arrange: start an orchestration instance which starts a sub orchestration instance
+            // Arrange: start an orchestration instance which starts a sub orchestration instance.
             string orchestrationName = "SubOrchestrationTest";
             TestInstance<int> testInstance = await this.testService.RunOrchestration(
                 input: 1,
@@ -457,11 +457,11 @@ namespace DurableTask.SqlServer.Tests.Integration
                     return result;
                 });
 
-            // Act: query orchestration instances to retrieve only parent instances
+            // Act: query orchestration instances to retrieve only parent instances.
             var filter = new SqlOrchestrationQuery { ExcludeSubOrchestrations = true };
             IReadOnlyCollection<OrchestrationState> list = await this.testService.OrchestrationServiceMock.Object.GetManyOrchestrationsAsync(filter, CancellationToken.None);
 
-            // Assert: total number of started orchestrations is 2 but we expect to have only one main orchestration
+            // Assert: total number of started orchestrations is 2 but we expect to have only one main orchestration.
             Assert.Equal(1, list.Count);
         }
 

--- a/test/DurableTask.SqlServer.Tests/Integration/Orchestrations.cs
+++ b/test/DurableTask.SqlServer.Tests/Integration/Orchestrations.cs
@@ -428,13 +428,41 @@ namespace DurableTask.SqlServer.Tests.Integration
                     if (input < 3)
                     {
                         int subResult =
-                            await ctx.CreateSubOrchestrationInstance<int>(orchestrationName, string.Empty, $"Sub{input}", input+1);
+                            await ctx.CreateSubOrchestrationInstance<int>(orchestrationName, string.Empty, $"Sub{input}", input + 1);
                         result += subResult;
                     }
                     return result;
                 });
             await testInstance.WaitForCompletion(
                 timeout: TimeSpan.FromSeconds(15), expectedOutput: 15);
+        }
+
+        [Fact]
+        public async Task ListParentOrchestrationsOnly()
+        {
+            // Arrange: start an orchestration instance which starts a sub orchestration instance
+            string orchestrationName = "SubOrchestrationTest";
+            TestInstance<int> testInstance = await this.testService.RunOrchestration(
+                input: 1,
+                orchestrationName,
+                implementation: async (ctx, input) =>
+                {
+                    int result = 5;
+                    if (input < 3)
+                    {
+                        int subResult =
+                            await ctx.CreateSubOrchestrationInstance<int>(orchestrationName, string.Empty, $"Sub{input}", input + 1);
+                        result += subResult;
+                    }
+                    return result;
+                });
+
+            // Act: query orchestration instances to retrieve only parent instances
+            var filter = new SqlOrchestrationQuery { FetchParentInstancesOnly = true };
+            IReadOnlyCollection<OrchestrationState> list = await this.testService.OrchestrationServiceMock.Object.GetManyOrchestrationsAsync(filter, CancellationToken.None);
+
+            // Assert: total number of started orchestrations is 2 but we expect to have only one main orchestration
+            Assert.Equal(1, list.Count);
         }
 
         [Fact]


### PR DESCRIPTION
Hello,
Refering to my issue at this link https://github.com/Azure/durabletask/issues/733
I created a Pull Request to filter results and retrieve only parent instances
This feature is required for our team and hope it'll be helpful for others.
I will create an other Pull Request in [durabletask](https://github.com/Azure/durabletask) to add the property FetchParentInstancesOnly  to OrchestrationQuery.
Thanks