### PR TITLE
Preparations for v1.0.0 (GA) release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@
 ### New
 
 * Support for orchestration rewind ([#96](https://github.com/microsoft/durabletask-mssql/pull/96)) - contributed by [@Greybird](https://github.com/Greybird)
+* Added PowerShell script for automated performance testing in Azure
+* Added new *LongHaul* stress test to the performance testing project
 
 ### Updates
 
@@ -13,8 +15,6 @@
 * Updated [Microsoft.Azure.WebJobs.Extensions.DurableTask](https://www.nuget.org/packages/Microsoft.Azure.WebJobs.Extensions.DurableTask) dependency to v2.7.*
 * Fixed data leak in ContinueAsNew path ([#102](https://github.com/microsoft/durabletask-mssql/pull/102))
 * Fixed inaccurate license headers
-* Added new *LongHaul* stress test to the performance testing project
-* Added PowerShell script for automated performance testing in Azure
 
 ### Breaking changes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,10 +13,12 @@
 * Updated [Microsoft.Azure.WebJobs.Extensions.DurableTask](https://www.nuget.org/packages/Microsoft.Azure.WebJobs.Extensions.DurableTask) dependency to v2.7.*
 * Fixed data leak in ContinueAsNew path ([#102](https://github.com/microsoft/durabletask-mssql/pull/102))
 * Fixed inaccurate license headers
+* Added new *LongHaul* stress test to the performance testing project
+* Added PowerShell script for automated performance testing in Azure
 
 ### Breaking changes
 
-None
+* Removed explicit dependencies on `Microsoft.Extensions.Caching.Memory` and `Microsoft.Extensions.Logging.Abstractions`
 
 ## v1.0.0-rc2
 

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -21,7 +21,7 @@ dotnet add package Microsoft.DurableTask.SqlServer.AzureFunctions --prerelease
 JavaScript, Python, and PowerShell projects can add the [Microsoft.DurableTask.SqlServer.AzureFunction](https://www.nuget.org/packages/Microsoft.DurableTask.SqlServer.AzureFunctions) package by running the following `func` CLI command. Note that in addition to the Azure Functions Core Tools, you must also have a recent [.NET SDK](https://dotnet.microsoft.com/download) installed locally.
 
 ```bash
-func extensions install -p Microsoft.DurableTask.SqlServer.AzureFunctions -v 1.0.0-rc
+func extensions install -p Microsoft.DurableTask.SqlServer.AzureFunctions -v 1.0.0
 ```
 
 ?> Check [here](https://www.nuget.org/packages/Microsoft.DurableTask.SqlServer.AzureFunctions) to see if newer versions of the SQL provider package are available, and update the above command to reference the latest available version.

--- a/src/DurableTask.SqlServer.AzureFunctions/SqlDurabilityProviderFactory.cs
+++ b/src/DurableTask.SqlServer.AzureFunctions/SqlDurabilityProviderFactory.cs
@@ -21,7 +21,7 @@ namespace DurableTask.SqlServer.AzureFunctions
 
         readonly DurableTaskOptions extensionOptions;
         readonly ILoggerFactory loggerFactory;
-        readonly IConnectionStringResolver connectionStringResolver;
+        readonly IConnectionInfoResolver connectionInfoResolver;
 
         SqlDurabilityOptions? defaultOptions;
         SqlOrchestrationServiceSettings? orchestrationServiceSettings;
@@ -36,15 +36,15 @@ namespace DurableTask.SqlServer.AzureFunctions
         /// </remarks>
         /// <param name="extensionOptions">Durable task extension configuration options.</param>
         /// <param name="loggerFactory">Logger factory registered with the Azure Functions runtime.</param>
-        /// <param name="connectionStringResolver">Resolver service for fetching Durable Task connection string information.</param>
+        /// <param name="connectionInfoResolver">Resolver service for fetching Durable Task connection string information.</param>
         public SqlDurabilityProviderFactory(
             IOptions<DurableTaskOptions> extensionOptions,
             ILoggerFactory loggerFactory,
-            IConnectionStringResolver connectionStringResolver)
+            IConnectionInfoResolver connectionInfoResolver)
         {
             this.extensionOptions = extensionOptions?.Value ?? throw new ArgumentNullException(nameof(extensionOptions));
             this.loggerFactory = loggerFactory ?? throw new ArgumentNullException(nameof(loggerFactory));
-            this.connectionStringResolver = connectionStringResolver ?? throw new ArgumentNullException(nameof(connectionStringResolver));
+            this.connectionInfoResolver = connectionInfoResolver ?? throw new ArgumentNullException(nameof(connectionInfoResolver));
         }
 
         // Called by the Durable trigger binding infrastructure
@@ -85,7 +85,7 @@ namespace DurableTask.SqlServer.AzureFunctions
                 IOrchestrationServiceClient serviceClient = 
                     new SqlOrchestrationService(clientOptions.GetOrchestrationServiceSettings(
                         this.extensionOptions,
-                        this.connectionStringResolver));
+                        this.connectionInfoResolver));
                 clientProvider = new SqlDurabilityProvider(
                     this.GetOrchestrationService(),
                     clientOptions,
@@ -156,7 +156,7 @@ namespace DurableTask.SqlServer.AzureFunctions
                 SqlDurabilityOptions options = this.GetDefaultSqlOptions();
                 this.orchestrationServiceSettings = options.GetOrchestrationServiceSettings(
                     this.extensionOptions,
-                    this.connectionStringResolver);
+                    this.connectionInfoResolver);
             }
 
             return this.orchestrationServiceSettings;

--- a/src/DurableTask.SqlServer/DurableTask.SqlServer.csproj
+++ b/src/DurableTask.SqlServer/DurableTask.SqlServer.csproj
@@ -23,8 +23,6 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Azure.DurableTask.Core" Version="2.9.0" />
     <PackageReference Include="Microsoft.Data.SqlClient" Version="3.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="3.1.*" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="3.1.*" />
     <PackageReference Include="SemanticVersion" Version="2.1.0" />
     <PackageReference Include="System.Threading.Channels" Version="4.7.1" />
   </ItemGroup>

--- a/test/PerformanceTests/LongHaul.cs
+++ b/test/PerformanceTests/LongHaul.cs
@@ -1,0 +1,154 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+namespace PerformanceTests
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Text.Json;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Microsoft.AspNetCore.Http;
+    using Microsoft.AspNetCore.Mvc;
+    using Microsoft.Azure.WebJobs;
+    using Microsoft.Azure.WebJobs.Extensions.DurableTask;
+    using Microsoft.Azure.WebJobs.Extensions.Http;
+    using Microsoft.Extensions.Logging;
+
+    public class LongHaul
+    {
+        // HTTPie command:
+        // http post http://localhost:7071/api/StartLongHaul TotalHours:=1 OrchestrationsPerInterval:=1000 Interval=00:05:00
+        [FunctionName(nameof(StartLongHaul))]
+        public static async Task<IActionResult> StartLongHaul(
+            [HttpTrigger(AuthorizationLevel.Anonymous, "post", Route = null)] HttpRequest req,
+            [DurableClient] IDurableClient starter,
+            ILogger log)
+        {
+            string input = await req.ReadAsStringAsync();
+
+            LongHaulOptions options = null;
+            if (!string.IsNullOrEmpty(input))
+            {
+                try
+                {
+                    options = JsonSerializer.Deserialize<LongHaulOptions>(input);
+                }
+                catch (JsonException e)
+                {
+                    log.LogWarning(e, "Received bad JSON input");
+                }
+            }
+
+            if (options == null || !options.IsValid())
+            {
+                return new BadRequestObjectResult(new
+                {
+                    error = "Required request content is missing or invalid",
+                    usage = new SortedDictionary<string, string>
+                    {
+                        [nameof(LongHaulOptions.TotalHours)] = "The total length of time the test should run. Example: '72' for 72 hours.",
+                        [nameof(LongHaulOptions.OrchestrationsPerInterval)] = "The number of orchestrations to schedule per interval. Example: '1000' to schedule 1,000 every interval.",
+                        [nameof(LongHaulOptions.Interval)] = "The frequency for scheduling orchestration batches. Example: '00:05:00' for 5 minutes.",
+                    },
+                });
+            }
+
+            // Instance ID contains the timestamp and the configuration parameters for easier searching and categorization
+            string instanceId = $"longhaul_{DateTime.UtcNow:yyyyMMddHHmmss}_{options.TotalHours}_{options.OrchestrationsPerInterval}_{(int)options.Interval.TotalSeconds}";
+            await starter.StartNewAsync(
+                nameof(LongHaulOrchestrator),
+                instanceId,
+                new LongHaulState 
+                { 
+                    Options = options,
+                    Deadline = DateTime.UtcNow.AddHours(options.TotalHours),
+                });
+
+            log.LogWarning("Started long-haul orchestrator with ID = {instanceId}", instanceId);
+            return starter.CreateCheckStatusResponse(req, instanceId);
+        }
+
+        /// <summary>
+        /// Long-running orchestration that schedules bursts of shorter "Hello cities" orchestrations to run on a given interval
+        /// </summary>
+        [FunctionName(nameof(LongHaulOrchestrator))]
+        public static async Task LongHaulOrchestrator(
+            [OrchestrationTrigger] IDurableOrchestrationContext context,
+            ILogger logger)
+        {
+            LongHaulState state = context.GetInput<LongHaulState>();
+            if (context.CurrentUtcDateTime > state.Deadline)
+            {
+                return;
+            }
+
+            state.Iteration++;
+            int currentTotal = state.TotalOrchestrationsCompleted;
+
+            // Schedule all orchestrations in parallel
+            List<Task> tasks = Enumerable
+                .Range(0, state.Options.OrchestrationsPerInterval)
+                .Select(i =>
+                {
+                    // Each sub-orchestration should have a unique ID
+                    int suffix = state.TotalOrchestrationsCompleted + i;
+                    return context.CallSubOrchestratorAsync(
+                        nameof(ManySequences.HelloCities),
+                        instanceId: $"{context.InstanceId}_{suffix:X8}",
+                        input: null);
+                })
+                .ToList();
+
+            context.SetCustomStatus(state);
+
+            // Wait for all sub-orchestrations to complete
+            await Task.WhenAll(tasks);
+
+            state.TotalOrchestrationsCompleted += tasks.Count;
+            context.SetCustomStatus(state);
+
+            DateTime nextRunTime = context.CurrentUtcDateTime.Add(state.Options.Interval);
+            await context.CreateTimer(nextRunTime, CancellationToken.None);
+
+            context.ContinueAsNew(state);
+        }
+
+        /// <summary>
+        /// Options for starting this orchestration
+        /// </summary>
+        class LongHaulOptions
+        {
+            [Newtonsoft.Json.JsonProperty]
+            public int TotalHours { get; set; }
+            [Newtonsoft.Json.JsonProperty]
+            public int OrchestrationsPerInterval { get; set; }
+            [Newtonsoft.Json.JsonProperty]
+            public TimeSpan Interval { get; set; }
+
+            public bool IsValid() => 
+                this.TotalHours > 0 &&
+                this.OrchestrationsPerInterval > 0 &&
+                this.Interval > TimeSpan.Zero;
+        }
+
+        /// <summary>
+        /// State maintained by the long-haul orchestration
+        /// </summary>
+        class LongHaulState
+        {
+            [Newtonsoft.Json.JsonProperty]
+            public LongHaulOptions Options { get; set; }
+
+            [Newtonsoft.Json.JsonProperty]
+            public DateTime Deadline { get; set; }
+
+            [Newtonsoft.Json.JsonProperty(DefaultValueHandling = Newtonsoft.Json.DefaultValueHandling.Ignore)]
+            public int TotalOrchestrationsCompleted { get; set; }
+
+            [Newtonsoft.Json.JsonProperty(DefaultValueHandling = Newtonsoft.Json.DefaultValueHandling.Ignore)]
+            public int Iteration { get; set; }
+        }
+    }
+}

--- a/test/PerformanceTests/Scripts/RunTestInAzure.ps1
+++ b/test/PerformanceTests/Scripts/RunTestInAzure.ps1
@@ -1,0 +1,86 @@
+﻿param(
+    [string]$subscription,
+    [string]$appName,
+    [string]$planName,
+    [string]$funcGroup,
+    [string]$sqlGroup,
+    [string]$functionSKU="EP2",
+    [int]$instanceCount=4,
+    [string]$sqlDbName,
+    [string]$sqlDbServer,
+    [string]$sqlComputeModel="Provisioned", # Provisioned, Serverless
+    [int]$sqlMinCpus=2,
+    [int]$sqlCPUs=2, # Gen5 options: 2, 4, 8, 16, 24, 32, 40, 64, 80
+    [int]$count=5000
+)
+
+$ErrorActionPreference = "Stop"
+
+# Installing the Azure CLI: https://docs.microsoft.com/cli/azure/install-azure-cli
+az account set -s $subscription
+
+# Update the SQL SKU
+# Reference: https://docs.microsoft.com/cli/azure/sql/db?view=azure-cli-latest#az_sql_db_update
+Write-Host "Setting $sqlDbServer/$sqlDbName to the $sqlComputeModel compute model with (or up to) $sqlCPUs vCPUs..."
+az sql db update --compute-model $sqlComputeModel --min-capacity $sqlMinCpus --capacity $sqlCPUs --family Gen5 --resource-group $sqlGroup --name $sqlDbName --server $sqlDbServer | Out-Null
+
+# Update the plan
+Write-Host "Setting $planName plan to max burst of $instanceCount instances..."
+
+# Update the app with a minimum instance count
+# NOTE: The order of these commands needs to change depending on whether we're adding or removing instances.
+#       If adding, update the plan first. If subtracting, update the app first.
+az functionapp plan update --resource-group $funcGroup --name $planName --sku $functionSKU --min-instances $instanceCount --max-burst $instanceCount | Out-Null
+az resource update --resource-group $funcGroup --name "$appName/config/web" --set properties.minimumElasticInstanceCount=$instanceCount --resource-type "Microsoft.Web/sites" | Out-Null
+
+Write-Host "Hard-restarting the app to ensure any plan changes take effect"
+az functionapp stop --name $appName --resource-group $funcGroup
+Sleep 10
+az functionapp start --name $appName --resource-group $funcGroup
+Sleep 10
+
+$Stoploop = $false
+[int]$Retrycount = 0
+ 
+do {
+    try {
+        # ping the site to make sure it's up and running
+        Write-Host "Pinging the app to ensure it can start-up"
+        Invoke-RestMethod -Method Post -Uri "https://$appName.azurewebsites.net/admin/host/ping"
+        $Stoploop = $true
+    }
+    catch {
+        if ($Retrycount -gt 10){
+            Write-Host "The app is still down after 10 ping retries. Giving up."
+            return
+        }
+        else {
+            Write-Host "Ping failed, which means the app is down. Retrying in 60 seconds..."
+            Start-Sleep -Seconds 60
+            $Retrycount = $Retrycount + 1
+        }
+    }
+}
+While ($Stoploop -eq $false)
+
+# get the master key
+$masterKey = (az functionapp keys list --name $appName --resource-group $funcGroup --query "masterKey" --output tsv)
+
+# clear any data to make sure all tests start with the same amount of data in the database
+Write-Host "Purging database of old instances"
+Invoke-RestMethod -Method Post -Uri "https://$appName.azurewebsites.net/api/PurgeOrchestrationData?code=$masterKey"
+
+# The Invoke-RestMethod command seems to run asynchronously, so sleep to give it time to finish
+Write-Host "Sleeping for 15 seconds in case the previous command finished before the purge completed"
+Sleep 15
+
+# run the test with a prefix (example: "EP1-max1-sql4-10000")
+if ($sqlComputeModel -eq "Serverless") {
+    $prefix = "$functionSKU-max$instanceCount-sqlServerless-$count-"
+} else { 
+    $prefix = "$functionSKU-max$instanceCount-sql$sqlCPUs-$count-"
+}
+Write-Host "Starting test with prefix '$prefix'..."
+$url = "https://$appName.azurewebsites.net/api/StartManySequences?count=$count&prefix=$prefix&code=$masterKey"
+Write-Host $url
+Invoke-RestMethod -Method Post -Uri $url


### PR DESCRIPTION
This PR contains a small variety of changes for the v1.0.0 (GA) release.

* Update documentation to reflect latest performance numbers (throughput has gone up almost 4x since `v0.11.1-beta`!)
* Remove unnecessary nuget packages that were breaking Azure Functions V2 compatibility
* Replace deprecated IConnectionStringResolver usage with IConnectionInfoResolver to resolve build warnings (no behavior change)
* Add new *LongHaul* stress test to the performance testing project
* Add PowerShell script that I used for running performance tests in Azure

This is expected to be the last PR before the v1.0.0 (GA) stable release.

Fixes https://github.com/microsoft/durabletask-mssql/issues/107