### PR TITLE
Added multi-schema support for DTF Sql-Server

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## v1.1.0
+
+### New
+
+* Support multiple schemas in a single database ([#110](https://github.com/microsoft/durabletask-mssql/pull/110)) - contributed by [@AndreiRR24](https://github.com/AndreiRR24)
+
 ## v1.0.1
 
 ### Updates

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## v1.0.1
+
+### Updates
+
+* Fixed script for case sensitive databases ([#113](https://github.com/microsoft/durabletask-mssql/pull/113)) - contributed by [@matei-dorian](https://github.com/matei-dorian)
+* Updating SqlDurabilityProviderStartup to implement IWebJobsStartup ([#117](https://github.com/microsoft/durabletask-mssql/pull/117))
+* Removed [Microsoft.Azure.Functions.Extensions](https://www.nuget.org/packages/Microsoft.Azure.Functions.Extensions/) package dependency
+
 ## v1.0.0
 
 ### New

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -6,11 +6,13 @@ The Microsoft SQL Provider for the Durable Task Framework (DTFx) and Durable Fun
 
 The DTFx schema is provisioned in the target database when the orchestration service is created. When using DTFx, this happens during the call to `SqlOrchestrationService.CreateAsync()`. When using Durable Functions, this happens automatically when the Functions host first starts up. It is not necessary to run any database provisioning scripts manually.
 
-The database provisioning scripts are compiled directly into the main provider DLL file as assembly resources. You can view these scripts in GitHub [here](https://github.com/microsoft/durabletask-mssql/tree/main/src/DurableTask.SqlServer/Scripts). All tables, views, and stored procedures are provisioned under a `dt` schema to distinguish it from any existing schema in the database.
+The database provisioning scripts are compiled directly into the main provider DLL file as assembly resources. You can view these scripts in GitHub [here](https://github.com/microsoft/durabletask-mssql/tree/main/src/DurableTask.SqlServer/Scripts). All tables, views, and stored procedures are provisioned under a default `dt` schema to distinguish it from any existing schema in the database, unless another schema name is provided at creation time.
+
+As mentioned, the schema can also have a custom name, in which case the following information regarding tables and scripts will have the `dt` replaced with `{customSchemaName}`.
 
 ![Schema](media/schema.png)
 
-The tables are as follows:
+The tables in the default version are as follows:
 
 * **dt.Instances**: Contains a list of all orchestration and entity instances that exist in this database.
 * **dt.History**: Contains the event history for all orchestration instances.
@@ -28,7 +30,7 @@ You can find the current version of the database schema in the `dt.Versions` tab
 
 The Microsoft SQL provider for DTFx was designed to operate both in the cloud and on-premises, in dedicated databases, and also in databases that might be shared with other line-of-business applications.
 
-As mentioned previously, all schema objects created by this provider are created under a `dt` schema object ("dt" is short for "**D**urable **T**ask"). The intent of creating this schema is to make it easy to reuse an existing database for DTFx and/or Durable Functions securely and without creating conflicts with any existing database objects.
+As mentioned previously, all schema objects created by this provider are created under a default `dt` schema object ("dt" is short for "**D**urable **T**ask"). The intent of creating this schema is to make it easy to reuse an existing database for DTFx and/or Durable Functions securely and without creating conflicts with any existing database objects.
 
 ?> "Schemas" in Microsoft SQL and other relational database management systems are essentially namespaces of objects like tables, views, stored procedures, etc. The advantage of schemas is that they provide the opportunity to simplify the administration of security, backup and restore, and general database organization. They are particularly useful if you want to co-host multiple applications in the same database, as we do in this case.
 

--- a/docs/introduction.md
+++ b/docs/introduction.md
@@ -20,7 +20,7 @@ This provider was designed from the ground-up with simplicity in mind. The data 
 
 ### Multitenancy
 
-One of the goals for this provider is to create a foundation for safe [multi-tenant deployments](https://en.wikipedia.org/wiki/Multitenancy). This is especially valuable when your organization has many small apps but prefers to manage only a single backend database. Different apps can connect to this database using different database login credentials. Database administrators will be able to query data across all tenants but individual apps will only have access to their own data. Note that tenant-specific code that runs _outside_ the database would still be expected to run on appropriately isolated compute instances. Learn how to get started with multitenancy [here](multitenancy.md).
+One of the goals for this provider is to create a foundation for safe [multi-tenant deployments](https://en.wikipedia.org/wiki/Multitenancy). This is especially valuable when your organization has many small apps but prefers to manage only a single backend database. Different apps can connect to this database using different database login credentials. Database administrators will be able to query data across all tenants but individual apps will only have access to their own data. When further isolation and security is needed, each app can [have its own schema](multitenancy.md#managing-custom-schemas). Note that tenant-specific code that runs _outside_ the database would still be expected to run on appropriately isolated compute instances. Learn how to get started with multitenancy [here](multitenancy.md).
 
 ## FAQ
 

--- a/docs/multitenancy.md
+++ b/docs/multitenancy.md
@@ -8,7 +8,24 @@ One of the goals for the Microsoft SQL provider for the Durable Task Framework (
 
 Multitenancy works by isolating each app into a separate [task hub](taskhubs.md). The current task hub is determined by the credentials used to log into the database. For example, if your app connects to a Microsoft SQL database using **dbo** credentials (the default, built-in admin user for most databases), then the name of the connected task hub will be "dbo". Task hubs provide data isolation, ensuring that two users in the same database will not be able to access each other's data.
 
+Another layer of multitenancy is added by the multi-schema support. This increases reliability and security for multiple services that are independently deployed in the same database, allowing each service control over their own schema and further isolation between service's data.
+
 ?> Task hub isolation in the current version of the SQL provider prevents one tenant from accessing data that belongs to another tenant. However, it doesn't impose any restrictions on data volumes or database CPU usage. If this kind of strict resource isolation is required, then each tenant should instead be separated into their own database.
+
+## Managing custom schemas
+
+For self-hosted DTFx app that opt for custom schema name, you can configure the schema name directly in the `SqlOrchestrationServiceSettings` class.
+
+```csharp
+var settings = new SqlOrchestrationServiceSettings
+{
+    SchemaName = "customSchemaName",
+    TaskHubConnectionString = Environment.GetEnvironmentVariable("SQLDB_Connection"),
+};
+```
+
+If no schema name name is explicitly configured, the default value `dt` will be used. Note that changing the value requires a restart of the app for the change to take effect.
+
 
 ## Enabling multitenancy
 

--- a/src/DurableTask.SqlServer.AzureFunctions/DurableTask.SqlServer.AzureFunctions.csproj
+++ b/src/DurableTask.SqlServer.AzureFunctions/DurableTask.SqlServer.AzureFunctions.csproj
@@ -16,7 +16,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Azure.Functions.Extensions" Version="1.0.0" />
     <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.DurableTask" Version="2.7.*" />
   </ItemGroup>
 

--- a/src/DurableTask.SqlServer.AzureFunctions/SqlDurabilityProviderStartup.cs
+++ b/src/DurableTask.SqlServer.AzureFunctions/SqlDurabilityProviderStartup.cs
@@ -1,19 +1,20 @@
-﻿// Copyright (c) Microsoft Corporation.
+// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-// Reference: https://docs.microsoft.com/en-us/azure/azure-functions/functions-dotnet-dependency-injection
-[assembly: Microsoft.Azure.Functions.Extensions.DependencyInjection.FunctionsStartup(
+[assembly: Microsoft.Azure.WebJobs.Hosting.WebJobsStartup(
     typeof(DurableTask.SqlServer.AzureFunctions.SqlDurabilityProviderStartup))]
 
 namespace DurableTask.SqlServer.AzureFunctions
 {
-    using Microsoft.Azure.Functions.Extensions.DependencyInjection;
+    using Microsoft.Azure.WebJobs;
     using Microsoft.Azure.WebJobs.Extensions.DurableTask;
+    using Microsoft.Azure.WebJobs.Hosting;
     using Microsoft.Extensions.DependencyInjection;
 
-    class SqlDurabilityProviderStartup : FunctionsStartup
+
+    class SqlDurabilityProviderStartup : IWebJobsStartup
     {
-        public override void Configure(IFunctionsHostBuilder builder)
+        public void Configure(IWebJobsBuilder builder)
         {
             builder.Services.AddSingleton<IDurabilityProviderFactory, SqlDurabilityProviderFactory>();
         }

--- a/src/DurableTask.SqlServer/Scripts/drop-schema.sql
+++ b/src/DurableTask.SqlServer/Scripts/drop-schema.sql
@@ -2,60 +2,60 @@
 -- Licensed under the MIT License.
 
 -- Functions
-DROP FUNCTION IF EXISTS dt.CurrentTaskHub
-DROP FUNCTION IF EXISTS dt.GetScaleMetric
-DROP FUNCTION IF EXISTS dt.GetScaleRecommendation
+DROP FUNCTION IF EXISTS {{SchemaNamePlaceholder}}.CurrentTaskHub
+DROP FUNCTION IF EXISTS {{SchemaNamePlaceholder}}.GetScaleMetric
+DROP FUNCTION IF EXISTS {{SchemaNamePlaceholder}}.GetScaleRecommendation
 
 -- Views
-DROP VIEW IF EXISTS dt.vHistory
-DROP VIEW IF EXISTS dt.vInstances
+DROP VIEW IF EXISTS {{SchemaNamePlaceholder}}.vHistory
+DROP VIEW IF EXISTS {{SchemaNamePlaceholder}}.vInstances
 
 -- Public Sprocs
-DROP PROCEDURE IF EXISTS dt.CreateInstance
-DROP PROCEDURE IF EXISTS dt.GetInstanceHistory
-DROP PROCEDURE IF EXISTS dt.QuerySingleOrchestration
-DROP PROCEDURE IF EXISTS dt.RaiseEvent
-DROP PROCEDURE IF EXISTS dt.SetGlobalSetting
-DROP PROCEDURE IF EXISTS dt.TerminateInstance
-DROP PROCEDURE IF EXISTS dt.PurgeInstanceStateByID
-DROP PROCEDURE IF EXISTS dt.PurgeInstanceStateByTime
+DROP PROCEDURE IF EXISTS {{SchemaNamePlaceholder}}.CreateInstance
+DROP PROCEDURE IF EXISTS {{SchemaNamePlaceholder}}.GetInstanceHistory
+DROP PROCEDURE IF EXISTS {{SchemaNamePlaceholder}}.QuerySingleOrchestration
+DROP PROCEDURE IF EXISTS {{SchemaNamePlaceholder}}.RaiseEvent
+DROP PROCEDURE IF EXISTS {{SchemaNamePlaceholder}}.SetGlobalSetting
+DROP PROCEDURE IF EXISTS {{SchemaNamePlaceholder}}.TerminateInstance
+DROP PROCEDURE IF EXISTS {{SchemaNamePlaceholder}}.PurgeInstanceStateByID
+DROP PROCEDURE IF EXISTS {{SchemaNamePlaceholder}}.PurgeInstanceStateByTime
 
 -- Private sprocs
-DROP PROCEDURE IF EXISTS dt._AddOrchestrationEvents
-DROP PROCEDURE IF EXISTS dt._CheckpointOrchestration
-DROP PROCEDURE IF EXISTS dt._CompleteTasks
-DROP PROCEDURE IF EXISTS dt._DiscardEventsAndUnlockInstance
-DROP PROCEDURE IF EXISTS dt._GetVersions
-DROP PROCEDURE IF EXISTS dt._LockNextOrchestration
-DROP PROCEDURE IF EXISTS dt._LockNextTask
-DROP PROCEDURE IF EXISTS dt._QueryManyOrchestrations
-DROP PROCEDURE IF EXISTS dt._RenewOrchestrationLocks
-DROP PROCEDURE IF EXISTS dt._RenewTaskLocks
-DROP PROCEDURE IF EXISTS dt._UpdateVersion
-DROP PROCEDURE IF EXISTS dt._RewindInstance
-DROP PROCEDURE IF EXISTS dt._RewindInstanceRecursive
+DROP PROCEDURE IF EXISTS {{SchemaNamePlaceholder}}._AddOrchestrationEvents
+DROP PROCEDURE IF EXISTS {{SchemaNamePlaceholder}}._CheckpointOrchestration
+DROP PROCEDURE IF EXISTS {{SchemaNamePlaceholder}}._CompleteTasks
+DROP PROCEDURE IF EXISTS {{SchemaNamePlaceholder}}._DiscardEventsAndUnlockInstance
+DROP PROCEDURE IF EXISTS {{SchemaNamePlaceholder}}._GetVersions
+DROP PROCEDURE IF EXISTS {{SchemaNamePlaceholder}}._LockNextOrchestration
+DROP PROCEDURE IF EXISTS {{SchemaNamePlaceholder}}._LockNextTask
+DROP PROCEDURE IF EXISTS {{SchemaNamePlaceholder}}._QueryManyOrchestrations
+DROP PROCEDURE IF EXISTS {{SchemaNamePlaceholder}}._RenewOrchestrationLocks
+DROP PROCEDURE IF EXISTS {{SchemaNamePlaceholder}}._RenewTaskLocks
+DROP PROCEDURE IF EXISTS {{SchemaNamePlaceholder}}._UpdateVersion
+DROP PROCEDURE IF EXISTS {{SchemaNamePlaceholder}}._RewindInstance
+DROP PROCEDURE IF EXISTS {{SchemaNamePlaceholder}}._RewindInstanceRecursive
 
 -- Tables
-DROP TABLE IF EXISTS dt.Versions
-DROP TABLE IF EXISTS dt.NewTasks
-DROP TABLE IF EXISTS dt.NewEvents
-DROP TABLE IF EXISTS dt.History
-DROP TABLE IF EXISTS dt.Instances
-DROP TABLE IF EXISTS dt.Payloads
-DROP TABLE IF EXISTS dt.GlobalSettings
+DROP TABLE IF EXISTS {{SchemaNamePlaceholder}}.Versions
+DROP TABLE IF EXISTS {{SchemaNamePlaceholder}}.NewTasks
+DROP TABLE IF EXISTS {{SchemaNamePlaceholder}}.NewEvents
+DROP TABLE IF EXISTS {{SchemaNamePlaceholder}}.History
+DROP TABLE IF EXISTS {{SchemaNamePlaceholder}}.Instances
+DROP TABLE IF EXISTS {{SchemaNamePlaceholder}}.Payloads
+DROP TABLE IF EXISTS {{SchemaNamePlaceholder}}.GlobalSettings
 
 -- Custom types
-DROP TYPE IF EXISTS dt.HistoryEvents
-DROP TYPE IF EXISTS dt.InstanceIDs
-DROP TYPE IF EXISTS dt.MessageIDs
-DROP TYPE IF EXISTS dt.OrchestrationEvents
-DROP TYPE IF EXISTS dt.TaskEvents
+DROP TYPE IF EXISTS {{SchemaNamePlaceholder}}.HistoryEvents
+DROP TYPE IF EXISTS {{SchemaNamePlaceholder}}.InstanceIDs
+DROP TYPE IF EXISTS {{SchemaNamePlaceholder}}.MessageIDs
+DROP TYPE IF EXISTS {{SchemaNamePlaceholder}}.OrchestrationEvents
+DROP TYPE IF EXISTS {{SchemaNamePlaceholder}}.TaskEvents
 
 -- This must be the last DROP statement related to schema
-DROP SCHEMA IF EXISTS dt
+DROP SCHEMA IF EXISTS {{SchemaNamePlaceholder}}
 
 -- Roles: all members have to be dropped before the role can be dropped
-DECLARE @rolename sysname = 'dt_runtime';
+DECLARE @rolename sysname = '{{SchemaNamePlaceholder}}_runtime';
 DECLARE @cmd AS nvarchar(MAX) = N'';
 SELECT @cmd = @cmd + '
     ALTER ROLE ' + QUOTENAME(@rolename) + ' DROP MEMBER ' + QUOTENAME(members.[name]) + ';'
@@ -67,4 +67,4 @@ FROM sys.database_role_members AS rolemembers
 WHERE roles.[name] = @rolename
 EXEC(@cmd);
 
-DROP ROLE IF EXISTS dt_runtime
+DROP ROLE IF EXISTS {{SchemaNamePlaceholder}}_runtime

--- a/src/DurableTask.SqlServer/Scripts/logic.sql
+++ b/src/DurableTask.SqlServer/Scripts/logic.sql
@@ -174,7 +174,7 @@ BEGIN
         -- Instance IDs can be overwritten only if the orchestration is in a terminal state
         IF @existingStatus IN ('Pending', 'Running')
         BEGIN
-            DECLARE @msg nvarchar(4000) = FORMATMESSAGE('Cannot create instance with ID ''%s'' because a pending or running instance with ID already exists.', @InstanceId);
+            DECLARE @msg nvarchar(4000) = FORMATMESSAGE('Cannot create instance with ID ''%s'' because a pending or running instance with ID already exists.', @InstanceID);
             THROW 50001, @msg, 1;
         END
         ELSE IF @existingStatus IS NOT NULL

--- a/src/DurableTask.SqlServer/Scripts/logic.sql
+++ b/src/DurableTask.SqlServer/Scripts/logic.sql
@@ -1,7 +1,7 @@
 ﻿-- Copyright (c) Microsoft Corporation.
 -- Licensed under the MIT License.
 
-CREATE OR ALTER FUNCTION dt.CurrentTaskHub()
+CREATE OR ALTER FUNCTION {{SchemaNamePlaceholder}}.CurrentTaskHub()
     RETURNS varchar(50)
     WITH EXECUTE AS CALLER
 AS
@@ -9,7 +9,7 @@ BEGIN
     -- Task Hub modes:
     -- 0: Task hub names are set by the app
     -- 1: Task hub names are inferred from the user credential
-    DECLARE @taskHubMode sql_variant = (SELECT TOP 1 [Value] FROM dt.GlobalSettings WHERE [Name] = 'TaskHubMode');
+    DECLARE @taskHubMode sql_variant = (SELECT TOP 1 [Value] FROM {{SchemaNamePlaceholder}}.GlobalSettings WHERE [Name] = 'TaskHubMode');
 
     DECLARE @taskHub varchar(150)
 
@@ -30,12 +30,12 @@ END
 GO
 
 
-CREATE OR ALTER FUNCTION dt.GetScaleMetric()
+CREATE OR ALTER FUNCTION {{SchemaNamePlaceholder}}.GetScaleMetric()
     RETURNS INT
     WITH EXECUTE AS CALLER
 AS
 BEGIN
-    DECLARE @taskHub varchar(50) = dt.CurrentTaskHub()
+    DECLARE @taskHub varchar(50) = {{SchemaNamePlaceholder}}.CurrentTaskHub()
     DECLARE @now datetime2 = SYSUTCDATETIME()
 
     DECLARE @liveInstances int = 0
@@ -44,9 +44,9 @@ BEGIN
     SELECT
         @liveInstances = COUNT(DISTINCT E.[InstanceID]),
         @liveTasks = COUNT(T.[InstanceID])
-    FROM dt.Instances I WITH (NOLOCK)
-        LEFT OUTER JOIN dt.NewEvents E WITH (NOLOCK) ON E.[TaskHub] = @taskHub AND E.[InstanceID] = I.[InstanceID]
-        LEFT OUTER JOIN dt.NewTasks T WITH (NOLOCK) ON T.[TaskHub] = @taskHub AND T.[InstanceID] = I.[InstanceID]
+    FROM {{SchemaNamePlaceholder}}.Instances I WITH (NOLOCK)
+        LEFT OUTER JOIN {{SchemaNamePlaceholder}}.NewEvents E WITH (NOLOCK) ON E.[TaskHub] = @taskHub AND E.[InstanceID] = I.[InstanceID]
+        LEFT OUTER JOIN {{SchemaNamePlaceholder}}.NewTasks T WITH (NOLOCK) ON T.[TaskHub] = @taskHub AND T.[InstanceID] = I.[InstanceID]
     WHERE
         I.[TaskHub] = @taskHub
         AND I.[RuntimeStatus] IN ('Pending', 'Running')
@@ -57,12 +57,12 @@ END
 GO
 
 
-CREATE OR ALTER FUNCTION dt.GetScaleRecommendation(@MaxOrchestrationsPerWorker real, @MaxActivitiesPerWorker real)
+CREATE OR ALTER FUNCTION {{SchemaNamePlaceholder}}.GetScaleRecommendation(@MaxOrchestrationsPerWorker real, @MaxActivitiesPerWorker real)
     RETURNS INT
     WITH EXECUTE AS CALLER
 AS
 BEGIN
-    DECLARE @taskHub varchar(50) = dt.CurrentTaskHub()
+    DECLARE @taskHub varchar(50) = {{SchemaNamePlaceholder}}.CurrentTaskHub()
     DECLARE @now datetime2 = SYSUTCDATETIME()
 
     DECLARE @liveInstances int = 0
@@ -71,9 +71,9 @@ BEGIN
     SELECT
         @liveInstances = COUNT(DISTINCT E.[InstanceID]),
         @liveTasks = COUNT(T.[InstanceID])
-    FROM dt.Instances I WITH (NOLOCK)
-        LEFT OUTER JOIN dt.NewEvents E WITH (NOLOCK) ON E.[TaskHub] = @taskHub AND E.[InstanceID] = I.[InstanceID]
-        LEFT OUTER JOIN dt.NewTasks T WITH (NOLOCK) ON T.[TaskHub] = @taskHub AND T.[InstanceID] = I.[InstanceID]
+    FROM {{SchemaNamePlaceholder}}.Instances I WITH (NOLOCK)
+        LEFT OUTER JOIN {{SchemaNamePlaceholder}}.NewEvents E WITH (NOLOCK) ON E.[TaskHub] = @taskHub AND E.[InstanceID] = I.[InstanceID]
+        LEFT OUTER JOIN {{SchemaNamePlaceholder}}.NewTasks T WITH (NOLOCK) ON T.[TaskHub] = @taskHub AND T.[InstanceID] = I.[InstanceID]
     WHERE
         I.[TaskHub] = @taskHub
         AND I.[RuntimeStatus] IN ('Pending', 'Running')
@@ -90,7 +90,7 @@ END
 GO
 
 
-CREATE OR ALTER VIEW dt.vInstances
+CREATE OR ALTER VIEW {{SchemaNamePlaceholder}}.vInstances
 AS
     SELECT
         I.[TaskHub],
@@ -102,24 +102,24 @@ AS
         I.[LastUpdatedTime],
         I.[CompletedTime],
         I.[RuntimeStatus],
-        (SELECT TOP 1 [Text] FROM Payloads P WHERE
-            P.[TaskHub] = dt.CurrentTaskHub() AND
+        (SELECT TOP 1 [Text] FROM {{SchemaNamePlaceholder}}.Payloads P WHERE
+            P.[TaskHub] = {{SchemaNamePlaceholder}}.CurrentTaskHub() AND
             P.[InstanceID] = I.[InstanceID] AND
             P.[PayloadID] = I.[CustomStatusPayloadID]) AS [CustomStatusText],
-        (SELECT TOP 1 [Text] FROM Payloads P WHERE
-            P.[TaskHub] = dt.CurrentTaskHub() AND
+        (SELECT TOP 1 [Text] FROM {{SchemaNamePlaceholder}}.Payloads P WHERE
+            P.[TaskHub] = {{SchemaNamePlaceholder}}.CurrentTaskHub() AND
             P.[InstanceID] = I.[InstanceID] AND
             P.[PayloadID] = I.[InputPayloadID]) AS [InputText],
-        (SELECT TOP 1 [Text] FROM Payloads P WHERE 
-            P.[TaskHub] = dt.CurrentTaskHub() AND
+        (SELECT TOP 1 [Text] FROM {{SchemaNamePlaceholder}}.Payloads P WHERE 
+            P.[TaskHub] = {{SchemaNamePlaceholder}}.CurrentTaskHub() AND
             P.[InstanceID] = I.[InstanceID] AND
             P.[PayloadID] = I.[OutputPayloadID]) AS [OutputText]
-    FROM Instances I
+    FROM {{SchemaNamePlaceholder}}.Instances I
     WHERE
-        I.[TaskHub] = dt.CurrentTaskHub()
+        I.[TaskHub] = {{SchemaNamePlaceholder}}.CurrentTaskHub()
 GO
 
-CREATE OR ALTER VIEW dt.vHistory
+CREATE OR ALTER VIEW {{SchemaNamePlaceholder}}.vHistory
 AS
     SELECT
         H.[TaskHub],
@@ -133,17 +133,17 @@ AS
 	    H.[Name],
 	    H.[RuntimeStatus],
         H.[VisibleTime],
-	    (SELECT TOP 1 [Text] FROM Payloads P WHERE
-            P.[TaskHub] = dt.CurrentTaskHub() AND
+	    (SELECT TOP 1 [Text] FROM {{SchemaNamePlaceholder}}.Payloads P WHERE
+            P.[TaskHub] = {{SchemaNamePlaceholder}}.CurrentTaskHub() AND
             P.[InstanceID] = H.[InstanceID] AND
             P.[PayloadID] = H.[DataPayloadID]) AS [Payload]
-    FROM History H
+    FROM {{SchemaNamePlaceholder}}.History H
     WHERE
-        H.[TaskHub] = dt.CurrentTaskHub()
+        H.[TaskHub] = {{SchemaNamePlaceholder}}.CurrentTaskHub()
 GO
 
 
-CREATE OR ALTER PROCEDURE dt.CreateInstance
+CREATE OR ALTER PROCEDURE {{SchemaNamePlaceholder}}.CreateInstance
     @Name varchar(300),
     @Version varchar(100) = NULL,
     @InstanceID varchar(100) = NULL,
@@ -152,7 +152,7 @@ CREATE OR ALTER PROCEDURE dt.CreateInstance
     @StartTime datetime2 = NULL
 AS
 BEGIN
-    DECLARE @TaskHub varchar(50) = dt.CurrentTaskHub()
+    DECLARE @TaskHub varchar(50) = {{SchemaNamePlaceholder}}.CurrentTaskHub()
     DECLARE @EventType varchar(30) = 'ExecutionStarted'
     DECLARE @RuntimeStatus varchar(30) = 'Pending'
 
@@ -167,7 +167,7 @@ BEGIN
 
         DECLARE @existingStatus varchar(30) = (
             SELECT TOP 1 existing.[RuntimeStatus]
-            FROM Instances existing WITH (HOLDLOCK)
+            FROM {{SchemaNamePlaceholder}}.Instances existing WITH (HOLDLOCK)
             WHERE [TaskHub] = @TaskHub AND [InstanceID] = @InstanceID
         )
 
@@ -182,7 +182,7 @@ BEGIN
             -- Purge the existing instance data so that it can be overwritten
             DECLARE @instancesToPurge InstanceIDs
             INSERT INTO @instancesToPurge VALUES (@InstanceID)
-            EXEC dt.PurgeInstanceStateByID @instancesToPurge
+            EXEC {{SchemaNamePlaceholder}}.PurgeInstanceStateByID @instancesToPurge
         END
 
         COMMIT TRANSACTION
@@ -204,11 +204,11 @@ BEGIN
     IF @InputText IS NOT NULL
     BEGIN
         SET @InputPayloadID = NEWID()
-        INSERT INTO Payloads ([TaskHub], [InstanceID], [PayloadID], [Text])
+        INSERT INTO {{SchemaNamePlaceholder}}.Payloads ([TaskHub], [InstanceID], [PayloadID], [Text])
         VALUES (@TaskHub, @InstanceID, @InputPayloadID, @InputText)
     END
 
-    INSERT INTO Instances (
+    INSERT INTO {{SchemaNamePlaceholder}}.Instances (
         [Name],
         [Version],
         [TaskHub],
@@ -226,7 +226,7 @@ BEGIN
         @InputPayloadID
     )
 
-    INSERT INTO NewEvents (
+    INSERT INTO {{SchemaNamePlaceholder}}.NewEvents (
         [Name],
         [TaskHub],
         [InstanceID],
@@ -250,19 +250,19 @@ END
 GO
 
 
-CREATE OR ALTER PROCEDURE dt.GetInstanceHistory
+CREATE OR ALTER PROCEDURE {{SchemaNamePlaceholder}}.GetInstanceHistory
     @InstanceID varchar(100),
     @GetInputsAndOutputs bit = 0
 AS
 BEGIN
-    DECLARE @TaskHub varchar(50) = dt.CurrentTaskHub()
+    DECLARE @TaskHub varchar(50) = {{SchemaNamePlaceholder}}.CurrentTaskHub()
     DECLARE @ParentInstanceID varchar(100)
     DECLARE @Version varchar(100)
     
     SELECT
         @ParentInstanceID = [ParentInstanceID],
         @Version = [Version]
-    FROM Instances WHERE [InstanceID] = @InstanceID
+    FROM {{SchemaNamePlaceholder}}.Instances WHERE [InstanceID] = @InstanceID
 
     SELECT
         H.[InstanceID],
@@ -280,8 +280,8 @@ BEGIN
         [PayloadID],
         @ParentInstanceID as [ParentInstanceID],
         @Version as [Version]
-    FROM History H WITH (INDEX (PK_History))
-        LEFT OUTER JOIN Payloads P ON
+    FROM {{SchemaNamePlaceholder}}.History H WITH (INDEX (PK_History))
+        LEFT OUTER JOIN {{SchemaNamePlaceholder}}.Payloads P ON
             P.[TaskHub] = @TaskHub AND
             P.[InstanceID] = H.[InstanceID] AND
             P.[PayloadID] = H.[DataPayloadID]
@@ -293,7 +293,7 @@ END
 GO
 
 
-CREATE OR ALTER PROCEDURE dt.RaiseEvent
+CREATE OR ALTER PROCEDURE {{SchemaNamePlaceholder}}.RaiseEvent
     @Name varchar(300),
     @InstanceID varchar(100) = NULL,
     @PayloadText varchar(MAX) = NULL,
@@ -302,16 +302,16 @@ AS
 BEGIN
     BEGIN TRANSACTION
 
-    DECLARE @TaskHub varchar(50) = dt.CurrentTaskHub()
+    DECLARE @TaskHub varchar(50) = {{SchemaNamePlaceholder}}.CurrentTaskHub()
 
     -- External event messages must target new instances or they must use
     -- the "auto start" instance ID format of @orchestrationname@identifier.
     IF NOT EXISTS (
         SELECT 1
-        FROM Instances I
+        FROM {{SchemaNamePlaceholder}}.Instances I
         WHERE [TaskHub] = @TaskHub AND I.[InstanceID] = @InstanceID)
     BEGIN
-        INSERT INTO Instances (
+        INSERT INTO {{SchemaNamePlaceholder}}.Instances (
             [TaskHub],
             [InstanceID],
             [ExecutionID],
@@ -337,11 +337,11 @@ BEGIN
     IF @PayloadText IS NOT NULL
     BEGIN
         SET @PayloadID = NEWID()
-        INSERT INTO Payloads ([TaskHub], [InstanceID], [PayloadID], [Text])
+        INSERT INTO {{SchemaNamePlaceholder}}.Payloads ([TaskHub], [InstanceID], [PayloadID], [Text])
         VALUES (@TaskHub, @InstanceID, @PayloadID, @PayloadText)
     END
 
-    INSERT INTO NewEvents (
+    INSERT INTO {{SchemaNamePlaceholder}}.NewEvents (
         [Name],
         [TaskHub],
         [InstanceID],
@@ -361,7 +361,7 @@ BEGIN
 END
 GO
 
-CREATE OR ALTER PROCEDURE dt.TerminateInstance
+CREATE OR ALTER PROCEDURE {{SchemaNamePlaceholder}}.TerminateInstance
     @InstanceID varchar(100),
     @Reason varchar(max) = NULL
 AS
@@ -373,11 +373,11 @@ BEGIN
     -- order across all stored procedures that execute within a transaction.
     -- Table order for this sproc: Instances --> (NewEvents --> Payloads --> NewEvents)  
 
-    DECLARE @TaskHub varchar(50) = dt.CurrentTaskHub()
+    DECLARE @TaskHub varchar(50) = {{SchemaNamePlaceholder}}.CurrentTaskHub()
 
     DECLARE @existingStatus varchar(30) = (
         SELECT TOP 1 existing.[RuntimeStatus]
-        FROM Instances existing WITH (HOLDLOCK)
+        FROM {{SchemaNamePlaceholder}}.Instances existing WITH (HOLDLOCK)
         WHERE [TaskHub] = @TaskHub AND [InstanceID] = @InstanceID
     )
 
@@ -388,7 +388,7 @@ BEGIN
     IF @existingStatus IN ('Pending', 'Running')
     BEGIN
         IF NOT EXISTS (
-            SELECT TOP (1) 1 FROM NewEvents
+            SELECT TOP (1) 1 FROM {{SchemaNamePlaceholder}}.NewEvents
             WHERE [TaskHub] = @TaskHub AND [InstanceID] = @InstanceID AND [EventType] = 'ExecutionTerminated'
         )
         BEGIN
@@ -398,11 +398,11 @@ BEGIN
             BEGIN
                 -- Note that we don't use the Reason column for the Reason with terminate events
                 SET @PayloadID = NEWID()
-                INSERT INTO Payloads ([TaskHub], [InstanceID], [PayloadID], [Text])
+                INSERT INTO {{SchemaNamePlaceholder}}.Payloads ([TaskHub], [InstanceID], [PayloadID], [Text])
                 VALUES (@TaskHub, @InstanceID, @PayloadID, @Reason)
             END
 
-            INSERT INTO NewEvents (
+            INSERT INTO {{SchemaNamePlaceholder}}.NewEvents (
                 [TaskHub],
                 [InstanceID],
                 [EventType],
@@ -420,20 +420,20 @@ END
 GO
 
 
-CREATE OR ALTER PROCEDURE dt.PurgeInstanceStateByID
+CREATE OR ALTER PROCEDURE {{SchemaNamePlaceholder}}.PurgeInstanceStateByID
     @InstanceIDs InstanceIDs READONLY
 AS
 BEGIN
-    DECLARE @TaskHub varchar(50) = dt.CurrentTaskHub()
+    DECLARE @TaskHub varchar(50) = {{SchemaNamePlaceholder}}.CurrentTaskHub()
 
     BEGIN TRANSACTION
 
-    DELETE FROM NewEvents WHERE [TaskHub] = @TaskHub AND [InstanceID] IN (SELECT [InstanceID] FROM @InstanceIDs)
-    DELETE FROM NewTasks  WHERE [TaskHub] = @TaskHub AND [InstanceID] IN (SELECT [InstanceID] FROM @InstanceIDs)
-    DELETE FROM Instances WHERE [TaskHub] = @TaskHub AND [InstanceID] IN (SELECT [InstanceID] FROM @InstanceIDs)
+    DELETE FROM {{SchemaNamePlaceholder}}.NewEvents WHERE [TaskHub] = @TaskHub AND [InstanceID] IN (SELECT [InstanceID] FROM @InstanceIDs)
+    DELETE FROM {{SchemaNamePlaceholder}}.NewTasks  WHERE [TaskHub] = @TaskHub AND [InstanceID] IN (SELECT [InstanceID] FROM @InstanceIDs)
+    DELETE FROM {{SchemaNamePlaceholder}}.Instances WHERE [TaskHub] = @TaskHub AND [InstanceID] IN (SELECT [InstanceID] FROM @InstanceIDs)
     DECLARE @deletedInstances int = @@ROWCOUNT
-    DELETE FROM History  WHERE [TaskHub] = @TaskHub AND [InstanceID] IN (SELECT [InstanceID] FROM @InstanceIDs)
-    DELETE FROM Payloads WHERE [TaskHub] = @TaskHub AND [InstanceID] IN (SELECT [InstanceID] FROM @InstanceIDs)
+    DELETE FROM {{SchemaNamePlaceholder}}.History  WHERE [TaskHub] = @TaskHub AND [InstanceID] IN (SELECT [InstanceID] FROM @InstanceIDs)
+    DELETE FROM {{SchemaNamePlaceholder}}.Payloads WHERE [TaskHub] = @TaskHub AND [InstanceID] IN (SELECT [InstanceID] FROM @InstanceIDs)
 
     COMMIT TRANSACTION
 
@@ -443,26 +443,26 @@ END
 GO
 
 
-CREATE OR ALTER PROCEDURE dt.PurgeInstanceStateByTime
+CREATE OR ALTER PROCEDURE {{SchemaNamePlaceholder}}.PurgeInstanceStateByTime
     @ThresholdTime datetime2,
     @FilterType tinyint = 0
 AS
 BEGIN
-    DECLARE @TaskHub varchar(50) = dt.CurrentTaskHub()
+    DECLARE @TaskHub varchar(50) = {{SchemaNamePlaceholder}}.CurrentTaskHub()
 
     DECLARE @instanceIDs InstanceIDs
 
     IF @FilterType = 0 -- created time
     BEGIN
         INSERT INTO @instanceIDs
-            SELECT [InstanceID] FROM Instances
+            SELECT [InstanceID] FROM {{SchemaNamePlaceholder}}.Instances
             WHERE [TaskHub] = @TaskHub AND [RuntimeStatus] IN ('Completed', 'Terminated', 'Failed')
                 AND [CreatedTime] <= @ThresholdTime
     END
     ELSE IF @FilterType = 1 -- completed time
     BEGIN
         INSERT INTO @instanceIDs
-            SELECT [InstanceID] FROM Instances
+            SELECT [InstanceID] FROM {{SchemaNamePlaceholder}}.Instances
             WHERE [TaskHub] = @TaskHub AND [RuntimeStatus] IN ('Completed', 'Terminated', 'Failed')
                 AND [CompletedTime] <= @ThresholdTime
     END
@@ -473,19 +473,19 @@ BEGIN
     END
 
     DECLARE @deletedInstances int
-    EXECUTE @deletedInstances = dt.PurgeInstanceStateByID @instanceIDs
+    EXECUTE @deletedInstances = {{SchemaNamePlaceholder}}.PurgeInstanceStateByID @instanceIDs
     RETURN @deletedInstances
 END
 GO
 
-CREATE OR ALTER PROCEDURE dt.SetGlobalSetting
+CREATE OR ALTER PROCEDURE {{SchemaNamePlaceholder}}.SetGlobalSetting
     @Name varchar(300),
     @Value sql_variant
 AS
 BEGIN
     BEGIN TRANSACTION
  
-    UPDATE dt.GlobalSettings WITH (UPDLOCK, HOLDLOCK)
+    UPDATE {{SchemaNamePlaceholder}}.GlobalSettings WITH (UPDLOCK, HOLDLOCK)
     SET
         [Value] = @Value,
         [Timestamp] = SYSUTCDATETIME(),
@@ -495,7 +495,7 @@ BEGIN
  
     IF @@ROWCOUNT = 0
     BEGIN
-        INSERT INTO dt.GlobalSettings ([Name], [Value]) VALUES (@Name, @Value)
+        INSERT INTO {{SchemaNamePlaceholder}}.GlobalSettings ([Name], [Value]) VALUES (@Name, @Value)
     END
  
     COMMIT TRANSACTION
@@ -503,7 +503,7 @@ END
 GO
 
 
-CREATE OR ALTER PROCEDURE dt._LockNextOrchestration
+CREATE OR ALTER PROCEDURE {{SchemaNamePlaceholder}}._LockNextOrchestration
     @BatchSize int,
     @LockedBy varchar(100),
     @LockExpiration datetime2
@@ -514,7 +514,7 @@ BEGIN
     DECLARE @parentInstanceID varchar(100)
     DECLARE @version varchar(100)
     DECLARE @runtimeStatus varchar(30)
-    DECLARE @TaskHub varchar(50) = dt.CurrentTaskHub()
+    DECLARE @TaskHub varchar(50) = {{SchemaNamePlaceholder}}.CurrentTaskHub()
 
     BEGIN TRANSACTION
 
@@ -526,7 +526,7 @@ BEGIN
     -- Lock the first active instance that has pending messages.
     -- Delayed events from durable timers will have a non-null VisibleTime value.
     -- Non-active instances will never have their messages or history read.
-    UPDATE TOP (1) Instances WITH (READPAST)
+    UPDATE TOP (1) {{SchemaNamePlaceholder}}.Instances WITH (READPAST)
     SET
         [LockedBy] = @LockedBy,
 	    [LockExpiration] = @LockExpiration,
@@ -535,7 +535,7 @@ BEGIN
         @runtimeStatus = I.[RuntimeStatus],
         @version = I.[Version]
     FROM 
-        dt.Instances I WITH (READPAST) INNER JOIN NewEvents E WITH (READPAST) ON
+        {{SchemaNamePlaceholder}}.Instances I WITH (READPAST) INNER JOIN {{SchemaNamePlaceholder}}.NewEvents E WITH (READPAST) ON
             E.[TaskHub] = @TaskHub AND
             E.[InstanceID] = I.[InstanceID]
     WHERE
@@ -564,8 +564,8 @@ BEGIN
         DATEDIFF(SECOND, [Timestamp], @now) AS [WaitTime],
         @parentInstanceID as [ParentInstanceID],
         @version as [Version]
-    FROM NewEvents N
-        LEFT OUTER JOIN dt.[Payloads] P ON 
+    FROM {{SchemaNamePlaceholder}}.NewEvents N
+        LEFT OUTER JOIN {{SchemaNamePlaceholder}}.[Payloads] P ON 
             P.[TaskHub] = @TaskHub AND
             P.[InstanceID] = N.[InstanceID] AND
             P.[PayloadID] = N.[PayloadID]
@@ -603,8 +603,8 @@ BEGIN
         [PayloadID],
         @parentInstanceID as [ParentInstanceID],
         @version as [Version]
-    FROM History H WITH (INDEX (PK_History))
-        LEFT OUTER JOIN Payloads P ON
+    FROM {{SchemaNamePlaceholder}}.History H WITH (INDEX (PK_History))
+        LEFT OUTER JOIN {{SchemaNamePlaceholder}}.Payloads P ON
             P.[TaskHub] = @TaskHub AND
             P.[InstanceID] = H.[InstanceID] AND
             P.[PayloadID] = H.[DataPayloadID]
@@ -616,7 +616,7 @@ END
 GO
 
 
-CREATE OR ALTER PROCEDURE dt._CheckpointOrchestration
+CREATE OR ALTER PROCEDURE {{SchemaNamePlaceholder}}._CheckpointOrchestration
     @InstanceID varchar(100),
     @ExecutionID varchar(50),
     @RuntimeStatus varchar(30),
@@ -629,7 +629,7 @@ AS
 BEGIN
     BEGIN TRANSACTION
 
-    DECLARE @TaskHub varchar(50) = dt.CurrentTaskHub()
+    DECLARE @TaskHub varchar(50) = {{SchemaNamePlaceholder}}.CurrentTaskHub()
 
     DECLARE @InputPayloadID uniqueidentifier
     DECLARE @CustomStatusPayloadID uniqueidentifier
@@ -644,7 +644,7 @@ BEGIN
         @CustomStatusPayloadID = I.[CustomStatusPayloadID],
         @ExistingCustomStatusPayload = P.[Text],
         @ExistingExecutionID = I.[ExecutionID]
-    FROM Payloads P RIGHT OUTER JOIN Instances I ON
+    FROM {{SchemaNamePlaceholder}}.Payloads P RIGHT OUTER JOIN {{SchemaNamePlaceholder}}.Instances I ON
         P.[TaskHub] = @TaskHub AND
         P.[InstanceID] = I.[InstanceID] AND
         P.[PayloadID] = I.[CustomStatusPayloadID]
@@ -654,10 +654,10 @@ BEGIN
     DECLARE @IsContinueAsNew BIT = 0
     IF @ExistingExecutionID IS NOT NULL AND @ExistingExecutionID <> @ExecutionID
     BEGIN
-        DELETE FROM History
+        DELETE FROM {{SchemaNamePlaceholder}}.History
         WHERE [TaskHub] = @TaskHub AND [InstanceID] = @InstanceID
 
-        DELETE FROM Payloads
+        DELETE FROM {{SchemaNamePlaceholder}}.Payloads
         WHERE [TaskHub] = @TaskHub AND [InstanceID] = @InstanceID
 
         -- The existing payload got purged in the previous statement 
@@ -669,14 +669,14 @@ BEGIN
     IF @ExistingCustomStatusPayload IS NULL AND @CustomStatusPayload IS NOT NULL
     BEGIN
         SET @CustomStatusPayloadID = NEWID()
-        INSERT INTO Payloads ([TaskHub], [InstanceID], [PayloadID], [Text])
+        INSERT INTO {{SchemaNamePlaceholder}}.Payloads ([TaskHub], [InstanceID], [PayloadID], [Text])
         VALUES (@TaskHub, @InstanceID, @CustomStatusPayloadID, @CustomStatusPayload)
     END
 
     -- Custom status case #2: Updating an existing custom status payload
     IF @ExistingCustomStatusPayload IS NOT NULL AND @ExistingCustomStatusPayload <> @CustomStatusPayload
     BEGIN
-        UPDATE Payloads SET [Text] = @CustomStatusPayload WHERE 
+        UPDATE {{SchemaNamePlaceholder}}.Payloads SET [Text] = @CustomStatusPayload WHERE 
             [TaskHub] = @TaskHub AND
             [InstanceID] = @InstanceID AND
             [PayloadID] = @CustomStatusPayloadID
@@ -713,12 +713,12 @@ BEGIN
     -- The [PayloadText] value will be NULL if there is no payload or if a payload is already known to exist in the DB.
     -- The [PayloadID] value might be set even if [PayloadText] and [Reason] are both NULL.
     -- This needs to be done before the UPDATE to Instances because the Instances table needs to reference the output payload.
-    INSERT INTO Payloads ([TaskHub], [InstanceID], [PayloadID], [Text], [Reason])
+    INSERT INTO {{SchemaNamePlaceholder}}.Payloads ([TaskHub], [InstanceID], [PayloadID], [Text], [Reason])
         SELECT @TaskHub, [InstanceID], [PayloadID], [PayloadText], [Reason]
         FROM @NewHistoryEvents
         WHERE [PayloadText] IS NOT NULL OR [Reason] IS NOT NULL
 
-    UPDATE Instances
+    UPDATE {{SchemaNamePlaceholder}}.Instances
     SET
         [ExecutionID] = @ExecutionID,
         [RuntimeStatus] = @RuntimeStatus,
@@ -728,7 +728,7 @@ BEGIN
         [CustomStatusPayloadID] = @CustomStatusPayloadID,
         [InputPayloadID] = @InputPayloadID,
         [OutputPayloadID] = @OutputPayloadID
-    FROM Instances
+    FROM {{SchemaNamePlaceholder}}.Instances
     WHERE [TaskHub] = @TaskHub and [InstanceID] = @InstanceID
 
     IF @@ROWCOUNT = 0
@@ -737,7 +737,7 @@ BEGIN
     -- External event messages can create new instances
     -- NOTE: There is a chance this could result in deadlocks if two 
     --       instances are sending events to each other at the same time
-    INSERT INTO Instances (
+    INSERT INTO {{SchemaNamePlaceholder}}.Instances (
         [TaskHub],
         [InstanceID],
         [ExecutionID],
@@ -756,13 +756,13 @@ BEGIN
         AND CHARINDEX('@', E.[InstanceID], 2) > 0
         AND NOT EXISTS (
             SELECT 1
-            FROM dt.Instances I
+            FROM {{SchemaNamePlaceholder}}.Instances I
             WHERE [TaskHub] = @TaskHub AND I.[InstanceID] = E.[InstanceID])
     GROUP BY E.[InstanceID]
     ORDER BY E.[InstanceID] ASC
 
     -- Create sub-orchestration instances
-    INSERT INTO Instances (
+    INSERT INTO {{SchemaNamePlaceholder}}.Instances (
         [TaskHub],
         [InstanceID],
         [ExecutionID],
@@ -782,24 +782,24 @@ BEGIN
     WHERE E.[EventType] IN ('ExecutionStarted')
         AND NOT EXISTS (
             SELECT 1
-            FROM dt.Instances I
+            FROM {{SchemaNamePlaceholder}}.Instances I
             WHERE [TaskHub] = @TaskHub AND I.[InstanceID] = E.[InstanceID])
     ORDER BY E.[InstanceID] ASC
 
     -- Insert new event data payloads into the Payloads table in batches.
     -- PayloadID values are provided by the caller only if a payload exists.
-    INSERT INTO Payloads ([TaskHub], [InstanceID], [PayloadID], [Text], [Reason])
+    INSERT INTO {{SchemaNamePlaceholder}}.Payloads ([TaskHub], [InstanceID], [PayloadID], [Text], [Reason])
         SELECT @TaskHub, [InstanceID], [PayloadID], [PayloadText], [Reason]
         FROM @NewOrchestrationEvents
         WHERE [PayloadID] IS NOT NULL
 
-    INSERT INTO Payloads ([TaskHub], [InstanceID], [PayloadID], [Text])
+    INSERT INTO {{SchemaNamePlaceholder}}.Payloads ([TaskHub], [InstanceID], [PayloadID], [Text])
         SELECT @TaskHub, [InstanceID], [PayloadID], [PayloadText]
         FROM @NewTaskEvents
         WHERE [PayloadID] IS NOT NULL
 
     -- Insert the new events with references to their payloads, if applicable
-    INSERT INTO NewEvents (
+    INSERT INTO {{SchemaNamePlaceholder}}.NewEvents (
         [TaskHub],
         [InstanceID],
         [ExecutionID],
@@ -826,7 +826,7 @@ BEGIN
     -- warning about missing messages
     DELETE E
     OUTPUT DELETED.InstanceID, DELETED.SequenceNumber
-    FROM dt.NewEvents E WITH (FORCESEEK(PK_NewEvents(TaskHub, InstanceID, SequenceNumber)))
+    FROM {{SchemaNamePlaceholder}}.NewEvents E WITH (FORCESEEK(PK_NewEvents(TaskHub, InstanceID, SequenceNumber)))
         INNER JOIN @DeletedEvents D ON 
             D.InstanceID = E.InstanceID AND
             D.SequenceNumber = E.SequenceNumber AND
@@ -835,7 +835,7 @@ BEGIN
     -- IMPORTANT: This insert is expected to fail with a primary key constraint violation in a
     --            split-brain situation where two instances try to execute the same orchestration
     --            at the same time. The SDK will check for this exact error condition.
-    INSERT INTO History (
+    INSERT INTO {{SchemaNamePlaceholder}}.History (
         [TaskHub],
         [InstanceID],
         [ExecutionID],
@@ -864,7 +864,7 @@ BEGIN
     FROM @NewHistoryEvents H
 
     -- TaskScheduled events
-    INSERT INTO NewTasks (
+    INSERT INTO {{SchemaNamePlaceholder}}.NewTasks (
         [TaskHub],
         [InstanceID],
         [ExecutionID],
@@ -897,31 +897,31 @@ END
 GO
 
 
-CREATE OR ALTER PROCEDURE dt._DiscardEventsAndUnlockInstance
+CREATE OR ALTER PROCEDURE {{SchemaNamePlaceholder}}._DiscardEventsAndUnlockInstance
     @InstanceID varchar(100),
     @DeletedEvents MessageIDs READONLY
 AS
 BEGIN
-    DECLARE @taskHub varchar(50) = dt.CurrentTaskHub()
+    DECLARE @taskHub varchar(50) = {{SchemaNamePlaceholder}}.CurrentTaskHub()
 
     -- We return the list of deleted messages so that the caller can issue a 
     -- warning about missing messages
     DELETE E
     OUTPUT DELETED.InstanceID, DELETED.SequenceNumber
-    FROM dt.NewEvents E WITH (FORCESEEK(PK_NewEvents(TaskHub, InstanceID, SequenceNumber)))
+    FROM {{SchemaNamePlaceholder}}.NewEvents E WITH (FORCESEEK(PK_NewEvents(TaskHub, InstanceID, SequenceNumber)))
         INNER JOIN @DeletedEvents D ON 
             D.InstanceID = E.InstanceID AND
             D.SequenceNumber = E.SequenceNumber AND
             E.TaskHub = @taskHub
 
     -- Release the lock on this instance
-    UPDATE Instances SET [LastUpdatedTime] = SYSUTCDATETIME(), [LockExpiration] = NULL
+    UPDATE {{SchemaNamePlaceholder}}.Instances SET [LastUpdatedTime] = SYSUTCDATETIME(), [LockExpiration] = NULL
     WHERE [TaskHub] = @taskHub and [InstanceID] = @InstanceID
 END
 GO
 
 
-CREATE OR ALTER PROCEDURE dt._AddOrchestrationEvents
+CREATE OR ALTER PROCEDURE {{SchemaNamePlaceholder}}._AddOrchestrationEvents
     @NewOrchestrationEvents OrchestrationEvents READONLY 
 AS
 BEGIN
@@ -932,13 +932,13 @@ BEGIN
     -- order across all stored procedures that execute within a transaction.
     -- Table order for this sproc: Payloads --> NewEvents
 
-    DECLARE @TaskHub varchar(50) = dt.CurrentTaskHub()
+    DECLARE @TaskHub varchar(50) = {{SchemaNamePlaceholder}}.CurrentTaskHub()
     
     -- External event messages can create new instances
     -- NOTE: There is a chance this could result in deadlocks if two 
     --       instances are sending events to each other at the same time
     BEGIN TRY
-        INSERT INTO Instances (
+        INSERT INTO {{SchemaNamePlaceholder}}.Instances (
             [TaskHub],
             [InstanceID],
             [ExecutionID],
@@ -969,13 +969,13 @@ BEGIN
 
     -- Insert new event data payloads into the Payloads table in batches.
     -- PayloadID values are provided by the caller only if a payload exists.
-    INSERT INTO Payloads ([TaskHub], [InstanceID], [PayloadID], [Text], [Reason])
+    INSERT INTO {{SchemaNamePlaceholder}}.Payloads ([TaskHub], [InstanceID], [PayloadID], [Text], [Reason])
         SELECT @TaskHub, [InstanceID], [PayloadID], [PayloadText], [Reason]
         FROM @NewOrchestrationEvents
         WHERE [PayloadID] IS NOT NULL
 
     -- Insert the new events with references to their payloads, if applicable
-    INSERT INTO NewEvents (
+    INSERT INTO {{SchemaNamePlaceholder}}.NewEvents (
         [TaskHub],
         [InstanceID],
         [ExecutionID],
@@ -1002,14 +1002,14 @@ BEGIN
 END
 GO
 
-CREATE OR ALTER PROCEDURE dt.QuerySingleOrchestration
+CREATE OR ALTER PROCEDURE {{SchemaNamePlaceholder}}.QuerySingleOrchestration
     @InstanceID varchar(100),
     @ExecutionID varchar(50) = NULL,
     @FetchInput bit = 1,
     @FetchOutput bit = 1
 AS
 BEGIN
-    DECLARE @TaskHub varchar(50) = dt.CurrentTaskHub()
+    DECLARE @TaskHub varchar(50) = {{SchemaNamePlaceholder}}.CurrentTaskHub()
 
     SELECT TOP 1
         I.[InstanceID],
@@ -1021,19 +1021,19 @@ BEGIN
         I.[CompletedTime],
         I.[RuntimeStatus],
         I.[ParentInstanceID],
-        (SELECT TOP 1 [Text] FROM Payloads P WHERE
+        (SELECT TOP 1 [Text] FROM {{SchemaNamePlaceholder}}.Payloads P WHERE
             P.[TaskHub] = @TaskHub AND
             P.[InstanceID] = I.[InstanceID] AND
             P.[PayloadID] = I.[CustomStatusPayloadID]) AS [CustomStatusText],
-        CASE WHEN @FetchInput = 1 THEN (SELECT TOP 1 [Text] FROM Payloads P WHERE
+        CASE WHEN @FetchInput = 1 THEN (SELECT TOP 1 [Text] FROM {{SchemaNamePlaceholder}}.Payloads P WHERE
             P.[TaskHub] = @TaskHub AND
             P.[InstanceID] = I.[InstanceID] AND
             P.[PayloadID] = I.[InputPayloadID]) ELSE NULL END AS [InputText],
-        CASE WHEN @FetchOutput = 1 THEN (SELECT TOP 1 [Text] FROM Payloads P WHERE
+        CASE WHEN @FetchOutput = 1 THEN (SELECT TOP 1 [Text] FROM {{SchemaNamePlaceholder}}.Payloads P WHERE
             P.[TaskHub] = @TaskHub AND
             P.[InstanceID] = I.[InstanceID] AND
             P.[PayloadID] = I.[OutputPayloadID]) ELSE NULL END AS [OutputText]
-    FROM Instances I
+    FROM {{SchemaNamePlaceholder}}.Instances I
     WHERE
         I.[TaskHub] = @TaskHub AND
         I.[InstanceID] = @InstanceID AND
@@ -1042,7 +1042,7 @@ END
 GO
 
 
-CREATE OR ALTER PROCEDURE dt._QueryManyOrchestrations
+CREATE OR ALTER PROCEDURE {{SchemaNamePlaceholder}}._QueryManyOrchestrations
     @PageSize smallint = 100,
     @PageNumber smallint = 0,
     @FetchInput bit = 1,
@@ -1054,7 +1054,7 @@ CREATE OR ALTER PROCEDURE dt._QueryManyOrchestrations
     @ExcludeSubOrchestrations bit = 0
 AS
 BEGIN
-    DECLARE @TaskHub varchar(50) = dt.CurrentTaskHub()
+    DECLARE @TaskHub varchar(50) = {{SchemaNamePlaceholder}}.CurrentTaskHub()
 
     SELECT
         I.[InstanceID],
@@ -1066,20 +1066,20 @@ BEGIN
         I.[CompletedTime],
         I.[RuntimeStatus],
         I.[ParentInstanceID],
-        (SELECT TOP 1 [Text] FROM Payloads P WHERE
+        (SELECT TOP 1 [Text] FROM {{SchemaNamePlaceholder}}.Payloads P WHERE
             P.[TaskHub] = @TaskHub AND
             P.[InstanceID] = I.[InstanceID] AND
             P.[PayloadID] = I.[CustomStatusPayloadID]) AS [CustomStatusText],
-        CASE WHEN @FetchInput = 1 THEN (SELECT TOP 1 [Text] FROM Payloads P WHERE
+        CASE WHEN @FetchInput = 1 THEN (SELECT TOP 1 [Text] FROM {{SchemaNamePlaceholder}}.Payloads P WHERE
             P.[TaskHub] = @TaskHub AND
             P.[InstanceID] = I.[InstanceID] AND
             P.[PayloadID] = I.[InputPayloadID]) ELSE NULL END AS [InputText],
-        CASE WHEN @FetchOutput = 1 THEN (SELECT TOP 1 [Text] FROM Payloads P WHERE
+        CASE WHEN @FetchOutput = 1 THEN (SELECT TOP 1 [Text] FROM {{SchemaNamePlaceholder}}.Payloads P WHERE
             P.[TaskHub] = @TaskHub AND
             P.[InstanceID] = I.[InstanceID] AND
             P.[PayloadID] = I.[OutputPayloadID]) ELSE NULL END AS [OutputText]
     FROM
-        Instances I
+        {{SchemaNamePlaceholder}}.Instances I
     WHERE
         I.[TaskHub] = @TaskHub AND
         (@CreatedTimeFrom IS NULL OR I.[CreatedTime] >= @CreatedTimeFrom) AND
@@ -1093,12 +1093,12 @@ END
 GO
 
 
-CREATE OR ALTER PROCEDURE dt._LockNextTask
+CREATE OR ALTER PROCEDURE {{SchemaNamePlaceholder}}._LockNextTask
     @LockedBy varchar(100),
     @LockExpiration datetime2
 AS
 BEGIN
-    DECLARE @TaskHub varchar(50) = dt.CurrentTaskHub()
+    DECLARE @TaskHub varchar(50) = {{SchemaNamePlaceholder}}.CurrentTaskHub()
     DECLARE @now datetime2 = SYSUTCDATETIME()
 
     DECLARE @SequenceNumber bigint
@@ -1112,14 +1112,14 @@ BEGIN
     -- Update (lock) and return a single row.
     -- The PK_NewTasks hint is specified to help ensure in-order selection.
     -- TODO: Filter out tasks for instances that are in a non-running state (suspended, etc.)
-    UPDATE TOP (1) NewTasks WITH (READPAST)
+    UPDATE TOP (1) {{SchemaNamePlaceholder}}.NewTasks WITH (READPAST)
     SET
         @SequenceNumber = [SequenceNumber],
         [LockedBy] = @LockedBy,
 	    [LockExpiration] = @LockExpiration,
         [DequeueCount] = [DequeueCount] + 1
     FROM
-        NewTasks WITH (INDEX (PK_NewTasks))
+        {{SchemaNamePlaceholder}}.NewTasks WITH (INDEX (PK_NewTasks))
     WHERE
         [TaskHub] = @TaskHub AND
 	    ([LockExpiration] IS NULL OR [LockExpiration] < @now) AND
@@ -1136,12 +1136,12 @@ BEGIN
         [Timestamp],
         [DequeueCount],
         [Version],
-        (SELECT TOP 1 [Text] FROM Payloads P WHERE
+        (SELECT TOP 1 [Text] FROM {{SchemaNamePlaceholder}}.Payloads P WHERE
             P.[TaskHub] = @TaskHub AND
             P.[InstanceID] = N.[InstanceID] AND
             P.[PayloadID] = N.[PayloadID]) AS [PayloadText],
         DATEDIFF(SECOND, [Timestamp], @now) AS [WaitTime]
-    FROM NewTasks N
+    FROM {{SchemaNamePlaceholder}}.NewTasks N
     WHERE [TaskHub] = @TaskHub AND [SequenceNumber] = @SequenceNumber
 
     COMMIT TRANSACTION
@@ -1149,42 +1149,42 @@ END
 GO
 
 
-CREATE OR ALTER PROCEDURE dt._RenewOrchestrationLocks
+CREATE OR ALTER PROCEDURE {{SchemaNamePlaceholder}}._RenewOrchestrationLocks
     @InstanceID varchar(100),
     @LockExpiration datetime2
 AS
 BEGIN
-    DECLARE @TaskHub varchar(50) = dt.CurrentTaskHub()
+    DECLARE @TaskHub varchar(50) = {{SchemaNamePlaceholder}}.CurrentTaskHub()
 
-    UPDATE Instances
+    UPDATE {{SchemaNamePlaceholder}}.Instances
     SET [LockExpiration] = @LockExpiration
     WHERE [TaskHub] = @TaskHub AND [InstanceID] = @InstanceID
 END
 GO
 
 
-CREATE OR ALTER PROCEDURE dt._RenewTaskLocks
+CREATE OR ALTER PROCEDURE {{SchemaNamePlaceholder}}._RenewTaskLocks
     @RenewingTasks MessageIDs READONLY,
     @LockExpiration datetime2
 AS
 BEGIN
-    DECLARE @TaskHub varchar(50) = dt.CurrentTaskHub()
+    DECLARE @TaskHub varchar(50) = {{SchemaNamePlaceholder}}.CurrentTaskHub()
 
     UPDATE N
     SET [LockExpiration] = @LockExpiration
-    FROM NewTasks N INNER JOIN @RenewingTasks C ON
+    FROM {{SchemaNamePlaceholder}}.NewTasks N INNER JOIN @RenewingTasks C ON
         C.[SequenceNumber] = N.[SequenceNumber] AND
         N.[TaskHub] = @TaskHub
 END
 GO
 
 
-CREATE OR ALTER PROCEDURE dt._CompleteTasks
+CREATE OR ALTER PROCEDURE {{SchemaNamePlaceholder}}._CompleteTasks
     @CompletedTasks MessageIDs READONLY,
     @Results TaskEvents READONLY
 AS
 BEGIN
-    DECLARE @TaskHub varchar(50) = dt.CurrentTaskHub()
+    DECLARE @TaskHub varchar(50) = {{SchemaNamePlaceholder}}.CurrentTaskHub()
 
     BEGIN TRANSACTION
 
@@ -1193,7 +1193,7 @@ BEGIN
     DECLARE @existingInstanceID varchar(100)
 
     SELECT @existingInstanceID = R.[InstanceID]
-    FROM Instances I WITH (HOLDLOCK)
+    FROM {{SchemaNamePlaceholder}}.Instances I WITH (HOLDLOCK)
         INNER JOIN @Results R ON 
             I.[TaskHub] = @TaskHub AND
             I.[InstanceID] = R.[InstanceID] AND 
@@ -1205,12 +1205,12 @@ BEGIN
     BEGIN
         -- Insert new event data payloads into the Payloads table in batches.
         -- PayloadID values are provided by the caller only if a payload exists.
-        INSERT INTO Payloads ([TaskHub], [InstanceID], [PayloadID], [Text], [Reason])
+        INSERT INTO {{SchemaNamePlaceholder}}.Payloads ([TaskHub], [InstanceID], [PayloadID], [Text], [Reason])
             SELECT @TaskHub, [InstanceID], [PayloadID], [PayloadText], [Reason]
             FROM @Results
             WHERE [PayloadID] IS NOT NULL
 
-        INSERT INTO NewEvents (
+        INSERT INTO {{SchemaNamePlaceholder}}.NewEvents (
             [TaskHub],
             [InstanceID],
             [ExecutionID],
@@ -1239,7 +1239,7 @@ BEGIN
     DELETE N
     OUTPUT DELETED.[PayloadID] INTO @payloadsToDelete
     OUTPUT DELETED.[SequenceNumber]
-    FROM NewTasks N WITH (FORCESEEK(PK_NewTasks(TaskHub, SequenceNumber)))
+    FROM {{SchemaNamePlaceholder}}.NewTasks N WITH (FORCESEEK(PK_NewTasks(TaskHub, SequenceNumber)))
         INNER JOIN @CompletedTasks C ON
             C.[SequenceNumber] = N.[SequenceNumber] AND
             N.[TaskHub] = @TaskHub
@@ -1255,47 +1255,47 @@ END
 GO
 
 
-CREATE OR ALTER PROCEDURE dt._GetVersions
+CREATE OR ALTER PROCEDURE {{SchemaNamePlaceholder}}._GetVersions
 AS
 BEGIN
     SELECT SemanticVersion, UpgradeTime
-    FROM Versions
+    FROM {{SchemaNamePlaceholder}}.Versions
     ORDER BY UpgradeTime DESC
 END
 GO
 
 
-CREATE OR ALTER PROCEDURE dt._UpdateVersion
+CREATE OR ALTER PROCEDURE {{SchemaNamePlaceholder}}._UpdateVersion
     @SemanticVersion varchar(100)
 AS
 BEGIN
     -- Duplicates are ignored (per the schema definition of dt.Versions)
-    INSERT INTO Versions (SemanticVersion)
+    INSERT INTO {{SchemaNamePlaceholder}}.Versions (SemanticVersion)
     VALUES (@SemanticVersion)
 END
 GO
 
 
-CREATE OR ALTER PROCEDURE dt._RewindInstance
+CREATE OR ALTER PROCEDURE {{SchemaNamePlaceholder}}._RewindInstance
     @InstanceID varchar(100),
     @Reason varchar(max) = NULL
 AS
 BEGIN
     BEGIN TRANSACTION
 
-    EXEC dt._RewindInstanceRecursive @InstanceID, @Reason
+    EXEC {{SchemaNamePlaceholder}}._RewindInstanceRecursive @InstanceID, @Reason
 
     COMMIT TRANSACTION
 END
 GO
 
 
-CREATE OR ALTER PROCEDURE dt._RewindInstanceRecursive
+CREATE OR ALTER PROCEDURE {{SchemaNamePlaceholder}}._RewindInstanceRecursive
     @InstanceID varchar(100),
     @Reason varchar(max) = NULL
 AS
 BEGIN
-    DECLARE @TaskHub varchar(50) = dt.CurrentTaskHub()
+    DECLARE @TaskHub varchar(50) = {{SchemaNamePlaceholder}}.CurrentTaskHub()
 
     -- *** IMPORTANT ***
     -- To prevent deadlocks, it is important to maintain consistent table access
@@ -1306,7 +1306,7 @@ BEGIN
     DECLARE @executionID varchar(50)
     
     SELECT TOP 1 @existingStatus = existing.[RuntimeStatus], @executionID = existing.[ExecutionID]
-    FROM Instances existing WITH (HOLDLOCK)
+    FROM {{SchemaNamePlaceholder}}.Instances existing WITH (HOLDLOCK)
     WHERE [TaskHub] = @TaskHub AND [InstanceID] = @InstanceID
 
     -- Instance IDs can be overwritten only if the orchestration is in a terminal state
@@ -1325,12 +1325,12 @@ BEGIN
     -- Save all events related to failures (ie TaskScheduled/TaskFailed and SubOrchestrationInstanceStarted/SubOrchestrationInstanceFailed couples)
     INSERT INTO @eventsInFailure
     SELECT h.[SequenceNumber], h.[EventType], h.[TaskID], h.[DataPayloadID]
-    FROM History h
+    FROM {{SchemaNamePlaceholder}}.History h
     WHERE h.[TaskHub] = @TaskHub
       AND h.[InstanceID] = @InstanceID
       AND (h.[EventType] IN ('TaskFailed', 'SubOrchestrationInstanceFailed') OR (h.[EventType] IN ('TaskScheduled', 'SubOrchestrationInstanceStarted') AND EXISTS (
         SELECT 1
-        FROM History f
+        FROM {{SchemaNamePlaceholder}}.History f
         WHERE f.[TaskHub] = @TaskHub 
           AND f.[InstanceID] = @InstanceID
           AND f.[TaskID] = h.[TaskID]
@@ -1338,9 +1338,9 @@ BEGIN
 
     -- Mark all events related to failure as rewound
     -- This first batch is for all events that have corresponding records in the Payloads table already
-    UPDATE Payloads
+    UPDATE {{SchemaNamePlaceholder}}.Payloads
     SET [Reason] = CONCAT('Rewound: ', ef.[EventType])
-    FROM Payloads p
+    FROM {{SchemaNamePlaceholder}}.Payloads p
     JOIN @eventsInFailure ef ON p.[PayloadID] = ef.[DataPayloadID]
     WHERE [TaskHub] = @TaskHub
       AND [InstanceID] = @InstanceID
@@ -1360,7 +1360,7 @@ BEGIN
 
     WHILE @@FETCH_STATUS = 0 BEGIN
         SET @payloadId = NEWID()
-        INSERT INTO Payloads (
+        INSERT INTO {{SchemaNamePlaceholder}}.Payloads (
             [TaskHub],
             [InstanceID],
             [PayloadID],
@@ -1373,7 +1373,7 @@ BEGIN
     DEALLOCATE sequenceNumberCursor
 
     -- Transform all events related to failure to GenericEvents, except for SubOrchestrationInstanceStarted that can be kept
-    UPDATE History
+    UPDATE {{SchemaNamePlaceholder}}.History
     SET [EventType] = 'GenericEvent'
     WHERE [TaskHub] = @TaskHub AND [InstanceID] = @InstanceID
       AND ([SequenceNumber] IN (SELECT [SequenceNumber]
@@ -1384,8 +1384,8 @@ BEGIN
     DECLARE @subOrchestrationInstanceID varchar(100)
     DECLARE subOrchestrationCursor CURSOR LOCAL FOR
         SELECT i.[InstanceID]
-        FROM dt.Instances i
-          JOIN dt.History h ON i.[TaskHub] = h.[TaskHub] AND i.[InstanceID] = h.[InstanceID]
+        FROM {{SchemaNamePlaceholder}}.Instances i
+          JOIN {{SchemaNamePlaceholder}}.History h ON i.[TaskHub] = h.[TaskHub] AND i.[InstanceID] = h.[InstanceID]
           JOIN @eventsInFailure e ON e.[TaskID] = h.[TaskID]
         WHERE i.[ParentInstanceID] = @InstanceID 
           AND h.[EventType] = 'ExecutionStarted'
@@ -1397,7 +1397,7 @@ BEGIN
 
     WHILE @@FETCH_STATUS = 0 BEGIN
         -- Call rewind recursively on the failing suborchestrations
-        EXECUTE dt._RewindInstanceRecursive @subOrchestrationInstanceID, @Reason
+        EXECUTE {{SchemaNamePlaceholder}}._RewindInstanceRecursive @subOrchestrationInstanceID, @Reason
         FETCH NEXT FROM subOrchestrationCursor INTO @subOrchestrationInstanceID
     END
     CLOSE subOrchestrationCursor
@@ -1405,14 +1405,14 @@ BEGIN
 
     -- Insert a line in NewEvents to ensure orchestration will start
     SET @payloadId = NEWID()
-    INSERT INTO Payloads (
+    INSERT INTO {{SchemaNamePlaceholder}}.Payloads (
         [TaskHub],
         [InstanceID],
         [PayloadID],
         [Text]
     )
     VALUES (@TaskHub, @InstanceID, @payloadId, @Reason)
-    INSERT INTO NewEvents (
+    INSERT INTO {{SchemaNamePlaceholder}}.NewEvents (
         [TaskHub],
         [InstanceID],
         [ExecutionID],
@@ -1427,7 +1427,7 @@ BEGIN
         @payloadId)
 
     -- Set orchestration status to Pending
-    UPDATE Instances
+    UPDATE {{SchemaNamePlaceholder}}.Instances
     SET [RuntimeStatus] = 'Pending', [LastUpdatedTime] = SYSUTCDATETIME()
     WHERE [TaskHub] = @TaskHub AND [InstanceID] = @InstanceID
 END

--- a/src/DurableTask.SqlServer/Scripts/permissions.sql
+++ b/src/DurableTask.SqlServer/Scripts/permissions.sql
@@ -2,11 +2,11 @@
 -- Licensed under the MIT License.
 
 -- Security 
-IF DATABASE_PRINCIPAL_ID('dt_runtime') IS NULL
+IF DATABASE_PRINCIPAL_ID('{{SchemaNamePlaceholder}}_runtime') IS NULL
 BEGIN
     -- This is the role to which all low-privilege user accounts should be associated using
     -- the 'ALTER ROLE dt_runtime ADD MEMBER [<username>]' statement.
-    CREATE ROLE dt_runtime
+    CREATE ROLE {{SchemaNamePlaceholder}}_runtime
 END
 
 -- Each stored procedure that is granted to dt_runtime must limits access to data based 
@@ -14,39 +14,39 @@ END
 -- database user can access data created by another database user.
 
 -- Functions 
-GRANT EXECUTE ON OBJECT::dt.GetScaleMetric TO dt_runtime
-GRANT EXECUTE ON OBJECT::dt.GetScaleRecommendation TO dt_runtime
-GRANT EXECUTE ON OBJECT::dt.CurrentTaskHub TO dt_runtime
+GRANT EXECUTE ON OBJECT::{{SchemaNamePlaceholder}}.GetScaleMetric TO {{SchemaNamePlaceholder}}_runtime
+GRANT EXECUTE ON OBJECT::{{SchemaNamePlaceholder}}.GetScaleRecommendation TO {{SchemaNamePlaceholder}}_runtime
+GRANT EXECUTE ON OBJECT::{{SchemaNamePlaceholder}}.CurrentTaskHub TO {{SchemaNamePlaceholder}}_runtime
 
 -- Public sprocs
-GRANT EXECUTE ON OBJECT::dt.CreateInstance TO dt_runtime
-GRANT EXECUTE ON OBJECT::dt.GetInstanceHistory TO dt_runtime
-GRANT EXECUTE ON OBJECT::dt.QuerySingleOrchestration TO dt_runtime
-GRANT EXECUTE ON OBJECT::dt.RaiseEvent TO dt_runtime
-GRANT EXECUTE ON OBJECT::dt.TerminateInstance TO dt_runtime
-GRANT EXECUTE ON OBJECT::dt.PurgeInstanceStateByID TO dt_runtime
-GRANT EXECUTE ON OBJECT::dt.PurgeInstanceStateByTime TO dt_runtime
+GRANT EXECUTE ON OBJECT::{{SchemaNamePlaceholder}}.CreateInstance TO {{SchemaNamePlaceholder}}_runtime
+GRANT EXECUTE ON OBJECT::{{SchemaNamePlaceholder}}.GetInstanceHistory TO {{SchemaNamePlaceholder}}_runtime
+GRANT EXECUTE ON OBJECT::{{SchemaNamePlaceholder}}.QuerySingleOrchestration TO {{SchemaNamePlaceholder}}_runtime
+GRANT EXECUTE ON OBJECT::{{SchemaNamePlaceholder}}.RaiseEvent TO {{SchemaNamePlaceholder}}_runtime
+GRANT EXECUTE ON OBJECT::{{SchemaNamePlaceholder}}.TerminateInstance TO {{SchemaNamePlaceholder}}_runtime
+GRANT EXECUTE ON OBJECT::{{SchemaNamePlaceholder}}.PurgeInstanceStateByID TO {{SchemaNamePlaceholder}}_runtime
+GRANT EXECUTE ON OBJECT::{{SchemaNamePlaceholder}}.PurgeInstanceStateByTime TO {{SchemaNamePlaceholder}}_runtime
 
 -- Internal sprocs
-GRANT EXECUTE ON OBJECT::dt._AddOrchestrationEvents TO dt_runtime
-GRANT EXECUTE ON OBJECT::dt._CheckpointOrchestration TO dt_runtime
-GRANT EXECUTE ON OBJECT::dt._CompleteTasks TO dt_runtime
-GRANT EXECUTE ON OBJECT::dt._DiscardEventsAndUnlockInstance TO dt_runtime
-GRANT EXECUTE ON OBJECT::dt._GetVersions TO dt_runtime
-GRANT EXECUTE ON OBJECT::dt._LockNextOrchestration TO dt_runtime
-GRANT EXECUTE ON OBJECT::dt._LockNextTask TO dt_runtime
-GRANT EXECUTE ON OBJECT::dt._QueryManyOrchestrations TO dt_runtime
-GRANT EXECUTE ON OBJECT::dt._RenewOrchestrationLocks TO dt_runtime
-GRANT EXECUTE ON OBJECT::dt._RenewTaskLocks TO dt_runtime
-GRANT EXECUTE ON OBJECT::dt._UpdateVersion TO dt_runtime
-GRANT EXECUTE ON OBJECT::dt._RewindInstance TO dt_runtime
-GRANT EXECUTE ON OBJECT::dt._RewindInstanceRecursive TO dt_runtime
+GRANT EXECUTE ON OBJECT::{{SchemaNamePlaceholder}}._AddOrchestrationEvents TO {{SchemaNamePlaceholder}}_runtime
+GRANT EXECUTE ON OBJECT::{{SchemaNamePlaceholder}}._CheckpointOrchestration TO {{SchemaNamePlaceholder}}_runtime
+GRANT EXECUTE ON OBJECT::{{SchemaNamePlaceholder}}._CompleteTasks TO {{SchemaNamePlaceholder}}_runtime
+GRANT EXECUTE ON OBJECT::{{SchemaNamePlaceholder}}._DiscardEventsAndUnlockInstance TO {{SchemaNamePlaceholder}}_runtime
+GRANT EXECUTE ON OBJECT::{{SchemaNamePlaceholder}}._GetVersions TO {{SchemaNamePlaceholder}}_runtime
+GRANT EXECUTE ON OBJECT::{{SchemaNamePlaceholder}}._LockNextOrchestration TO {{SchemaNamePlaceholder}}_runtime
+GRANT EXECUTE ON OBJECT::{{SchemaNamePlaceholder}}._LockNextTask TO {{SchemaNamePlaceholder}}_runtime
+GRANT EXECUTE ON OBJECT::{{SchemaNamePlaceholder}}._QueryManyOrchestrations TO {{SchemaNamePlaceholder}}_runtime
+GRANT EXECUTE ON OBJECT::{{SchemaNamePlaceholder}}._RenewOrchestrationLocks TO {{SchemaNamePlaceholder}}_runtime
+GRANT EXECUTE ON OBJECT::{{SchemaNamePlaceholder}}._RenewTaskLocks TO {{SchemaNamePlaceholder}}_runtime
+GRANT EXECUTE ON OBJECT::{{SchemaNamePlaceholder}}._UpdateVersion TO {{SchemaNamePlaceholder}}_runtime
+GRANT EXECUTE ON OBJECT::{{SchemaNamePlaceholder}}._RewindInstance TO {{SchemaNamePlaceholder}}_runtime
+GRANT EXECUTE ON OBJECT::{{SchemaNamePlaceholder}}._RewindInstanceRecursive TO {{SchemaNamePlaceholder}}_runtime
 
 -- Types
-GRANT EXECUTE ON TYPE::dt.HistoryEvents TO dt_runtime
-GRANT EXECUTE ON TYPE::dt.MessageIDs TO dt_runtime
-GRANT EXECUTE ON TYPE::dt.InstanceIDs TO dt_runtime
-GRANT EXECUTE ON TYPE::dt.OrchestrationEvents TO dt_runtime
-GRANT EXECUTE ON TYPE::dt.TaskEvents TO dt_runtime
+GRANT EXECUTE ON TYPE::{{SchemaNamePlaceholder}}.HistoryEvents TO {{SchemaNamePlaceholder}}_runtime
+GRANT EXECUTE ON TYPE::{{SchemaNamePlaceholder}}.MessageIDs TO {{SchemaNamePlaceholder}}_runtime
+GRANT EXECUTE ON TYPE::{{SchemaNamePlaceholder}}.InstanceIDs TO {{SchemaNamePlaceholder}}_runtime
+GRANT EXECUTE ON TYPE::{{SchemaNamePlaceholder}}.OrchestrationEvents TO {{SchemaNamePlaceholder}}_runtime
+GRANT EXECUTE ON TYPE::{{SchemaNamePlaceholder}}.TaskEvents TO {{SchemaNamePlaceholder}}_runtime
 
 GO

--- a/src/DurableTask.SqlServer/SqlDbManager.cs
+++ b/src/DurableTask.SqlServer/SqlDbManager.cs
@@ -41,7 +41,7 @@ namespace DurableTask.SqlServer
             {
                 // If the database already has the latest schema, then skip
                 using SqlCommand command = dbLock.CreateCommand();
-                command.CommandText = "dt._GetVersions";
+                command.CommandText = $"{this.settings.SchemaName}._GetVersions";
                 command.CommandType = CommandType.StoredProcedure;
 
                 try
@@ -110,7 +110,7 @@ namespace DurableTask.SqlServer
             // we need to update the sprocs or views.
             using (SqlCommand command = dbLock.CreateCommand())
             {
-                command.CommandText = "dt._UpdateVersion";
+                command.CommandText = $"{this.settings.SchemaName}._UpdateVersion";
                 command.CommandType = CommandType.StoredProcedure;
                 command.Parameters.Add("@SemanticVersion", SqlDbType.NVarChar, 100).Value = DTUtils.ExtensionVersion.ToString();
 
@@ -229,7 +229,9 @@ namespace DurableTask.SqlServer
             }
 
             string scriptText = await GetScriptTextAsync(scriptName);
-
+            
+            scriptText = scriptText.Replace("{{SchemaNamePlaceholder}}", this.settings.SchemaName);
+            
             // Split script into distinct executeable commands
             IEnumerable<string> scriptCommands = Regex.Split(scriptText, @"^\s*GO\s*$", RegexOptions.Multiline | RegexOptions.IgnoreCase)
                 .Where(x => x.Trim().Length > 0);

--- a/src/DurableTask.SqlServer/SqlOrchestrationServiceSettings.cs
+++ b/src/DurableTask.SqlServer/SqlOrchestrationServiceSettings.cs
@@ -19,7 +19,8 @@ namespace DurableTask.SqlServer
         /// </summary>
         /// <param name="connectionString">The connection string for connecting to the database.</param>
         /// <param name="taskHubName">Optional. The name of the task hub. If not specified, a default name will be used.</param>
-        public SqlOrchestrationServiceSettings(string connectionString, string? taskHubName = null)
+        /// <param name="schemaName">Optional. The name of the schema. If not specified, the default 'dt' value will be used.</param>
+        public SqlOrchestrationServiceSettings(string connectionString, string? taskHubName = null, string? schemaName = null)
         {
             if (string.IsNullOrEmpty(connectionString))
             {
@@ -27,6 +28,7 @@ namespace DurableTask.SqlServer
             }
 
             this.TaskHubName = taskHubName ?? "default";
+            this.SchemaName = schemaName ?? "dt";
 
             var builder = new SqlConnectionStringBuilder(connectionString)
             {
@@ -61,6 +63,12 @@ namespace DurableTask.SqlServer
         /// </summary>
         [JsonProperty("taskHubName")]
         public string TaskHubName { get; }
+        
+        /// <summary>
+        /// Gets the name of the schema.
+        /// </summary>
+        [JsonProperty("schemaName")]
+        public string SchemaName { get; }
 
         /// <summary>
         /// Gets or sets the name of the app. Used for logging purposes.

--- a/src/DurableTask.SqlServer/SqlTypes/HistoryEventSqlType.cs
+++ b/src/DurableTask.SqlServer/SqlTypes/HistoryEventSqlType.cs
@@ -60,10 +60,11 @@ namespace DurableTask.SqlServer.SqlTypes
             IEnumerable<HistoryEvent> newEventCollection,
             OrchestrationInstance instance,
             int nextSequenceNumber,
-            EventPayloadMap eventPayloadMap)
+            EventPayloadMap eventPayloadMap,
+            string schemaName)
         {
             SqlParameter param = commandParameters.Add(paramName, SqlDbType.Structured);
-            param.TypeName = "dt.HistoryEvents";
+            param.TypeName = $"{schemaName}.HistoryEvents";
             param.Value = ToHistoryEventsParameter(newEventCollection, instance, nextSequenceNumber, eventPayloadMap);
             return param;
         }

--- a/src/DurableTask.SqlServer/SqlTypes/MessageIdSqlType.cs
+++ b/src/DurableTask.SqlServer/SqlTypes/MessageIdSqlType.cs
@@ -11,8 +11,6 @@ namespace DurableTask.SqlServer.SqlTypes
 
     static class MessageIdSqlType
     {
-        const string SqlTypeName = "dt.MessageIDs";
-
         static readonly SqlMetaData[] MessageIdSchema = new SqlMetaData[]
         {
             // IMPORTANT: The order and schema of these items must always match the order of the SQL type in logic.sql
@@ -23,10 +21,11 @@ namespace DurableTask.SqlServer.SqlTypes
         public static SqlParameter AddMessageIdParameter(
             this SqlParameterCollection commandParameters,
             string paramName,
-            IEnumerable<TaskMessage> messageCollection)
+            IEnumerable<TaskMessage> messageCollection,
+            string schemaName)
         {
             SqlParameter param = commandParameters.Add(paramName, SqlDbType.Structured);
-            param.TypeName = SqlTypeName;
+            param.TypeName = $"{schemaName}.MessageIDs";
             param.Value = ToMessageIDsParameter(messageCollection);
             return param;
         }
@@ -34,10 +33,11 @@ namespace DurableTask.SqlServer.SqlTypes
         public static SqlParameter AddMessageIdParameter(
             this SqlParameterCollection commandParameters,
             string paramName,
-            TaskMessage message)
+            TaskMessage message,
+            string schemaName)
         {
             SqlParameter param = commandParameters.Add(paramName, SqlDbType.Structured);
-            param.TypeName = SqlTypeName;
+            param.TypeName = $"{schemaName}.MessageIDs";
             param.Value = ToMessageIDsParameter(message);
             return param;
         }

--- a/src/DurableTask.SqlServer/SqlTypes/OrchestrationEventSqlType.cs
+++ b/src/DurableTask.SqlServer/SqlTypes/OrchestrationEventSqlType.cs
@@ -14,8 +14,6 @@ namespace DurableTask.SqlServer.SqlTypes
 
     static class OrchestrationEventSqlType
     {
-        const string SqlTypeName = "dt.OrchestrationEvents";
-
         static readonly SqlMetaData[] OrchestrationEventSchema = new SqlMetaData[]
         {
             // IMPORTANT: The order and schema of these items must always match the order of the SQL type in logic.sql
@@ -58,10 +56,11 @@ namespace DurableTask.SqlServer.SqlTypes
             IList<TaskMessage> orchestratorMessages,
             IList<TaskMessage> timerMessages,
             TaskMessage continuedAsNewMessage,
-            EventPayloadMap eventPayloadMap)
+            EventPayloadMap eventPayloadMap,
+            string schemaName)
         {
             SqlParameter param = commandParameters.Add(paramName, SqlDbType.Structured);
-            param.TypeName = SqlTypeName;
+            param.TypeName = $"{schemaName}.OrchestrationEvents";
 
             IEnumerable<TaskMessage> messages = orchestratorMessages.Union(timerMessages);
             if (continuedAsNewMessage != null)
@@ -76,10 +75,11 @@ namespace DurableTask.SqlServer.SqlTypes
         public static SqlParameter AddOrchestrationEventsParameter(
             this SqlParameterCollection commandParameters,
             string paramName,
-            TaskMessage message)
+            TaskMessage message,
+            string schemaName)
         {
             SqlParameter param = commandParameters.Add(paramName, SqlDbType.Structured);
-            param.TypeName = SqlTypeName;
+            param.TypeName = $"{schemaName}.OrchestrationEvents";
             param.Value = ToOrchestrationMessageParameter(message);
             return param;
         }

--- a/src/DurableTask.SqlServer/SqlTypes/TaskEventSqlType.cs
+++ b/src/DurableTask.SqlServer/SqlTypes/TaskEventSqlType.cs
@@ -14,8 +14,6 @@ namespace DurableTask.SqlServer.SqlTypes
 
     static class TaskEventSqlType
     {
-        const string SqlTypeName = "dt.TaskEvents";
-
         static readonly SqlMetaData[] TaskEventSchema = new SqlMetaData[]
         {
             // IMPORTANT: Must be kept in sync with the database schema
@@ -54,10 +52,11 @@ namespace DurableTask.SqlServer.SqlTypes
             this SqlParameterCollection commandParameters,
             string paramName,
             IList<TaskMessage> outboundMessages,
-            EventPayloadMap eventPayloadMap)
+            EventPayloadMap eventPayloadMap,
+            string schemaName)
         {
             SqlParameter param = commandParameters.Add(paramName, SqlDbType.Structured);
-            param.TypeName = SqlTypeName;
+            param.TypeName = $"{schemaName}.TaskEvents";
             param.Value = ToTaskMessagesParameter(outboundMessages, eventPayloadMap);
             return param;
         }
@@ -65,10 +64,11 @@ namespace DurableTask.SqlServer.SqlTypes
         public static SqlParameter AddTaskEventsParameter(
             this SqlParameterCollection commandParameters,
             string paramName,
-            TaskMessage message)
+            TaskMessage message,
+            string schemaName)
         {
             SqlParameter param = commandParameters.Add(paramName, SqlDbType.Structured);
-            param.TypeName = SqlTypeName;
+            param.TypeName = $"{schemaName}.TaskEvents";
             param.Value = ToTaskMessageParameter(message);
             return param;
         }

--- a/src/DurableTask.SqlServer/SqlUtils.cs
+++ b/src/DurableTask.SqlServer/SqlUtils.cs
@@ -26,7 +26,7 @@ namespace DurableTask.SqlServer
         {
             return reader.IsDBNull(columnIndex) ? null : reader.GetString(columnIndex);
         }
-
+        
         public static TaskMessage GetTaskMessage(this DbDataReader reader)
         {
             return new TaskMessage
@@ -369,7 +369,8 @@ namespace DurableTask.SqlServer
         public static SqlParameter AddInstanceIDsParameter(
             this SqlParameterCollection commandParameters,
             string paramName,
-            IEnumerable<string> instanceIds)
+            IEnumerable<string> instanceIds,
+            string schemaName)
         {
             static IEnumerable<SqlDataRecord> GetInstanceIdRecords(IEnumerable<string> instanceIds)
             {
@@ -382,7 +383,7 @@ namespace DurableTask.SqlServer
             }
 
             SqlParameter param = commandParameters.Add(paramName, SqlDbType.Structured);
-            param.TypeName = "dt.InstanceIDs";
+            param.TypeName = $"{schemaName}.InstanceIDs";
             param.Value = instanceIds.Any() ? GetInstanceIdRecords(instanceIds) : null;
             return param;
         }

--- a/src/common.props
+++ b/src/common.props
@@ -16,8 +16,8 @@
   <!-- Version settings: https://andrewlock.net/version-vs-versionsuffix-vs-packageversion-what-do-they-all-mean/ -->
   <PropertyGroup>
     <MajorVersion>1</MajorVersion>
-    <MinorVersion>0</MinorVersion>
-    <PatchVersion>1</PatchVersion>
+    <MinorVersion>1</MinorVersion>
+    <PatchVersion>0</PatchVersion>
     <VersionPrefix>$(MajorVersion).$(MinorVersion).$(PatchVersion)</VersionPrefix>
     <AssemblyVersion>$(MajorVersion).$(MinorVersion).0.0</AssemblyVersion>
     <FileVersion>$(VersionPrefix).0</FileVersion>

--- a/src/common.props
+++ b/src/common.props
@@ -17,7 +17,7 @@
   <PropertyGroup>
     <MajorVersion>1</MajorVersion>
     <MinorVersion>0</MinorVersion>
-    <PatchVersion>0</PatchVersion>
+    <PatchVersion>1</PatchVersion>
     <VersionPrefix>$(MajorVersion).$(MinorVersion).$(PatchVersion)</VersionPrefix>
     <AssemblyVersion>$(MajorVersion).$(MinorVersion).0.0</AssemblyVersion>
     <FileVersion>$(VersionPrefix).0</FileVersion>


### PR DESCRIPTION
Added multi-schema support for DTF Sql-Server as requested in #105.  Following the plan suggested by George, I've refactored the code to be able to use a custom schema name instead of the hardcoded "dt" as such:

-  Added a new property in SqlOrchestrationServiceSettings called SchemaName, defaulting to "dt"
- Modified all the scripts under /Scripts by replacing "dt" with a placeholder called {{SchemaNamePlaceholder}} and also added explicit table accessing by specifying the schemaName for each access.
- Added a new parameter to all xxxParameter methods from the SqlTypes files under /SqlTypes and from SqlUtils, called schemaName to be able to remove the hardcoded "dt".
- Modified the SqlDbManager such that before executing the script commands, it will replace the schemaNamePlaceholder with the schema name from the settings. I found it to be the easiest way to replace the "dt" from the script files without rewriting the whole script. There is still room for improvement on this part and any suggestion is highly appreciated.
- Added a new test file to test if the program is able to create and delete a schema with a custom name.
- Modified the test files such that it will be able to test custom table names by adding a new parameter to the test method and replacing all the occurrences of "dt" with said parameter value.

As such, this version is backwards compatible as far as I know and is able to do all the operations with custom schema names.

Co-Authored-By: George Moldovan <george.moldovan@uipath.com>