### PR TITLE
Updating SqlDurabilityProviderStartup to implement IWebJobsStartup

### DIFF
--- a/src/DurableTask.SqlServer.AzureFunctions/DurableTask.SqlServer.AzureFunctions.csproj
+++ b/src/DurableTask.SqlServer.AzureFunctions/DurableTask.SqlServer.AzureFunctions.csproj
@@ -16,7 +16,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Azure.Functions.Extensions" Version="1.0.0" />
     <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.DurableTask" Version="2.7.*" />
   </ItemGroup>
 

--- a/src/DurableTask.SqlServer.AzureFunctions/SqlDurabilityProviderStartup.cs
+++ b/src/DurableTask.SqlServer.AzureFunctions/SqlDurabilityProviderStartup.cs
@@ -1,7 +1,6 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-// Reference: https://docs.microsoft.com/en-us/azure/azure-functions/functions-dotnet-dependency-injection
 [assembly: Microsoft.Azure.WebJobs.Hosting.WebJobsStartup(
     typeof(DurableTask.SqlServer.AzureFunctions.SqlDurabilityProviderStartup))]
 

--- a/src/DurableTask.SqlServer.AzureFunctions/SqlDurabilityProviderStartup.cs
+++ b/src/DurableTask.SqlServer.AzureFunctions/SqlDurabilityProviderStartup.cs
@@ -1,19 +1,21 @@
-﻿// Copyright (c) Microsoft Corporation.
+// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
 // Reference: https://docs.microsoft.com/en-us/azure/azure-functions/functions-dotnet-dependency-injection
-[assembly: Microsoft.Azure.Functions.Extensions.DependencyInjection.FunctionsStartup(
+[assembly: Microsoft.Azure.WebJobs.Hosting.WebJobsStartup(
     typeof(DurableTask.SqlServer.AzureFunctions.SqlDurabilityProviderStartup))]
 
 namespace DurableTask.SqlServer.AzureFunctions
 {
-    using Microsoft.Azure.Functions.Extensions.DependencyInjection;
+    using Microsoft.Azure.WebJobs;
     using Microsoft.Azure.WebJobs.Extensions.DurableTask;
+    using Microsoft.Azure.WebJobs.Hosting;
     using Microsoft.Extensions.DependencyInjection;
 
-    class SqlDurabilityProviderStartup : FunctionsStartup
+
+    class SqlDurabilityProviderStartup : IWebJobsStartup
     {
-        public override void Configure(IFunctionsHostBuilder builder)
+        public void Configure(IWebJobsBuilder builder)
         {
             builder.Services.AddSingleton<IDurabilityProviderFactory, SqlDurabilityProviderFactory>();
         }


### PR DESCRIPTION
Updating SqlDurabilityProviderStartup to implement IWebJobsStartup instead of FunctionsStartup. Similar PR merged in another Durable extension - https://github.com/microsoft/durabletask-netherite/pull/186