### PR TITLE
Delete all payload data on ContinueAsNew

### DIFF
--- a/src/DurableTask.SqlServer/Scripts/logic.sql
+++ b/src/DurableTask.SqlServer/Scripts/logic.sql
@@ -660,6 +660,8 @@ BEGIN
         DELETE FROM Payloads
         WHERE [TaskHub] = @TaskHub AND [InstanceID] = @InstanceID
 
+        -- The existing payload got purged in the previous statement 
+        SET @ExistingCustomStatusPayload = NULL
         SET @IsContinueAsNew = 1
     END
 
@@ -695,7 +697,7 @@ BEGIN
     SET @IsCompleted = (CASE WHEN @RuntimeStatus IN ('Completed', 'Failed', 'Terminated') THEN 1 ELSE 0 END)
 
     -- The output payload will only exist when the orchestration has completed.
-    -- Fetch it's payload ID now so that we can update it in the Instances table further down.
+    -- Fetch its payload ID now so that we can update it in the Instances table further down.
     DECLARE @OutputPayloadID uniqueidentifier
     IF @IsCompleted = 1
     BEGIN


### PR DESCRIPTION
Resolves https://github.com/microsoft/durabletask-mssql/issues/100

The previous logic deleted payload data that was associated with the rows in the History table. In theory, this should "work" because there shouldn't be any payload data (besides custom status) that doesn't have an associated record in the History table. However, it seems that this isn't necessarily the case, or that we're losing track of certain payload IDs over time.

Regardless of the root cause for the previous issue, it makes sense to just purge all runtime data as part of ContinueAsNew. This PR does exactly that, ensuring that we can't run into this kind of problem in the future.