### PR TITLE
Rename SchemaNamePlaceholder and add Azure Functions support

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -4,13 +4,13 @@ The Microsoft SQL Provider for the Durable Task Framework (DTFx) and Durable Fun
 
 ## Table schema
 
-The DTFx schema is provisioned in the target database when the orchestration service is created. When using DTFx, this happens during the call to `SqlOrchestrationService.CreateAsync()`. When using Durable Functions, this happens automatically when the Functions host first starts up. It is not necessary to run any database provisioning scripts manually.
+The DTFx schema is provisioned in the target database when the orchestration service is created. When using DTFx, this happens during the call to `SqlOrchestrationService.CreateAsync()`. When using Durable Functions, this happens automatically when the Functions host first starts up. It's not strictly necessary to run any database provisioning scripts manually. However, this requires that the connection used by the app has appropriate permissions to create schema objects. Otherwise, the schema will need to be provisioned into the database ahead of time by a user with appropriate privileges.
 
-The database provisioning scripts are compiled directly into the main provider DLL file as assembly resources. You can view these scripts in GitHub [here](https://github.com/microsoft/durabletask-mssql/tree/main/src/DurableTask.SqlServer/Scripts). All tables, views, and stored procedures are provisioned under a default `dt` schema to distinguish it from any existing schema in the database, unless another schema name is provided at creation time.
-
-As mentioned, the schema can also have a custom name, in which case the following information regarding tables and scripts will have the `dt` replaced with `{customSchemaName}`.
+The database provisioning scripts are compiled directly into the main provider DLL file as assembly resources. You can view these scripts in GitHub [here](https://github.com/microsoft/durabletask-mssql/tree/main/src/DurableTask.SqlServer/Scripts). Note that these scripts contain schema name placeholders (`__SchemaNamePlaceholder__`) which are replaced at runtime when the scripts are executed. By default, all tables, views, and stored procedures are provisioned under a `dt` schema to distinguish it from any existing schema in the database.
 
 ![Schema](media/schema.png)
+
+To support multiple tenants in the same database, a custom schema name can be configured, in which case the database objects will be created under the custom name instead of `dt`. See the [Multitenancy](multitenancy.md) documentation for more details.
 
 The tables in the default version are as follows:
 

--- a/docs/multitenancy.md
+++ b/docs/multitenancy.md
@@ -4,36 +4,23 @@ This article describes the multitenancy features of the Durable Task SQL backend
 
 ## Overview
 
-One of the goals for the Microsoft SQL provider for the Durable Task Framework (DTFx) is to enable [multi-tenant deployments](https://en.wikipedia.org/wiki/Multitenancy) with multiple apps sharing the same database. This is often valuable when your organization has many small apps but prefers to manage only a single backend database. When multitenancy is enabled, different apps connect to a shared database using different database login credentials. Database administrators will be able to query data across all tenants but individual apps will only have access to their own data.
+One of the goals for the Microsoft SQL provider for the Durable Task Framework (DTFx) is to enable [multi-tenant deployments](https://en.wikipedia.org/wiki/Multitenancy) with multiple apps sharing the same database. This is often valuable when your organization has many small apps but prefers to manage only a single backend database. When multitenancy is enabled, different apps connect to a shared database using different database login credentials and each app will only have access to its own data.
 
-Multitenancy works by isolating each app into a separate [task hub](taskhubs.md). The current task hub is determined by the credentials used to log into the database. For example, if your app connects to a Microsoft SQL database using **dbo** credentials (the default, built-in admin user for most databases), then the name of the connected task hub will be "dbo". Task hubs provide data isolation, ensuring that two users in the same database will not be able to access each other's data.
+Note that there are two modes for multi-tenancy, _shared schema_ mode and _isolated schema_ mode.
 
-Another layer of multitenancy is added by the multi-schema support. This increases reliability and security for multiple services that are independently deployed in the same database, allowing each service control over their own schema and further isolation between service's data.
+?> Multitenancy in the current version of the SQL provider prevents one tenant from accessing data that belongs to another tenant. However, it doesn't provide isolation for shared resources within a database, such as memory or CPU. If this kind of strict resource isolation is required, then each tenant should instead be separated into its own database.
 
-?> Task hub isolation in the current version of the SQL provider prevents one tenant from accessing data that belongs to another tenant. However, it doesn't impose any restrictions on data volumes or database CPU usage. If this kind of strict resource isolation is required, then each tenant should instead be separated into their own database.
+## Shared schema mode
 
-## Managing custom schemas
+Shared schema multitenancy works by isolating each app into a separate [task hub](taskhubs.md). The current task hub is determined by the credentials used to log into the database. For example, if your app connects to a Microsoft SQL database using **dbo** credentials (the default, built-in admin user for most databases), then the name of the connected task hub will be "dbo". Task hubs provide data isolation, ensuring that two users in the same database will not be able to access each other's data.
 
-For self-hosted DTFx app that opt for custom schema name, you can configure the schema name directly in the `SqlOrchestrationServiceSettings` class.
+Shared schema mode is available starting in the v1.0.0 version of the MSSQL storage provider. The benefit of this mode is that fewer database objects need to be created in the database. It also enables high-privileged user accounts to write SQL queries that span multiple tenants. The downside of this mode is that schema updates must be applied to all tenants at once, which increases the risk associated with schema upgrades.
 
-```csharp
-var settings = new SqlOrchestrationServiceSettings
-{
-    SchemaName = "customSchemaName",
-    TaskHubConnectionString = Environment.GetEnvironmentVariable("SQLDB_Connection"),
-};
-```
+### Enabling shared schema multitenancy
 
-If no schema name name is explicitly configured, the default value `dt` will be used. Note that changing the value requires a restart of the app for the change to take effect.
+Shared schema multitenancy is enabled by default. When using shared schema multitenacy, you do not (and should not) configure a task hub name in code or configuration. Instead, the SQL login username (from the [`USER_NAME()`](https://docs.microsoft.com/sql/t-sql/functions/user-name-transact-sql) SQL function) is automatically used as the task hub name (for example, `dbo`).
 
-
-## Enabling multitenancy
-
-Multitenancy is enabled by default. In this mode, database administrators provide individual app owners with SQL credentials known only to them, and each credential maps to an isolated task hub within the database.
-
-When using multitenacy mode, you do not (and should not) configure a task hub name in code or configuration. Instead, the SQL login username (from the [`USER_NAME()`](https://docs.microsoft.com/sql/t-sql/functions/user-name-transact-sql) SQL function) is automatically used as the task hub name (for example, `dbo`).
-
-The following T-SQL can be used to _disable_ multitenancy:
+The following T-SQL can be used to _disable_ shared schema multitenancy:
 
 ```sql
 -- Disable multi-tenancy mode
@@ -42,18 +29,53 @@ EXECUTE dt.SetGlobalSetting @Name='TaskHubMode', @Value=0
 
 The value `0` instructs all runtime stored procedures to instead infer the current task hub from the [`APP_NAME()`](https://docs.microsoft.com/sql/t-sql/functions/app-name-transact-sql) SQL function. The configured connection string is automatically modified to ensure that `APP_NAME()` is set to the explicitly configured name of the task hub, or `default` if no task hub name is configured.
 
-Multitenancy can be re-enabled using the following T-SQL:
+Shared schema multitenancy can be re-enabled using the following T-SQL:
 
 ```sql
 -- Enable multi-tenancy mode
 EXECUTE dt.SetGlobalSetting @Name='TaskHubMode', @Value=1
 ```
 
-!> Enabling or disabling multitenancy may result in subsequent logins using a different task hub name. Any orchestrations or entities created using a previous task hub names will not be visible to an app that switches to a new task hub name. Switching between task hub modes must therefore be done with careful planning and should not be done while apps are actively running.
+!> Enabling or disabling shared schema multitenancy may result in subsequent logins using a different task hub name. Any orchestrations or entities created using a previous task hub names will not be visible to an app that switches to a new task hub name. Switching between task hub modes must therefore be done with careful planning and should not be done while apps are actively running.
+
+## Isolated schema mode
+
+Isolated schema mode provisions an independent set of database objects (tables, views, stored procedures, etc.) for each tenant. This increases reliability and security for multiple services that are independently deployed in the same database, allowing each service control over their own schema and further isolation between service's data. For example, it's also possible to provide a degree of storage isolation for tables of particular tenants using [SQL Server Filegroups](https://docs.microsoft.com/sql/relational-databases/databases/database-files-and-filegroups?view=sql-server-ver16) (note that there is no automatic support for this). Isolated schema mode also allows schema versions to be managed independently for each tenant.
+
+Isolated schema mode is available starting in the v1.1.0 release of the MSSQL storage provider.
+
+### Managing custom schemas
+
+For Azure Functions apps, you can configure a custom schema name in the Azure Functions **host.json** file.
+
+```json
+{
+  "version": "2.0",
+  "extensions": {
+    "durableTask": {
+      "storageProvider": {
+        "type": "mssql",
+        "connectionStringName": "SQLDB_Connection",
+        "schemaName": "MyCustomSchemaName"
+      }
+    }
+  }
+}
+```
+
+For self-hosted DTFx app that opt for custom schema name, you can configure the schema name directly in the `SqlOrchestrationServiceSettings` constructor.
+
+```csharp
+var settings = new SqlOrchestrationServiceSettings(
+    connectionString: Environment.GetEnvironmentVariable("SQLDB_Connection"),
+    schemaName: "MyCustomSchemaName");
+```
+
+If no schema name name is explicitly configured, the default value `dt` will be used. Note that changing the value requires a restart of the app for the change to take effect.
 
 ## Managing user credentials
 
-Once multitenancy is enabled, each tenant must be given its own login and user ID for the target database. To ensure that each tenant can only access its own data, you should add each user to the `dt_runtime` role that is created automatically by the database setup scripts.
+Once multitenancy is enabled, each tenant must be given its own login and user ID for the target database. To ensure that each tenant can only access its own data, you should add each user to the `{schema_name}_runtime` role that is created automatically by the database setup scripts. By default, this is `dt_runtime` since the default schema name is `dt`.
 
 The following SQL statements illustrate how this can be done for a SQL database that supports username/password authentication.
 
@@ -67,7 +89,7 @@ CREATE USER {username} FOR LOGIN {login_name}
 GO
 
 -- add the user to the restricted dt_runtime role
-ALTER ROLE dt_runtime ADD MEMBER {username}
+ALTER ROLE {schema_name}_runtime ADD MEMBER {username}
 GO
 ```
 

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -21,7 +21,7 @@ dotnet add package Microsoft.DurableTask.SqlServer.AzureFunctions --prerelease
 JavaScript, Python, and PowerShell projects can add the [Microsoft.DurableTask.SqlServer.AzureFunction](https://www.nuget.org/packages/Microsoft.DurableTask.SqlServer.AzureFunctions) package by running the following `func` CLI command. Note that in addition to the Azure Functions Core Tools, you must also have a recent [.NET SDK](https://dotnet.microsoft.com/download) installed locally.
 
 ```bash
-func extensions install -p Microsoft.DurableTask.SqlServer.AzureFunctions -v 1.0.0
+func extensions install -p Microsoft.DurableTask.SqlServer.AzureFunctions -v 1.1.0
 ```
 
 ?> Check [here](https://www.nuget.org/packages/Microsoft.DurableTask.SqlServer.AzureFunctions) to see if newer versions of the SQL provider package are available, and update the above command to reference the latest available version.
@@ -52,7 +52,8 @@ You can configure the Durable SQL provider by updating the `extensions/durableTa
         "type": "mssql",
         "connectionStringName": "SQLDB_Connection",
         "taskEventLockTimeout": "00:02:00",
-        "createDatabaseIfNotExists": true
+        "createDatabaseIfNotExists": true,
+        "schemaName": null
       }
     }
   }
@@ -75,6 +76,8 @@ The `connectionStringName` setting is required and must be set to the name of th
   }
 }
 ```
+
+The `schemaName` settings is an optional string value that defaults to `null`. This property is required when database objects are provisioned under a custom schema name. If not specified, a schema name of `dt` is assumed. See the [Multitenancy](multitenancy.md) documentation for more details.
 
 To enable diagnostic logging, you can also add the following `logging` configuration to your **host.json** file:
 

--- a/src/DurableTask.SqlServer.AzureFunctions/SqlDurabilityOptions.cs
+++ b/src/DurableTask.SqlServer.AzureFunctions/SqlDurabilityOptions.cs
@@ -28,6 +28,9 @@ namespace DurableTask.SqlServer.AzureFunctions
         [JsonProperty("createDatabaseIfNotExists")]
         public bool CreateDatabaseIfNotExists { get; set; }
 
+        [JsonProperty("schemaName")]
+        public string? SchemaName { get; set; }
+
         internal ILoggerFactory LoggerFactory { get; set; } = NullLoggerFactory.Instance;
         
         internal SqlOrchestrationServiceSettings GetOrchestrationServiceSettings(
@@ -56,7 +59,7 @@ namespace DurableTask.SqlServer.AzureFunctions
                 throw new ArgumentException("The provided connection string is invalid.", e);
             }
 
-            var settings = new SqlOrchestrationServiceSettings(connectionStringSection.Value, this.TaskHubName)
+            var settings = new SqlOrchestrationServiceSettings(connectionStringSection.Value, this.TaskHubName, this.SchemaName)
             {
                 CreateDatabaseIfNotExists = this.CreateDatabaseIfNotExists,
                 LoggerFactory = this.LoggerFactory,

--- a/src/DurableTask.SqlServer/DurableTask.SqlServer.csproj
+++ b/src/DurableTask.SqlServer/DurableTask.SqlServer.csproj
@@ -21,7 +21,7 @@
   </ItemGroup>
   
   <ItemGroup>
-    <PackageReference Include="Microsoft.Azure.DurableTask.Core" Version="2.9.0" />
+    <PackageReference Include="Microsoft.Azure.DurableTask.Core" Version="2.10.0" />
     <PackageReference Include="Microsoft.Data.SqlClient" Version="3.0.0" />
     <PackageReference Include="SemanticVersion" Version="2.1.0" />
     <PackageReference Include="System.Threading.Channels" Version="4.7.1" />

--- a/src/DurableTask.SqlServer/Scripts/drop-schema.sql
+++ b/src/DurableTask.SqlServer/Scripts/drop-schema.sql
@@ -2,60 +2,60 @@
 -- Licensed under the MIT License.
 
 -- Functions
-DROP FUNCTION IF EXISTS {{SchemaNamePlaceholder}}.CurrentTaskHub
-DROP FUNCTION IF EXISTS {{SchemaNamePlaceholder}}.GetScaleMetric
-DROP FUNCTION IF EXISTS {{SchemaNamePlaceholder}}.GetScaleRecommendation
+DROP FUNCTION IF EXISTS __SchemaNamePlaceholder__.CurrentTaskHub
+DROP FUNCTION IF EXISTS __SchemaNamePlaceholder__.GetScaleMetric
+DROP FUNCTION IF EXISTS __SchemaNamePlaceholder__.GetScaleRecommendation
 
 -- Views
-DROP VIEW IF EXISTS {{SchemaNamePlaceholder}}.vHistory
-DROP VIEW IF EXISTS {{SchemaNamePlaceholder}}.vInstances
+DROP VIEW IF EXISTS __SchemaNamePlaceholder__.vHistory
+DROP VIEW IF EXISTS __SchemaNamePlaceholder__.vInstances
 
 -- Public Sprocs
-DROP PROCEDURE IF EXISTS {{SchemaNamePlaceholder}}.CreateInstance
-DROP PROCEDURE IF EXISTS {{SchemaNamePlaceholder}}.GetInstanceHistory
-DROP PROCEDURE IF EXISTS {{SchemaNamePlaceholder}}.QuerySingleOrchestration
-DROP PROCEDURE IF EXISTS {{SchemaNamePlaceholder}}.RaiseEvent
-DROP PROCEDURE IF EXISTS {{SchemaNamePlaceholder}}.SetGlobalSetting
-DROP PROCEDURE IF EXISTS {{SchemaNamePlaceholder}}.TerminateInstance
-DROP PROCEDURE IF EXISTS {{SchemaNamePlaceholder}}.PurgeInstanceStateByID
-DROP PROCEDURE IF EXISTS {{SchemaNamePlaceholder}}.PurgeInstanceStateByTime
+DROP PROCEDURE IF EXISTS __SchemaNamePlaceholder__.CreateInstance
+DROP PROCEDURE IF EXISTS __SchemaNamePlaceholder__.GetInstanceHistory
+DROP PROCEDURE IF EXISTS __SchemaNamePlaceholder__.QuerySingleOrchestration
+DROP PROCEDURE IF EXISTS __SchemaNamePlaceholder__.RaiseEvent
+DROP PROCEDURE IF EXISTS __SchemaNamePlaceholder__.SetGlobalSetting
+DROP PROCEDURE IF EXISTS __SchemaNamePlaceholder__.TerminateInstance
+DROP PROCEDURE IF EXISTS __SchemaNamePlaceholder__.PurgeInstanceStateByID
+DROP PROCEDURE IF EXISTS __SchemaNamePlaceholder__.PurgeInstanceStateByTime
 
 -- Private sprocs
-DROP PROCEDURE IF EXISTS {{SchemaNamePlaceholder}}._AddOrchestrationEvents
-DROP PROCEDURE IF EXISTS {{SchemaNamePlaceholder}}._CheckpointOrchestration
-DROP PROCEDURE IF EXISTS {{SchemaNamePlaceholder}}._CompleteTasks
-DROP PROCEDURE IF EXISTS {{SchemaNamePlaceholder}}._DiscardEventsAndUnlockInstance
-DROP PROCEDURE IF EXISTS {{SchemaNamePlaceholder}}._GetVersions
-DROP PROCEDURE IF EXISTS {{SchemaNamePlaceholder}}._LockNextOrchestration
-DROP PROCEDURE IF EXISTS {{SchemaNamePlaceholder}}._LockNextTask
-DROP PROCEDURE IF EXISTS {{SchemaNamePlaceholder}}._QueryManyOrchestrations
-DROP PROCEDURE IF EXISTS {{SchemaNamePlaceholder}}._RenewOrchestrationLocks
-DROP PROCEDURE IF EXISTS {{SchemaNamePlaceholder}}._RenewTaskLocks
-DROP PROCEDURE IF EXISTS {{SchemaNamePlaceholder}}._UpdateVersion
-DROP PROCEDURE IF EXISTS {{SchemaNamePlaceholder}}._RewindInstance
-DROP PROCEDURE IF EXISTS {{SchemaNamePlaceholder}}._RewindInstanceRecursive
+DROP PROCEDURE IF EXISTS __SchemaNamePlaceholder__._AddOrchestrationEvents
+DROP PROCEDURE IF EXISTS __SchemaNamePlaceholder__._CheckpointOrchestration
+DROP PROCEDURE IF EXISTS __SchemaNamePlaceholder__._CompleteTasks
+DROP PROCEDURE IF EXISTS __SchemaNamePlaceholder__._DiscardEventsAndUnlockInstance
+DROP PROCEDURE IF EXISTS __SchemaNamePlaceholder__._GetVersions
+DROP PROCEDURE IF EXISTS __SchemaNamePlaceholder__._LockNextOrchestration
+DROP PROCEDURE IF EXISTS __SchemaNamePlaceholder__._LockNextTask
+DROP PROCEDURE IF EXISTS __SchemaNamePlaceholder__._QueryManyOrchestrations
+DROP PROCEDURE IF EXISTS __SchemaNamePlaceholder__._RenewOrchestrationLocks
+DROP PROCEDURE IF EXISTS __SchemaNamePlaceholder__._RenewTaskLocks
+DROP PROCEDURE IF EXISTS __SchemaNamePlaceholder__._UpdateVersion
+DROP PROCEDURE IF EXISTS __SchemaNamePlaceholder__._RewindInstance
+DROP PROCEDURE IF EXISTS __SchemaNamePlaceholder__._RewindInstanceRecursive
 
 -- Tables
-DROP TABLE IF EXISTS {{SchemaNamePlaceholder}}.Versions
-DROP TABLE IF EXISTS {{SchemaNamePlaceholder}}.NewTasks
-DROP TABLE IF EXISTS {{SchemaNamePlaceholder}}.NewEvents
-DROP TABLE IF EXISTS {{SchemaNamePlaceholder}}.History
-DROP TABLE IF EXISTS {{SchemaNamePlaceholder}}.Instances
-DROP TABLE IF EXISTS {{SchemaNamePlaceholder}}.Payloads
-DROP TABLE IF EXISTS {{SchemaNamePlaceholder}}.GlobalSettings
+DROP TABLE IF EXISTS __SchemaNamePlaceholder__.Versions
+DROP TABLE IF EXISTS __SchemaNamePlaceholder__.NewTasks
+DROP TABLE IF EXISTS __SchemaNamePlaceholder__.NewEvents
+DROP TABLE IF EXISTS __SchemaNamePlaceholder__.History
+DROP TABLE IF EXISTS __SchemaNamePlaceholder__.Instances
+DROP TABLE IF EXISTS __SchemaNamePlaceholder__.Payloads
+DROP TABLE IF EXISTS __SchemaNamePlaceholder__.GlobalSettings
 
 -- Custom types
-DROP TYPE IF EXISTS {{SchemaNamePlaceholder}}.HistoryEvents
-DROP TYPE IF EXISTS {{SchemaNamePlaceholder}}.InstanceIDs
-DROP TYPE IF EXISTS {{SchemaNamePlaceholder}}.MessageIDs
-DROP TYPE IF EXISTS {{SchemaNamePlaceholder}}.OrchestrationEvents
-DROP TYPE IF EXISTS {{SchemaNamePlaceholder}}.TaskEvents
+DROP TYPE IF EXISTS __SchemaNamePlaceholder__.HistoryEvents
+DROP TYPE IF EXISTS __SchemaNamePlaceholder__.InstanceIDs
+DROP TYPE IF EXISTS __SchemaNamePlaceholder__.MessageIDs
+DROP TYPE IF EXISTS __SchemaNamePlaceholder__.OrchestrationEvents
+DROP TYPE IF EXISTS __SchemaNamePlaceholder__.TaskEvents
 
 -- This must be the last DROP statement related to schema
-DROP SCHEMA IF EXISTS {{SchemaNamePlaceholder}}
+DROP SCHEMA IF EXISTS __SchemaNamePlaceholder__
 
 -- Roles: all members have to be dropped before the role can be dropped
-DECLARE @rolename sysname = '{{SchemaNamePlaceholder}}_runtime';
+DECLARE @rolename sysname = '__SchemaNamePlaceholder___runtime';
 DECLARE @cmd AS nvarchar(MAX) = N'';
 SELECT @cmd = @cmd + '
     ALTER ROLE ' + QUOTENAME(@rolename) + ' DROP MEMBER ' + QUOTENAME(members.[name]) + ';'
@@ -67,4 +67,5 @@ FROM sys.database_role_members AS rolemembers
 WHERE roles.[name] = @rolename
 EXEC(@cmd);
 
-DROP ROLE IF EXISTS {{SchemaNamePlaceholder}}_runtime
+-- Using EXEC
+DROP ROLE IF EXISTS __SchemaNamePlaceholder___runtime

--- a/src/DurableTask.SqlServer/Scripts/logic.sql
+++ b/src/DurableTask.SqlServer/Scripts/logic.sql
@@ -1,7 +1,7 @@
 ﻿-- Copyright (c) Microsoft Corporation.
 -- Licensed under the MIT License.
 
-CREATE OR ALTER FUNCTION {{SchemaNamePlaceholder}}.CurrentTaskHub()
+CREATE OR ALTER FUNCTION __SchemaNamePlaceholder__.CurrentTaskHub()
     RETURNS varchar(50)
     WITH EXECUTE AS CALLER
 AS
@@ -9,7 +9,7 @@ BEGIN
     -- Task Hub modes:
     -- 0: Task hub names are set by the app
     -- 1: Task hub names are inferred from the user credential
-    DECLARE @taskHubMode sql_variant = (SELECT TOP 1 [Value] FROM {{SchemaNamePlaceholder}}.GlobalSettings WHERE [Name] = 'TaskHubMode');
+    DECLARE @taskHubMode sql_variant = (SELECT TOP 1 [Value] FROM GlobalSettings WHERE [Name] = 'TaskHubMode');
 
     DECLARE @taskHub varchar(150)
 
@@ -30,12 +30,12 @@ END
 GO
 
 
-CREATE OR ALTER FUNCTION {{SchemaNamePlaceholder}}.GetScaleMetric()
+CREATE OR ALTER FUNCTION __SchemaNamePlaceholder__.GetScaleMetric()
     RETURNS INT
     WITH EXECUTE AS CALLER
 AS
 BEGIN
-    DECLARE @taskHub varchar(50) = {{SchemaNamePlaceholder}}.CurrentTaskHub()
+    DECLARE @taskHub varchar(50) = __SchemaNamePlaceholder__.CurrentTaskHub()
     DECLARE @now datetime2 = SYSUTCDATETIME()
 
     DECLARE @liveInstances int = 0
@@ -44,9 +44,9 @@ BEGIN
     SELECT
         @liveInstances = COUNT(DISTINCT E.[InstanceID]),
         @liveTasks = COUNT(T.[InstanceID])
-    FROM {{SchemaNamePlaceholder}}.Instances I WITH (NOLOCK)
-        LEFT OUTER JOIN {{SchemaNamePlaceholder}}.NewEvents E WITH (NOLOCK) ON E.[TaskHub] = @taskHub AND E.[InstanceID] = I.[InstanceID]
-        LEFT OUTER JOIN {{SchemaNamePlaceholder}}.NewTasks T WITH (NOLOCK) ON T.[TaskHub] = @taskHub AND T.[InstanceID] = I.[InstanceID]
+    FROM Instances I WITH (NOLOCK)
+        LEFT OUTER JOIN NewEvents E WITH (NOLOCK) ON E.[TaskHub] = @taskHub AND E.[InstanceID] = I.[InstanceID]
+        LEFT OUTER JOIN NewTasks T WITH (NOLOCK) ON T.[TaskHub] = @taskHub AND T.[InstanceID] = I.[InstanceID]
     WHERE
         I.[TaskHub] = @taskHub
         AND I.[RuntimeStatus] IN ('Pending', 'Running')
@@ -57,12 +57,12 @@ END
 GO
 
 
-CREATE OR ALTER FUNCTION {{SchemaNamePlaceholder}}.GetScaleRecommendation(@MaxOrchestrationsPerWorker real, @MaxActivitiesPerWorker real)
+CREATE OR ALTER FUNCTION __SchemaNamePlaceholder__.GetScaleRecommendation(@MaxOrchestrationsPerWorker real, @MaxActivitiesPerWorker real)
     RETURNS INT
     WITH EXECUTE AS CALLER
 AS
 BEGIN
-    DECLARE @taskHub varchar(50) = {{SchemaNamePlaceholder}}.CurrentTaskHub()
+    DECLARE @taskHub varchar(50) = __SchemaNamePlaceholder__.CurrentTaskHub()
     DECLARE @now datetime2 = SYSUTCDATETIME()
 
     DECLARE @liveInstances int = 0
@@ -71,9 +71,9 @@ BEGIN
     SELECT
         @liveInstances = COUNT(DISTINCT E.[InstanceID]),
         @liveTasks = COUNT(T.[InstanceID])
-    FROM {{SchemaNamePlaceholder}}.Instances I WITH (NOLOCK)
-        LEFT OUTER JOIN {{SchemaNamePlaceholder}}.NewEvents E WITH (NOLOCK) ON E.[TaskHub] = @taskHub AND E.[InstanceID] = I.[InstanceID]
-        LEFT OUTER JOIN {{SchemaNamePlaceholder}}.NewTasks T WITH (NOLOCK) ON T.[TaskHub] = @taskHub AND T.[InstanceID] = I.[InstanceID]
+    FROM Instances I WITH (NOLOCK)
+        LEFT OUTER JOIN NewEvents E WITH (NOLOCK) ON E.[TaskHub] = @taskHub AND E.[InstanceID] = I.[InstanceID]
+        LEFT OUTER JOIN NewTasks T WITH (NOLOCK) ON T.[TaskHub] = @taskHub AND T.[InstanceID] = I.[InstanceID]
     WHERE
         I.[TaskHub] = @taskHub
         AND I.[RuntimeStatus] IN ('Pending', 'Running')
@@ -90,7 +90,7 @@ END
 GO
 
 
-CREATE OR ALTER VIEW {{SchemaNamePlaceholder}}.vInstances
+CREATE OR ALTER VIEW __SchemaNamePlaceholder__.vInstances
 AS
     SELECT
         I.[TaskHub],
@@ -102,24 +102,24 @@ AS
         I.[LastUpdatedTime],
         I.[CompletedTime],
         I.[RuntimeStatus],
-        (SELECT TOP 1 [Text] FROM {{SchemaNamePlaceholder}}.Payloads P WHERE
-            P.[TaskHub] = {{SchemaNamePlaceholder}}.CurrentTaskHub() AND
+        (SELECT TOP 1 [Text] FROM Payloads P WHERE
+            P.[TaskHub] = __SchemaNamePlaceholder__.CurrentTaskHub() AND
             P.[InstanceID] = I.[InstanceID] AND
             P.[PayloadID] = I.[CustomStatusPayloadID]) AS [CustomStatusText],
-        (SELECT TOP 1 [Text] FROM {{SchemaNamePlaceholder}}.Payloads P WHERE
-            P.[TaskHub] = {{SchemaNamePlaceholder}}.CurrentTaskHub() AND
+        (SELECT TOP 1 [Text] FROM Payloads P WHERE
+            P.[TaskHub] = __SchemaNamePlaceholder__.CurrentTaskHub() AND
             P.[InstanceID] = I.[InstanceID] AND
             P.[PayloadID] = I.[InputPayloadID]) AS [InputText],
-        (SELECT TOP 1 [Text] FROM {{SchemaNamePlaceholder}}.Payloads P WHERE 
-            P.[TaskHub] = {{SchemaNamePlaceholder}}.CurrentTaskHub() AND
+        (SELECT TOP 1 [Text] FROM Payloads P WHERE 
+            P.[TaskHub] = __SchemaNamePlaceholder__.CurrentTaskHub() AND
             P.[InstanceID] = I.[InstanceID] AND
             P.[PayloadID] = I.[OutputPayloadID]) AS [OutputText]
-    FROM {{SchemaNamePlaceholder}}.Instances I
+    FROM Instances I
     WHERE
-        I.[TaskHub] = {{SchemaNamePlaceholder}}.CurrentTaskHub()
+        I.[TaskHub] = __SchemaNamePlaceholder__.CurrentTaskHub()
 GO
 
-CREATE OR ALTER VIEW {{SchemaNamePlaceholder}}.vHistory
+CREATE OR ALTER VIEW __SchemaNamePlaceholder__.vHistory
 AS
     SELECT
         H.[TaskHub],
@@ -133,17 +133,17 @@ AS
 	    H.[Name],
 	    H.[RuntimeStatus],
         H.[VisibleTime],
-	    (SELECT TOP 1 [Text] FROM {{SchemaNamePlaceholder}}.Payloads P WHERE
-            P.[TaskHub] = {{SchemaNamePlaceholder}}.CurrentTaskHub() AND
+	    (SELECT TOP 1 [Text] FROM Payloads P WHERE
+            P.[TaskHub] = __SchemaNamePlaceholder__.CurrentTaskHub() AND
             P.[InstanceID] = H.[InstanceID] AND
             P.[PayloadID] = H.[DataPayloadID]) AS [Payload]
-    FROM {{SchemaNamePlaceholder}}.History H
+    FROM History H
     WHERE
-        H.[TaskHub] = {{SchemaNamePlaceholder}}.CurrentTaskHub()
+        H.[TaskHub] = __SchemaNamePlaceholder__.CurrentTaskHub()
 GO
 
 
-CREATE OR ALTER PROCEDURE {{SchemaNamePlaceholder}}.CreateInstance
+CREATE OR ALTER PROCEDURE __SchemaNamePlaceholder__.CreateInstance
     @Name varchar(300),
     @Version varchar(100) = NULL,
     @InstanceID varchar(100) = NULL,
@@ -152,7 +152,7 @@ CREATE OR ALTER PROCEDURE {{SchemaNamePlaceholder}}.CreateInstance
     @StartTime datetime2 = NULL
 AS
 BEGIN
-    DECLARE @TaskHub varchar(50) = {{SchemaNamePlaceholder}}.CurrentTaskHub()
+    DECLARE @TaskHub varchar(50) = __SchemaNamePlaceholder__.CurrentTaskHub()
     DECLARE @EventType varchar(30) = 'ExecutionStarted'
     DECLARE @RuntimeStatus varchar(30) = 'Pending'
 
@@ -167,7 +167,7 @@ BEGIN
 
         DECLARE @existingStatus varchar(30) = (
             SELECT TOP 1 existing.[RuntimeStatus]
-            FROM {{SchemaNamePlaceholder}}.Instances existing WITH (HOLDLOCK)
+            FROM Instances existing WITH (HOLDLOCK)
             WHERE [TaskHub] = @TaskHub AND [InstanceID] = @InstanceID
         )
 
@@ -182,7 +182,7 @@ BEGIN
             -- Purge the existing instance data so that it can be overwritten
             DECLARE @instancesToPurge InstanceIDs
             INSERT INTO @instancesToPurge VALUES (@InstanceID)
-            EXEC {{SchemaNamePlaceholder}}.PurgeInstanceStateByID @instancesToPurge
+            EXEC __SchemaNamePlaceholder__.PurgeInstanceStateByID @instancesToPurge
         END
 
         COMMIT TRANSACTION
@@ -204,11 +204,11 @@ BEGIN
     IF @InputText IS NOT NULL
     BEGIN
         SET @InputPayloadID = NEWID()
-        INSERT INTO {{SchemaNamePlaceholder}}.Payloads ([TaskHub], [InstanceID], [PayloadID], [Text])
+        INSERT INTO Payloads ([TaskHub], [InstanceID], [PayloadID], [Text])
         VALUES (@TaskHub, @InstanceID, @InputPayloadID, @InputText)
     END
 
-    INSERT INTO {{SchemaNamePlaceholder}}.Instances (
+    INSERT INTO Instances (
         [Name],
         [Version],
         [TaskHub],
@@ -226,7 +226,7 @@ BEGIN
         @InputPayloadID
     )
 
-    INSERT INTO {{SchemaNamePlaceholder}}.NewEvents (
+    INSERT INTO NewEvents (
         [Name],
         [TaskHub],
         [InstanceID],
@@ -250,19 +250,19 @@ END
 GO
 
 
-CREATE OR ALTER PROCEDURE {{SchemaNamePlaceholder}}.GetInstanceHistory
+CREATE OR ALTER PROCEDURE __SchemaNamePlaceholder__.GetInstanceHistory
     @InstanceID varchar(100),
     @GetInputsAndOutputs bit = 0
 AS
 BEGIN
-    DECLARE @TaskHub varchar(50) = {{SchemaNamePlaceholder}}.CurrentTaskHub()
+    DECLARE @TaskHub varchar(50) = __SchemaNamePlaceholder__.CurrentTaskHub()
     DECLARE @ParentInstanceID varchar(100)
     DECLARE @Version varchar(100)
     
     SELECT
         @ParentInstanceID = [ParentInstanceID],
         @Version = [Version]
-    FROM {{SchemaNamePlaceholder}}.Instances WHERE [InstanceID] = @InstanceID
+    FROM Instances WHERE [InstanceID] = @InstanceID
 
     SELECT
         H.[InstanceID],
@@ -280,8 +280,8 @@ BEGIN
         [PayloadID],
         @ParentInstanceID as [ParentInstanceID],
         @Version as [Version]
-    FROM {{SchemaNamePlaceholder}}.History H WITH (INDEX (PK_History))
-        LEFT OUTER JOIN {{SchemaNamePlaceholder}}.Payloads P ON
+    FROM History H WITH (INDEX (PK_History))
+        LEFT OUTER JOIN Payloads P ON
             P.[TaskHub] = @TaskHub AND
             P.[InstanceID] = H.[InstanceID] AND
             P.[PayloadID] = H.[DataPayloadID]
@@ -293,7 +293,7 @@ END
 GO
 
 
-CREATE OR ALTER PROCEDURE {{SchemaNamePlaceholder}}.RaiseEvent
+CREATE OR ALTER PROCEDURE __SchemaNamePlaceholder__.RaiseEvent
     @Name varchar(300),
     @InstanceID varchar(100) = NULL,
     @PayloadText varchar(MAX) = NULL,
@@ -302,16 +302,16 @@ AS
 BEGIN
     BEGIN TRANSACTION
 
-    DECLARE @TaskHub varchar(50) = {{SchemaNamePlaceholder}}.CurrentTaskHub()
+    DECLARE @TaskHub varchar(50) = __SchemaNamePlaceholder__.CurrentTaskHub()
 
     -- External event messages must target new instances or they must use
     -- the "auto start" instance ID format of @orchestrationname@identifier.
     IF NOT EXISTS (
         SELECT 1
-        FROM {{SchemaNamePlaceholder}}.Instances I
+        FROM Instances I
         WHERE [TaskHub] = @TaskHub AND I.[InstanceID] = @InstanceID)
     BEGIN
-        INSERT INTO {{SchemaNamePlaceholder}}.Instances (
+        INSERT INTO Instances (
             [TaskHub],
             [InstanceID],
             [ExecutionID],
@@ -337,11 +337,11 @@ BEGIN
     IF @PayloadText IS NOT NULL
     BEGIN
         SET @PayloadID = NEWID()
-        INSERT INTO {{SchemaNamePlaceholder}}.Payloads ([TaskHub], [InstanceID], [PayloadID], [Text])
+        INSERT INTO Payloads ([TaskHub], [InstanceID], [PayloadID], [Text])
         VALUES (@TaskHub, @InstanceID, @PayloadID, @PayloadText)
     END
 
-    INSERT INTO {{SchemaNamePlaceholder}}.NewEvents (
+    INSERT INTO NewEvents (
         [Name],
         [TaskHub],
         [InstanceID],
@@ -361,7 +361,7 @@ BEGIN
 END
 GO
 
-CREATE OR ALTER PROCEDURE {{SchemaNamePlaceholder}}.TerminateInstance
+CREATE OR ALTER PROCEDURE __SchemaNamePlaceholder__.TerminateInstance
     @InstanceID varchar(100),
     @Reason varchar(max) = NULL
 AS
@@ -373,11 +373,11 @@ BEGIN
     -- order across all stored procedures that execute within a transaction.
     -- Table order for this sproc: Instances --> (NewEvents --> Payloads --> NewEvents)  
 
-    DECLARE @TaskHub varchar(50) = {{SchemaNamePlaceholder}}.CurrentTaskHub()
+    DECLARE @TaskHub varchar(50) = __SchemaNamePlaceholder__.CurrentTaskHub()
 
     DECLARE @existingStatus varchar(30) = (
         SELECT TOP 1 existing.[RuntimeStatus]
-        FROM {{SchemaNamePlaceholder}}.Instances existing WITH (HOLDLOCK)
+        FROM Instances existing WITH (HOLDLOCK)
         WHERE [TaskHub] = @TaskHub AND [InstanceID] = @InstanceID
     )
 
@@ -388,7 +388,7 @@ BEGIN
     IF @existingStatus IN ('Pending', 'Running')
     BEGIN
         IF NOT EXISTS (
-            SELECT TOP (1) 1 FROM {{SchemaNamePlaceholder}}.NewEvents
+            SELECT TOP (1) 1 FROM NewEvents
             WHERE [TaskHub] = @TaskHub AND [InstanceID] = @InstanceID AND [EventType] = 'ExecutionTerminated'
         )
         BEGIN
@@ -398,11 +398,11 @@ BEGIN
             BEGIN
                 -- Note that we don't use the Reason column for the Reason with terminate events
                 SET @PayloadID = NEWID()
-                INSERT INTO {{SchemaNamePlaceholder}}.Payloads ([TaskHub], [InstanceID], [PayloadID], [Text])
+                INSERT INTO Payloads ([TaskHub], [InstanceID], [PayloadID], [Text])
                 VALUES (@TaskHub, @InstanceID, @PayloadID, @Reason)
             END
 
-            INSERT INTO {{SchemaNamePlaceholder}}.NewEvents (
+            INSERT INTO NewEvents (
                 [TaskHub],
                 [InstanceID],
                 [EventType],
@@ -420,20 +420,20 @@ END
 GO
 
 
-CREATE OR ALTER PROCEDURE {{SchemaNamePlaceholder}}.PurgeInstanceStateByID
+CREATE OR ALTER PROCEDURE __SchemaNamePlaceholder__.PurgeInstanceStateByID
     @InstanceIDs InstanceIDs READONLY
 AS
 BEGIN
-    DECLARE @TaskHub varchar(50) = {{SchemaNamePlaceholder}}.CurrentTaskHub()
+    DECLARE @TaskHub varchar(50) = __SchemaNamePlaceholder__.CurrentTaskHub()
 
     BEGIN TRANSACTION
 
-    DELETE FROM {{SchemaNamePlaceholder}}.NewEvents WHERE [TaskHub] = @TaskHub AND [InstanceID] IN (SELECT [InstanceID] FROM @InstanceIDs)
-    DELETE FROM {{SchemaNamePlaceholder}}.NewTasks  WHERE [TaskHub] = @TaskHub AND [InstanceID] IN (SELECT [InstanceID] FROM @InstanceIDs)
-    DELETE FROM {{SchemaNamePlaceholder}}.Instances WHERE [TaskHub] = @TaskHub AND [InstanceID] IN (SELECT [InstanceID] FROM @InstanceIDs)
+    DELETE FROM NewEvents WHERE [TaskHub] = @TaskHub AND [InstanceID] IN (SELECT [InstanceID] FROM @InstanceIDs)
+    DELETE FROM NewTasks  WHERE [TaskHub] = @TaskHub AND [InstanceID] IN (SELECT [InstanceID] FROM @InstanceIDs)
+    DELETE FROM Instances WHERE [TaskHub] = @TaskHub AND [InstanceID] IN (SELECT [InstanceID] FROM @InstanceIDs)
     DECLARE @deletedInstances int = @@ROWCOUNT
-    DELETE FROM {{SchemaNamePlaceholder}}.History  WHERE [TaskHub] = @TaskHub AND [InstanceID] IN (SELECT [InstanceID] FROM @InstanceIDs)
-    DELETE FROM {{SchemaNamePlaceholder}}.Payloads WHERE [TaskHub] = @TaskHub AND [InstanceID] IN (SELECT [InstanceID] FROM @InstanceIDs)
+    DELETE FROM History  WHERE [TaskHub] = @TaskHub AND [InstanceID] IN (SELECT [InstanceID] FROM @InstanceIDs)
+    DELETE FROM Payloads WHERE [TaskHub] = @TaskHub AND [InstanceID] IN (SELECT [InstanceID] FROM @InstanceIDs)
 
     COMMIT TRANSACTION
 
@@ -443,26 +443,26 @@ END
 GO
 
 
-CREATE OR ALTER PROCEDURE {{SchemaNamePlaceholder}}.PurgeInstanceStateByTime
+CREATE OR ALTER PROCEDURE __SchemaNamePlaceholder__.PurgeInstanceStateByTime
     @ThresholdTime datetime2,
     @FilterType tinyint = 0
 AS
 BEGIN
-    DECLARE @TaskHub varchar(50) = {{SchemaNamePlaceholder}}.CurrentTaskHub()
+    DECLARE @TaskHub varchar(50) = __SchemaNamePlaceholder__.CurrentTaskHub()
 
     DECLARE @instanceIDs InstanceIDs
 
     IF @FilterType = 0 -- created time
     BEGIN
         INSERT INTO @instanceIDs
-            SELECT [InstanceID] FROM {{SchemaNamePlaceholder}}.Instances
+            SELECT [InstanceID] FROM Instances
             WHERE [TaskHub] = @TaskHub AND [RuntimeStatus] IN ('Completed', 'Terminated', 'Failed')
                 AND [CreatedTime] <= @ThresholdTime
     END
     ELSE IF @FilterType = 1 -- completed time
     BEGIN
         INSERT INTO @instanceIDs
-            SELECT [InstanceID] FROM {{SchemaNamePlaceholder}}.Instances
+            SELECT [InstanceID] FROM Instances
             WHERE [TaskHub] = @TaskHub AND [RuntimeStatus] IN ('Completed', 'Terminated', 'Failed')
                 AND [CompletedTime] <= @ThresholdTime
     END
@@ -473,19 +473,19 @@ BEGIN
     END
 
     DECLARE @deletedInstances int
-    EXECUTE @deletedInstances = {{SchemaNamePlaceholder}}.PurgeInstanceStateByID @instanceIDs
+    EXECUTE @deletedInstances = __SchemaNamePlaceholder__.PurgeInstanceStateByID @instanceIDs
     RETURN @deletedInstances
 END
 GO
 
-CREATE OR ALTER PROCEDURE {{SchemaNamePlaceholder}}.SetGlobalSetting
+CREATE OR ALTER PROCEDURE __SchemaNamePlaceholder__.SetGlobalSetting
     @Name varchar(300),
     @Value sql_variant
 AS
 BEGIN
     BEGIN TRANSACTION
  
-    UPDATE {{SchemaNamePlaceholder}}.GlobalSettings WITH (UPDLOCK, HOLDLOCK)
+    UPDATE GlobalSettings WITH (UPDLOCK, HOLDLOCK)
     SET
         [Value] = @Value,
         [Timestamp] = SYSUTCDATETIME(),
@@ -495,7 +495,7 @@ BEGIN
  
     IF @@ROWCOUNT = 0
     BEGIN
-        INSERT INTO {{SchemaNamePlaceholder}}.GlobalSettings ([Name], [Value]) VALUES (@Name, @Value)
+        INSERT INTO GlobalSettings ([Name], [Value]) VALUES (@Name, @Value)
     END
  
     COMMIT TRANSACTION
@@ -503,7 +503,7 @@ END
 GO
 
 
-CREATE OR ALTER PROCEDURE {{SchemaNamePlaceholder}}._LockNextOrchestration
+CREATE OR ALTER PROCEDURE __SchemaNamePlaceholder__._LockNextOrchestration
     @BatchSize int,
     @LockedBy varchar(100),
     @LockExpiration datetime2
@@ -514,7 +514,7 @@ BEGIN
     DECLARE @parentInstanceID varchar(100)
     DECLARE @version varchar(100)
     DECLARE @runtimeStatus varchar(30)
-    DECLARE @TaskHub varchar(50) = {{SchemaNamePlaceholder}}.CurrentTaskHub()
+    DECLARE @TaskHub varchar(50) = __SchemaNamePlaceholder__.CurrentTaskHub()
 
     BEGIN TRANSACTION
 
@@ -526,7 +526,7 @@ BEGIN
     -- Lock the first active instance that has pending messages.
     -- Delayed events from durable timers will have a non-null VisibleTime value.
     -- Non-active instances will never have their messages or history read.
-    UPDATE TOP (1) {{SchemaNamePlaceholder}}.Instances WITH (READPAST)
+    UPDATE TOP (1) Instances WITH (READPAST)
     SET
         [LockedBy] = @LockedBy,
 	    [LockExpiration] = @LockExpiration,
@@ -535,7 +535,7 @@ BEGIN
         @runtimeStatus = I.[RuntimeStatus],
         @version = I.[Version]
     FROM 
-        {{SchemaNamePlaceholder}}.Instances I WITH (READPAST) INNER JOIN {{SchemaNamePlaceholder}}.NewEvents E WITH (READPAST) ON
+        Instances I WITH (READPAST) INNER JOIN NewEvents E WITH (READPAST) ON
             E.[TaskHub] = @TaskHub AND
             E.[InstanceID] = I.[InstanceID]
     WHERE
@@ -564,8 +564,8 @@ BEGIN
         DATEDIFF(SECOND, [Timestamp], @now) AS [WaitTime],
         @parentInstanceID as [ParentInstanceID],
         @version as [Version]
-    FROM {{SchemaNamePlaceholder}}.NewEvents N
-        LEFT OUTER JOIN {{SchemaNamePlaceholder}}.[Payloads] P ON 
+    FROM NewEvents N
+        LEFT OUTER JOIN __SchemaNamePlaceholder__.[Payloads] P ON 
             P.[TaskHub] = @TaskHub AND
             P.[InstanceID] = N.[InstanceID] AND
             P.[PayloadID] = N.[PayloadID]
@@ -603,8 +603,8 @@ BEGIN
         [PayloadID],
         @parentInstanceID as [ParentInstanceID],
         @version as [Version]
-    FROM {{SchemaNamePlaceholder}}.History H WITH (INDEX (PK_History))
-        LEFT OUTER JOIN {{SchemaNamePlaceholder}}.Payloads P ON
+    FROM History H WITH (INDEX (PK_History))
+        LEFT OUTER JOIN Payloads P ON
             P.[TaskHub] = @TaskHub AND
             P.[InstanceID] = H.[InstanceID] AND
             P.[PayloadID] = H.[DataPayloadID]
@@ -616,7 +616,7 @@ END
 GO
 
 
-CREATE OR ALTER PROCEDURE {{SchemaNamePlaceholder}}._CheckpointOrchestration
+CREATE OR ALTER PROCEDURE __SchemaNamePlaceholder__._CheckpointOrchestration
     @InstanceID varchar(100),
     @ExecutionID varchar(50),
     @RuntimeStatus varchar(30),
@@ -629,7 +629,7 @@ AS
 BEGIN
     BEGIN TRANSACTION
 
-    DECLARE @TaskHub varchar(50) = {{SchemaNamePlaceholder}}.CurrentTaskHub()
+    DECLARE @TaskHub varchar(50) = __SchemaNamePlaceholder__.CurrentTaskHub()
 
     DECLARE @InputPayloadID uniqueidentifier
     DECLARE @CustomStatusPayloadID uniqueidentifier
@@ -644,7 +644,7 @@ BEGIN
         @CustomStatusPayloadID = I.[CustomStatusPayloadID],
         @ExistingCustomStatusPayload = P.[Text],
         @ExistingExecutionID = I.[ExecutionID]
-    FROM {{SchemaNamePlaceholder}}.Payloads P RIGHT OUTER JOIN {{SchemaNamePlaceholder}}.Instances I ON
+    FROM Payloads P RIGHT OUTER JOIN Instances I ON
         P.[TaskHub] = @TaskHub AND
         P.[InstanceID] = I.[InstanceID] AND
         P.[PayloadID] = I.[CustomStatusPayloadID]
@@ -654,10 +654,10 @@ BEGIN
     DECLARE @IsContinueAsNew BIT = 0
     IF @ExistingExecutionID IS NOT NULL AND @ExistingExecutionID <> @ExecutionID
     BEGIN
-        DELETE FROM {{SchemaNamePlaceholder}}.History
+        DELETE FROM History
         WHERE [TaskHub] = @TaskHub AND [InstanceID] = @InstanceID
 
-        DELETE FROM {{SchemaNamePlaceholder}}.Payloads
+        DELETE FROM Payloads
         WHERE [TaskHub] = @TaskHub AND [InstanceID] = @InstanceID
 
         -- The existing payload got purged in the previous statement 
@@ -669,14 +669,14 @@ BEGIN
     IF @ExistingCustomStatusPayload IS NULL AND @CustomStatusPayload IS NOT NULL
     BEGIN
         SET @CustomStatusPayloadID = NEWID()
-        INSERT INTO {{SchemaNamePlaceholder}}.Payloads ([TaskHub], [InstanceID], [PayloadID], [Text])
+        INSERT INTO Payloads ([TaskHub], [InstanceID], [PayloadID], [Text])
         VALUES (@TaskHub, @InstanceID, @CustomStatusPayloadID, @CustomStatusPayload)
     END
 
     -- Custom status case #2: Updating an existing custom status payload
     IF @ExistingCustomStatusPayload IS NOT NULL AND @ExistingCustomStatusPayload <> @CustomStatusPayload
     BEGIN
-        UPDATE {{SchemaNamePlaceholder}}.Payloads SET [Text] = @CustomStatusPayload WHERE 
+        UPDATE Payloads SET [Text] = @CustomStatusPayload WHERE 
             [TaskHub] = @TaskHub AND
             [InstanceID] = @InstanceID AND
             [PayloadID] = @CustomStatusPayloadID
@@ -713,12 +713,12 @@ BEGIN
     -- The [PayloadText] value will be NULL if there is no payload or if a payload is already known to exist in the DB.
     -- The [PayloadID] value might be set even if [PayloadText] and [Reason] are both NULL.
     -- This needs to be done before the UPDATE to Instances because the Instances table needs to reference the output payload.
-    INSERT INTO {{SchemaNamePlaceholder}}.Payloads ([TaskHub], [InstanceID], [PayloadID], [Text], [Reason])
+    INSERT INTO Payloads ([TaskHub], [InstanceID], [PayloadID], [Text], [Reason])
         SELECT @TaskHub, [InstanceID], [PayloadID], [PayloadText], [Reason]
         FROM @NewHistoryEvents
         WHERE [PayloadText] IS NOT NULL OR [Reason] IS NOT NULL
 
-    UPDATE {{SchemaNamePlaceholder}}.Instances
+    UPDATE Instances
     SET
         [ExecutionID] = @ExecutionID,
         [RuntimeStatus] = @RuntimeStatus,
@@ -728,7 +728,7 @@ BEGIN
         [CustomStatusPayloadID] = @CustomStatusPayloadID,
         [InputPayloadID] = @InputPayloadID,
         [OutputPayloadID] = @OutputPayloadID
-    FROM {{SchemaNamePlaceholder}}.Instances
+    FROM Instances
     WHERE [TaskHub] = @TaskHub and [InstanceID] = @InstanceID
 
     IF @@ROWCOUNT = 0
@@ -737,7 +737,7 @@ BEGIN
     -- External event messages can create new instances
     -- NOTE: There is a chance this could result in deadlocks if two 
     --       instances are sending events to each other at the same time
-    INSERT INTO {{SchemaNamePlaceholder}}.Instances (
+    INSERT INTO Instances (
         [TaskHub],
         [InstanceID],
         [ExecutionID],
@@ -756,13 +756,13 @@ BEGIN
         AND CHARINDEX('@', E.[InstanceID], 2) > 0
         AND NOT EXISTS (
             SELECT 1
-            FROM {{SchemaNamePlaceholder}}.Instances I
+            FROM Instances I
             WHERE [TaskHub] = @TaskHub AND I.[InstanceID] = E.[InstanceID])
     GROUP BY E.[InstanceID]
     ORDER BY E.[InstanceID] ASC
 
     -- Create sub-orchestration instances
-    INSERT INTO {{SchemaNamePlaceholder}}.Instances (
+    INSERT INTO Instances (
         [TaskHub],
         [InstanceID],
         [ExecutionID],
@@ -782,24 +782,24 @@ BEGIN
     WHERE E.[EventType] IN ('ExecutionStarted')
         AND NOT EXISTS (
             SELECT 1
-            FROM {{SchemaNamePlaceholder}}.Instances I
+            FROM Instances I
             WHERE [TaskHub] = @TaskHub AND I.[InstanceID] = E.[InstanceID])
     ORDER BY E.[InstanceID] ASC
 
     -- Insert new event data payloads into the Payloads table in batches.
     -- PayloadID values are provided by the caller only if a payload exists.
-    INSERT INTO {{SchemaNamePlaceholder}}.Payloads ([TaskHub], [InstanceID], [PayloadID], [Text], [Reason])
+    INSERT INTO Payloads ([TaskHub], [InstanceID], [PayloadID], [Text], [Reason])
         SELECT @TaskHub, [InstanceID], [PayloadID], [PayloadText], [Reason]
         FROM @NewOrchestrationEvents
         WHERE [PayloadID] IS NOT NULL
 
-    INSERT INTO {{SchemaNamePlaceholder}}.Payloads ([TaskHub], [InstanceID], [PayloadID], [Text])
+    INSERT INTO Payloads ([TaskHub], [InstanceID], [PayloadID], [Text])
         SELECT @TaskHub, [InstanceID], [PayloadID], [PayloadText]
         FROM @NewTaskEvents
         WHERE [PayloadID] IS NOT NULL
 
     -- Insert the new events with references to their payloads, if applicable
-    INSERT INTO {{SchemaNamePlaceholder}}.NewEvents (
+    INSERT INTO NewEvents (
         [TaskHub],
         [InstanceID],
         [ExecutionID],
@@ -826,7 +826,7 @@ BEGIN
     -- warning about missing messages
     DELETE E
     OUTPUT DELETED.InstanceID, DELETED.SequenceNumber
-    FROM {{SchemaNamePlaceholder}}.NewEvents E WITH (FORCESEEK(PK_NewEvents(TaskHub, InstanceID, SequenceNumber)))
+    FROM NewEvents E WITH (FORCESEEK(PK_NewEvents(TaskHub, InstanceID, SequenceNumber)))
         INNER JOIN @DeletedEvents D ON 
             D.InstanceID = E.InstanceID AND
             D.SequenceNumber = E.SequenceNumber AND
@@ -835,7 +835,7 @@ BEGIN
     -- IMPORTANT: This insert is expected to fail with a primary key constraint violation in a
     --            split-brain situation where two instances try to execute the same orchestration
     --            at the same time. The SDK will check for this exact error condition.
-    INSERT INTO {{SchemaNamePlaceholder}}.History (
+    INSERT INTO History (
         [TaskHub],
         [InstanceID],
         [ExecutionID],
@@ -864,7 +864,7 @@ BEGIN
     FROM @NewHistoryEvents H
 
     -- TaskScheduled events
-    INSERT INTO {{SchemaNamePlaceholder}}.NewTasks (
+    INSERT INTO NewTasks (
         [TaskHub],
         [InstanceID],
         [ExecutionID],
@@ -897,31 +897,31 @@ END
 GO
 
 
-CREATE OR ALTER PROCEDURE {{SchemaNamePlaceholder}}._DiscardEventsAndUnlockInstance
+CREATE OR ALTER PROCEDURE __SchemaNamePlaceholder__._DiscardEventsAndUnlockInstance
     @InstanceID varchar(100),
     @DeletedEvents MessageIDs READONLY
 AS
 BEGIN
-    DECLARE @taskHub varchar(50) = {{SchemaNamePlaceholder}}.CurrentTaskHub()
+    DECLARE @taskHub varchar(50) = __SchemaNamePlaceholder__.CurrentTaskHub()
 
     -- We return the list of deleted messages so that the caller can issue a 
     -- warning about missing messages
     DELETE E
     OUTPUT DELETED.InstanceID, DELETED.SequenceNumber
-    FROM {{SchemaNamePlaceholder}}.NewEvents E WITH (FORCESEEK(PK_NewEvents(TaskHub, InstanceID, SequenceNumber)))
+    FROM NewEvents E WITH (FORCESEEK(PK_NewEvents(TaskHub, InstanceID, SequenceNumber)))
         INNER JOIN @DeletedEvents D ON 
             D.InstanceID = E.InstanceID AND
             D.SequenceNumber = E.SequenceNumber AND
             E.TaskHub = @taskHub
 
     -- Release the lock on this instance
-    UPDATE {{SchemaNamePlaceholder}}.Instances SET [LastUpdatedTime] = SYSUTCDATETIME(), [LockExpiration] = NULL
+    UPDATE Instances SET [LastUpdatedTime] = SYSUTCDATETIME(), [LockExpiration] = NULL
     WHERE [TaskHub] = @taskHub and [InstanceID] = @InstanceID
 END
 GO
 
 
-CREATE OR ALTER PROCEDURE {{SchemaNamePlaceholder}}._AddOrchestrationEvents
+CREATE OR ALTER PROCEDURE __SchemaNamePlaceholder__._AddOrchestrationEvents
     @NewOrchestrationEvents OrchestrationEvents READONLY 
 AS
 BEGIN
@@ -932,13 +932,13 @@ BEGIN
     -- order across all stored procedures that execute within a transaction.
     -- Table order for this sproc: Payloads --> NewEvents
 
-    DECLARE @TaskHub varchar(50) = {{SchemaNamePlaceholder}}.CurrentTaskHub()
+    DECLARE @TaskHub varchar(50) = __SchemaNamePlaceholder__.CurrentTaskHub()
     
     -- External event messages can create new instances
     -- NOTE: There is a chance this could result in deadlocks if two 
     --       instances are sending events to each other at the same time
     BEGIN TRY
-        INSERT INTO {{SchemaNamePlaceholder}}.Instances (
+        INSERT INTO Instances (
             [TaskHub],
             [InstanceID],
             [ExecutionID],
@@ -969,13 +969,13 @@ BEGIN
 
     -- Insert new event data payloads into the Payloads table in batches.
     -- PayloadID values are provided by the caller only if a payload exists.
-    INSERT INTO {{SchemaNamePlaceholder}}.Payloads ([TaskHub], [InstanceID], [PayloadID], [Text], [Reason])
+    INSERT INTO Payloads ([TaskHub], [InstanceID], [PayloadID], [Text], [Reason])
         SELECT @TaskHub, [InstanceID], [PayloadID], [PayloadText], [Reason]
         FROM @NewOrchestrationEvents
         WHERE [PayloadID] IS NOT NULL
 
     -- Insert the new events with references to their payloads, if applicable
-    INSERT INTO {{SchemaNamePlaceholder}}.NewEvents (
+    INSERT INTO NewEvents (
         [TaskHub],
         [InstanceID],
         [ExecutionID],
@@ -1002,14 +1002,14 @@ BEGIN
 END
 GO
 
-CREATE OR ALTER PROCEDURE {{SchemaNamePlaceholder}}.QuerySingleOrchestration
+CREATE OR ALTER PROCEDURE __SchemaNamePlaceholder__.QuerySingleOrchestration
     @InstanceID varchar(100),
     @ExecutionID varchar(50) = NULL,
     @FetchInput bit = 1,
     @FetchOutput bit = 1
 AS
 BEGIN
-    DECLARE @TaskHub varchar(50) = {{SchemaNamePlaceholder}}.CurrentTaskHub()
+    DECLARE @TaskHub varchar(50) = __SchemaNamePlaceholder__.CurrentTaskHub()
 
     SELECT TOP 1
         I.[InstanceID],
@@ -1021,19 +1021,19 @@ BEGIN
         I.[CompletedTime],
         I.[RuntimeStatus],
         I.[ParentInstanceID],
-        (SELECT TOP 1 [Text] FROM {{SchemaNamePlaceholder}}.Payloads P WHERE
+        (SELECT TOP 1 [Text] FROM Payloads P WHERE
             P.[TaskHub] = @TaskHub AND
             P.[InstanceID] = I.[InstanceID] AND
             P.[PayloadID] = I.[CustomStatusPayloadID]) AS [CustomStatusText],
-        CASE WHEN @FetchInput = 1 THEN (SELECT TOP 1 [Text] FROM {{SchemaNamePlaceholder}}.Payloads P WHERE
+        CASE WHEN @FetchInput = 1 THEN (SELECT TOP 1 [Text] FROM Payloads P WHERE
             P.[TaskHub] = @TaskHub AND
             P.[InstanceID] = I.[InstanceID] AND
             P.[PayloadID] = I.[InputPayloadID]) ELSE NULL END AS [InputText],
-        CASE WHEN @FetchOutput = 1 THEN (SELECT TOP 1 [Text] FROM {{SchemaNamePlaceholder}}.Payloads P WHERE
+        CASE WHEN @FetchOutput = 1 THEN (SELECT TOP 1 [Text] FROM Payloads P WHERE
             P.[TaskHub] = @TaskHub AND
             P.[InstanceID] = I.[InstanceID] AND
             P.[PayloadID] = I.[OutputPayloadID]) ELSE NULL END AS [OutputText]
-    FROM {{SchemaNamePlaceholder}}.Instances I
+    FROM Instances I
     WHERE
         I.[TaskHub] = @TaskHub AND
         I.[InstanceID] = @InstanceID AND
@@ -1042,7 +1042,7 @@ END
 GO
 
 
-CREATE OR ALTER PROCEDURE {{SchemaNamePlaceholder}}._QueryManyOrchestrations
+CREATE OR ALTER PROCEDURE __SchemaNamePlaceholder__._QueryManyOrchestrations
     @PageSize smallint = 100,
     @PageNumber smallint = 0,
     @FetchInput bit = 1,
@@ -1054,7 +1054,7 @@ CREATE OR ALTER PROCEDURE {{SchemaNamePlaceholder}}._QueryManyOrchestrations
     @ExcludeSubOrchestrations bit = 0
 AS
 BEGIN
-    DECLARE @TaskHub varchar(50) = {{SchemaNamePlaceholder}}.CurrentTaskHub()
+    DECLARE @TaskHub varchar(50) = __SchemaNamePlaceholder__.CurrentTaskHub()
 
     SELECT
         I.[InstanceID],
@@ -1066,20 +1066,20 @@ BEGIN
         I.[CompletedTime],
         I.[RuntimeStatus],
         I.[ParentInstanceID],
-        (SELECT TOP 1 [Text] FROM {{SchemaNamePlaceholder}}.Payloads P WHERE
+        (SELECT TOP 1 [Text] FROM Payloads P WHERE
             P.[TaskHub] = @TaskHub AND
             P.[InstanceID] = I.[InstanceID] AND
             P.[PayloadID] = I.[CustomStatusPayloadID]) AS [CustomStatusText],
-        CASE WHEN @FetchInput = 1 THEN (SELECT TOP 1 [Text] FROM {{SchemaNamePlaceholder}}.Payloads P WHERE
+        CASE WHEN @FetchInput = 1 THEN (SELECT TOP 1 [Text] FROM Payloads P WHERE
             P.[TaskHub] = @TaskHub AND
             P.[InstanceID] = I.[InstanceID] AND
             P.[PayloadID] = I.[InputPayloadID]) ELSE NULL END AS [InputText],
-        CASE WHEN @FetchOutput = 1 THEN (SELECT TOP 1 [Text] FROM {{SchemaNamePlaceholder}}.Payloads P WHERE
+        CASE WHEN @FetchOutput = 1 THEN (SELECT TOP 1 [Text] FROM Payloads P WHERE
             P.[TaskHub] = @TaskHub AND
             P.[InstanceID] = I.[InstanceID] AND
             P.[PayloadID] = I.[OutputPayloadID]) ELSE NULL END AS [OutputText]
     FROM
-        {{SchemaNamePlaceholder}}.Instances I
+        Instances I
     WHERE
         I.[TaskHub] = @TaskHub AND
         (@CreatedTimeFrom IS NULL OR I.[CreatedTime] >= @CreatedTimeFrom) AND
@@ -1093,12 +1093,12 @@ END
 GO
 
 
-CREATE OR ALTER PROCEDURE {{SchemaNamePlaceholder}}._LockNextTask
+CREATE OR ALTER PROCEDURE __SchemaNamePlaceholder__._LockNextTask
     @LockedBy varchar(100),
     @LockExpiration datetime2
 AS
 BEGIN
-    DECLARE @TaskHub varchar(50) = {{SchemaNamePlaceholder}}.CurrentTaskHub()
+    DECLARE @TaskHub varchar(50) = __SchemaNamePlaceholder__.CurrentTaskHub()
     DECLARE @now datetime2 = SYSUTCDATETIME()
 
     DECLARE @SequenceNumber bigint
@@ -1112,14 +1112,14 @@ BEGIN
     -- Update (lock) and return a single row.
     -- The PK_NewTasks hint is specified to help ensure in-order selection.
     -- TODO: Filter out tasks for instances that are in a non-running state (suspended, etc.)
-    UPDATE TOP (1) {{SchemaNamePlaceholder}}.NewTasks WITH (READPAST)
+    UPDATE TOP (1) NewTasks WITH (READPAST)
     SET
         @SequenceNumber = [SequenceNumber],
         [LockedBy] = @LockedBy,
 	    [LockExpiration] = @LockExpiration,
         [DequeueCount] = [DequeueCount] + 1
     FROM
-        {{SchemaNamePlaceholder}}.NewTasks WITH (INDEX (PK_NewTasks))
+        NewTasks WITH (INDEX (PK_NewTasks))
     WHERE
         [TaskHub] = @TaskHub AND
 	    ([LockExpiration] IS NULL OR [LockExpiration] < @now) AND
@@ -1136,12 +1136,12 @@ BEGIN
         [Timestamp],
         [DequeueCount],
         [Version],
-        (SELECT TOP 1 [Text] FROM {{SchemaNamePlaceholder}}.Payloads P WHERE
+        (SELECT TOP 1 [Text] FROM Payloads P WHERE
             P.[TaskHub] = @TaskHub AND
             P.[InstanceID] = N.[InstanceID] AND
             P.[PayloadID] = N.[PayloadID]) AS [PayloadText],
         DATEDIFF(SECOND, [Timestamp], @now) AS [WaitTime]
-    FROM {{SchemaNamePlaceholder}}.NewTasks N
+    FROM NewTasks N
     WHERE [TaskHub] = @TaskHub AND [SequenceNumber] = @SequenceNumber
 
     COMMIT TRANSACTION
@@ -1149,42 +1149,42 @@ END
 GO
 
 
-CREATE OR ALTER PROCEDURE {{SchemaNamePlaceholder}}._RenewOrchestrationLocks
+CREATE OR ALTER PROCEDURE __SchemaNamePlaceholder__._RenewOrchestrationLocks
     @InstanceID varchar(100),
     @LockExpiration datetime2
 AS
 BEGIN
-    DECLARE @TaskHub varchar(50) = {{SchemaNamePlaceholder}}.CurrentTaskHub()
+    DECLARE @TaskHub varchar(50) = __SchemaNamePlaceholder__.CurrentTaskHub()
 
-    UPDATE {{SchemaNamePlaceholder}}.Instances
+    UPDATE Instances
     SET [LockExpiration] = @LockExpiration
     WHERE [TaskHub] = @TaskHub AND [InstanceID] = @InstanceID
 END
 GO
 
 
-CREATE OR ALTER PROCEDURE {{SchemaNamePlaceholder}}._RenewTaskLocks
+CREATE OR ALTER PROCEDURE __SchemaNamePlaceholder__._RenewTaskLocks
     @RenewingTasks MessageIDs READONLY,
     @LockExpiration datetime2
 AS
 BEGIN
-    DECLARE @TaskHub varchar(50) = {{SchemaNamePlaceholder}}.CurrentTaskHub()
+    DECLARE @TaskHub varchar(50) = __SchemaNamePlaceholder__.CurrentTaskHub()
 
     UPDATE N
     SET [LockExpiration] = @LockExpiration
-    FROM {{SchemaNamePlaceholder}}.NewTasks N INNER JOIN @RenewingTasks C ON
+    FROM NewTasks N INNER JOIN @RenewingTasks C ON
         C.[SequenceNumber] = N.[SequenceNumber] AND
         N.[TaskHub] = @TaskHub
 END
 GO
 
 
-CREATE OR ALTER PROCEDURE {{SchemaNamePlaceholder}}._CompleteTasks
+CREATE OR ALTER PROCEDURE __SchemaNamePlaceholder__._CompleteTasks
     @CompletedTasks MessageIDs READONLY,
     @Results TaskEvents READONLY
 AS
 BEGIN
-    DECLARE @TaskHub varchar(50) = {{SchemaNamePlaceholder}}.CurrentTaskHub()
+    DECLARE @TaskHub varchar(50) = __SchemaNamePlaceholder__.CurrentTaskHub()
 
     BEGIN TRANSACTION
 
@@ -1193,7 +1193,7 @@ BEGIN
     DECLARE @existingInstanceID varchar(100)
 
     SELECT @existingInstanceID = R.[InstanceID]
-    FROM {{SchemaNamePlaceholder}}.Instances I WITH (HOLDLOCK)
+    FROM Instances I WITH (HOLDLOCK)
         INNER JOIN @Results R ON 
             I.[TaskHub] = @TaskHub AND
             I.[InstanceID] = R.[InstanceID] AND 
@@ -1205,12 +1205,12 @@ BEGIN
     BEGIN
         -- Insert new event data payloads into the Payloads table in batches.
         -- PayloadID values are provided by the caller only if a payload exists.
-        INSERT INTO {{SchemaNamePlaceholder}}.Payloads ([TaskHub], [InstanceID], [PayloadID], [Text], [Reason])
+        INSERT INTO Payloads ([TaskHub], [InstanceID], [PayloadID], [Text], [Reason])
             SELECT @TaskHub, [InstanceID], [PayloadID], [PayloadText], [Reason]
             FROM @Results
             WHERE [PayloadID] IS NOT NULL
 
-        INSERT INTO {{SchemaNamePlaceholder}}.NewEvents (
+        INSERT INTO NewEvents (
             [TaskHub],
             [InstanceID],
             [ExecutionID],
@@ -1239,7 +1239,7 @@ BEGIN
     DELETE N
     OUTPUT DELETED.[PayloadID] INTO @payloadsToDelete
     OUTPUT DELETED.[SequenceNumber]
-    FROM {{SchemaNamePlaceholder}}.NewTasks N WITH (FORCESEEK(PK_NewTasks(TaskHub, SequenceNumber)))
+    FROM NewTasks N WITH (FORCESEEK(PK_NewTasks(TaskHub, SequenceNumber)))
         INNER JOIN @CompletedTasks C ON
             C.[SequenceNumber] = N.[SequenceNumber] AND
             N.[TaskHub] = @TaskHub
@@ -1255,47 +1255,47 @@ END
 GO
 
 
-CREATE OR ALTER PROCEDURE {{SchemaNamePlaceholder}}._GetVersions
+CREATE OR ALTER PROCEDURE __SchemaNamePlaceholder__._GetVersions
 AS
 BEGIN
     SELECT SemanticVersion, UpgradeTime
-    FROM {{SchemaNamePlaceholder}}.Versions
+    FROM Versions
     ORDER BY UpgradeTime DESC
 END
 GO
 
 
-CREATE OR ALTER PROCEDURE {{SchemaNamePlaceholder}}._UpdateVersion
+CREATE OR ALTER PROCEDURE __SchemaNamePlaceholder__._UpdateVersion
     @SemanticVersion varchar(100)
 AS
 BEGIN
     -- Duplicates are ignored (per the schema definition of dt.Versions)
-    INSERT INTO {{SchemaNamePlaceholder}}.Versions (SemanticVersion)
+    INSERT INTO Versions (SemanticVersion)
     VALUES (@SemanticVersion)
 END
 GO
 
 
-CREATE OR ALTER PROCEDURE {{SchemaNamePlaceholder}}._RewindInstance
+CREATE OR ALTER PROCEDURE __SchemaNamePlaceholder__._RewindInstance
     @InstanceID varchar(100),
     @Reason varchar(max) = NULL
 AS
 BEGIN
     BEGIN TRANSACTION
 
-    EXEC {{SchemaNamePlaceholder}}._RewindInstanceRecursive @InstanceID, @Reason
+    EXEC __SchemaNamePlaceholder__._RewindInstanceRecursive @InstanceID, @Reason
 
     COMMIT TRANSACTION
 END
 GO
 
 
-CREATE OR ALTER PROCEDURE {{SchemaNamePlaceholder}}._RewindInstanceRecursive
+CREATE OR ALTER PROCEDURE __SchemaNamePlaceholder__._RewindInstanceRecursive
     @InstanceID varchar(100),
     @Reason varchar(max) = NULL
 AS
 BEGIN
-    DECLARE @TaskHub varchar(50) = {{SchemaNamePlaceholder}}.CurrentTaskHub()
+    DECLARE @TaskHub varchar(50) = __SchemaNamePlaceholder__.CurrentTaskHub()
 
     -- *** IMPORTANT ***
     -- To prevent deadlocks, it is important to maintain consistent table access
@@ -1306,7 +1306,7 @@ BEGIN
     DECLARE @executionID varchar(50)
     
     SELECT TOP 1 @existingStatus = existing.[RuntimeStatus], @executionID = existing.[ExecutionID]
-    FROM {{SchemaNamePlaceholder}}.Instances existing WITH (HOLDLOCK)
+    FROM Instances existing WITH (HOLDLOCK)
     WHERE [TaskHub] = @TaskHub AND [InstanceID] = @InstanceID
 
     -- Instance IDs can be overwritten only if the orchestration is in a terminal state
@@ -1325,12 +1325,12 @@ BEGIN
     -- Save all events related to failures (ie TaskScheduled/TaskFailed and SubOrchestrationInstanceStarted/SubOrchestrationInstanceFailed couples)
     INSERT INTO @eventsInFailure
     SELECT h.[SequenceNumber], h.[EventType], h.[TaskID], h.[DataPayloadID]
-    FROM {{SchemaNamePlaceholder}}.History h
+    FROM History h
     WHERE h.[TaskHub] = @TaskHub
       AND h.[InstanceID] = @InstanceID
       AND (h.[EventType] IN ('TaskFailed', 'SubOrchestrationInstanceFailed') OR (h.[EventType] IN ('TaskScheduled', 'SubOrchestrationInstanceStarted') AND EXISTS (
         SELECT 1
-        FROM {{SchemaNamePlaceholder}}.History f
+        FROM History f
         WHERE f.[TaskHub] = @TaskHub 
           AND f.[InstanceID] = @InstanceID
           AND f.[TaskID] = h.[TaskID]
@@ -1338,9 +1338,9 @@ BEGIN
 
     -- Mark all events related to failure as rewound
     -- This first batch is for all events that have corresponding records in the Payloads table already
-    UPDATE {{SchemaNamePlaceholder}}.Payloads
+    UPDATE Payloads
     SET [Reason] = CONCAT('Rewound: ', ef.[EventType])
-    FROM {{SchemaNamePlaceholder}}.Payloads p
+    FROM Payloads p
     JOIN @eventsInFailure ef ON p.[PayloadID] = ef.[DataPayloadID]
     WHERE [TaskHub] = @TaskHub
       AND [InstanceID] = @InstanceID
@@ -1360,7 +1360,7 @@ BEGIN
 
     WHILE @@FETCH_STATUS = 0 BEGIN
         SET @payloadId = NEWID()
-        INSERT INTO {{SchemaNamePlaceholder}}.Payloads (
+        INSERT INTO Payloads (
             [TaskHub],
             [InstanceID],
             [PayloadID],
@@ -1373,7 +1373,7 @@ BEGIN
     DEALLOCATE sequenceNumberCursor
 
     -- Transform all events related to failure to GenericEvents, except for SubOrchestrationInstanceStarted that can be kept
-    UPDATE {{SchemaNamePlaceholder}}.History
+    UPDATE History
     SET [EventType] = 'GenericEvent'
     WHERE [TaskHub] = @TaskHub AND [InstanceID] = @InstanceID
       AND ([SequenceNumber] IN (SELECT [SequenceNumber]
@@ -1384,8 +1384,8 @@ BEGIN
     DECLARE @subOrchestrationInstanceID varchar(100)
     DECLARE subOrchestrationCursor CURSOR LOCAL FOR
         SELECT i.[InstanceID]
-        FROM {{SchemaNamePlaceholder}}.Instances i
-          JOIN {{SchemaNamePlaceholder}}.History h ON i.[TaskHub] = h.[TaskHub] AND i.[InstanceID] = h.[InstanceID]
+        FROM Instances i
+          JOIN History h ON i.[TaskHub] = h.[TaskHub] AND i.[InstanceID] = h.[InstanceID]
           JOIN @eventsInFailure e ON e.[TaskID] = h.[TaskID]
         WHERE i.[ParentInstanceID] = @InstanceID 
           AND h.[EventType] = 'ExecutionStarted'
@@ -1397,7 +1397,7 @@ BEGIN
 
     WHILE @@FETCH_STATUS = 0 BEGIN
         -- Call rewind recursively on the failing suborchestrations
-        EXECUTE {{SchemaNamePlaceholder}}._RewindInstanceRecursive @subOrchestrationInstanceID, @Reason
+        EXECUTE __SchemaNamePlaceholder__._RewindInstanceRecursive @subOrchestrationInstanceID, @Reason
         FETCH NEXT FROM subOrchestrationCursor INTO @subOrchestrationInstanceID
     END
     CLOSE subOrchestrationCursor
@@ -1405,14 +1405,14 @@ BEGIN
 
     -- Insert a line in NewEvents to ensure orchestration will start
     SET @payloadId = NEWID()
-    INSERT INTO {{SchemaNamePlaceholder}}.Payloads (
+    INSERT INTO Payloads (
         [TaskHub],
         [InstanceID],
         [PayloadID],
         [Text]
     )
     VALUES (@TaskHub, @InstanceID, @payloadId, @Reason)
-    INSERT INTO {{SchemaNamePlaceholder}}.NewEvents (
+    INSERT INTO NewEvents (
         [TaskHub],
         [InstanceID],
         [ExecutionID],
@@ -1427,7 +1427,7 @@ BEGIN
         @payloadId)
 
     -- Set orchestration status to Pending
-    UPDATE {{SchemaNamePlaceholder}}.Instances
+    UPDATE Instances
     SET [RuntimeStatus] = 'Pending', [LastUpdatedTime] = SYSUTCDATETIME()
     WHERE [TaskHub] = @TaskHub AND [InstanceID] = @InstanceID
 END

--- a/src/DurableTask.SqlServer/Scripts/permissions.sql
+++ b/src/DurableTask.SqlServer/Scripts/permissions.sql
@@ -2,11 +2,11 @@
 -- Licensed under the MIT License.
 
 -- Security 
-IF DATABASE_PRINCIPAL_ID('{{SchemaNamePlaceholder}}_runtime') IS NULL
+IF DATABASE_PRINCIPAL_ID('__SchemaNamePlaceholder___runtime') IS NULL
 BEGIN
     -- This is the role to which all low-privilege user accounts should be associated using
     -- the 'ALTER ROLE dt_runtime ADD MEMBER [<username>]' statement.
-    CREATE ROLE {{SchemaNamePlaceholder}}_runtime
+    CREATE ROLE __SchemaNamePlaceholder___runtime
 END
 
 -- Each stored procedure that is granted to dt_runtime must limits access to data based 
@@ -14,39 +14,39 @@ END
 -- database user can access data created by another database user.
 
 -- Functions 
-GRANT EXECUTE ON OBJECT::{{SchemaNamePlaceholder}}.GetScaleMetric TO {{SchemaNamePlaceholder}}_runtime
-GRANT EXECUTE ON OBJECT::{{SchemaNamePlaceholder}}.GetScaleRecommendation TO {{SchemaNamePlaceholder}}_runtime
-GRANT EXECUTE ON OBJECT::{{SchemaNamePlaceholder}}.CurrentTaskHub TO {{SchemaNamePlaceholder}}_runtime
+GRANT EXECUTE ON OBJECT::__SchemaNamePlaceholder__.GetScaleMetric TO __SchemaNamePlaceholder___runtime
+GRANT EXECUTE ON OBJECT::__SchemaNamePlaceholder__.GetScaleRecommendation TO __SchemaNamePlaceholder___runtime
+GRANT EXECUTE ON OBJECT::__SchemaNamePlaceholder__.CurrentTaskHub TO __SchemaNamePlaceholder___runtime
 
 -- Public sprocs
-GRANT EXECUTE ON OBJECT::{{SchemaNamePlaceholder}}.CreateInstance TO {{SchemaNamePlaceholder}}_runtime
-GRANT EXECUTE ON OBJECT::{{SchemaNamePlaceholder}}.GetInstanceHistory TO {{SchemaNamePlaceholder}}_runtime
-GRANT EXECUTE ON OBJECT::{{SchemaNamePlaceholder}}.QuerySingleOrchestration TO {{SchemaNamePlaceholder}}_runtime
-GRANT EXECUTE ON OBJECT::{{SchemaNamePlaceholder}}.RaiseEvent TO {{SchemaNamePlaceholder}}_runtime
-GRANT EXECUTE ON OBJECT::{{SchemaNamePlaceholder}}.TerminateInstance TO {{SchemaNamePlaceholder}}_runtime
-GRANT EXECUTE ON OBJECT::{{SchemaNamePlaceholder}}.PurgeInstanceStateByID TO {{SchemaNamePlaceholder}}_runtime
-GRANT EXECUTE ON OBJECT::{{SchemaNamePlaceholder}}.PurgeInstanceStateByTime TO {{SchemaNamePlaceholder}}_runtime
+GRANT EXECUTE ON OBJECT::__SchemaNamePlaceholder__.CreateInstance TO __SchemaNamePlaceholder___runtime
+GRANT EXECUTE ON OBJECT::__SchemaNamePlaceholder__.GetInstanceHistory TO __SchemaNamePlaceholder___runtime
+GRANT EXECUTE ON OBJECT::__SchemaNamePlaceholder__.QuerySingleOrchestration TO __SchemaNamePlaceholder___runtime
+GRANT EXECUTE ON OBJECT::__SchemaNamePlaceholder__.RaiseEvent TO __SchemaNamePlaceholder___runtime
+GRANT EXECUTE ON OBJECT::__SchemaNamePlaceholder__.TerminateInstance TO __SchemaNamePlaceholder___runtime
+GRANT EXECUTE ON OBJECT::__SchemaNamePlaceholder__.PurgeInstanceStateByID TO __SchemaNamePlaceholder___runtime
+GRANT EXECUTE ON OBJECT::__SchemaNamePlaceholder__.PurgeInstanceStateByTime TO __SchemaNamePlaceholder___runtime
 
 -- Internal sprocs
-GRANT EXECUTE ON OBJECT::{{SchemaNamePlaceholder}}._AddOrchestrationEvents TO {{SchemaNamePlaceholder}}_runtime
-GRANT EXECUTE ON OBJECT::{{SchemaNamePlaceholder}}._CheckpointOrchestration TO {{SchemaNamePlaceholder}}_runtime
-GRANT EXECUTE ON OBJECT::{{SchemaNamePlaceholder}}._CompleteTasks TO {{SchemaNamePlaceholder}}_runtime
-GRANT EXECUTE ON OBJECT::{{SchemaNamePlaceholder}}._DiscardEventsAndUnlockInstance TO {{SchemaNamePlaceholder}}_runtime
-GRANT EXECUTE ON OBJECT::{{SchemaNamePlaceholder}}._GetVersions TO {{SchemaNamePlaceholder}}_runtime
-GRANT EXECUTE ON OBJECT::{{SchemaNamePlaceholder}}._LockNextOrchestration TO {{SchemaNamePlaceholder}}_runtime
-GRANT EXECUTE ON OBJECT::{{SchemaNamePlaceholder}}._LockNextTask TO {{SchemaNamePlaceholder}}_runtime
-GRANT EXECUTE ON OBJECT::{{SchemaNamePlaceholder}}._QueryManyOrchestrations TO {{SchemaNamePlaceholder}}_runtime
-GRANT EXECUTE ON OBJECT::{{SchemaNamePlaceholder}}._RenewOrchestrationLocks TO {{SchemaNamePlaceholder}}_runtime
-GRANT EXECUTE ON OBJECT::{{SchemaNamePlaceholder}}._RenewTaskLocks TO {{SchemaNamePlaceholder}}_runtime
-GRANT EXECUTE ON OBJECT::{{SchemaNamePlaceholder}}._UpdateVersion TO {{SchemaNamePlaceholder}}_runtime
-GRANT EXECUTE ON OBJECT::{{SchemaNamePlaceholder}}._RewindInstance TO {{SchemaNamePlaceholder}}_runtime
-GRANT EXECUTE ON OBJECT::{{SchemaNamePlaceholder}}._RewindInstanceRecursive TO {{SchemaNamePlaceholder}}_runtime
+GRANT EXECUTE ON OBJECT::__SchemaNamePlaceholder__._AddOrchestrationEvents TO __SchemaNamePlaceholder___runtime
+GRANT EXECUTE ON OBJECT::__SchemaNamePlaceholder__._CheckpointOrchestration TO __SchemaNamePlaceholder___runtime
+GRANT EXECUTE ON OBJECT::__SchemaNamePlaceholder__._CompleteTasks TO __SchemaNamePlaceholder___runtime
+GRANT EXECUTE ON OBJECT::__SchemaNamePlaceholder__._DiscardEventsAndUnlockInstance TO __SchemaNamePlaceholder___runtime
+GRANT EXECUTE ON OBJECT::__SchemaNamePlaceholder__._GetVersions TO __SchemaNamePlaceholder___runtime
+GRANT EXECUTE ON OBJECT::__SchemaNamePlaceholder__._LockNextOrchestration TO __SchemaNamePlaceholder___runtime
+GRANT EXECUTE ON OBJECT::__SchemaNamePlaceholder__._LockNextTask TO __SchemaNamePlaceholder___runtime
+GRANT EXECUTE ON OBJECT::__SchemaNamePlaceholder__._QueryManyOrchestrations TO __SchemaNamePlaceholder___runtime
+GRANT EXECUTE ON OBJECT::__SchemaNamePlaceholder__._RenewOrchestrationLocks TO __SchemaNamePlaceholder___runtime
+GRANT EXECUTE ON OBJECT::__SchemaNamePlaceholder__._RenewTaskLocks TO __SchemaNamePlaceholder___runtime
+GRANT EXECUTE ON OBJECT::__SchemaNamePlaceholder__._UpdateVersion TO __SchemaNamePlaceholder___runtime
+GRANT EXECUTE ON OBJECT::__SchemaNamePlaceholder__._RewindInstance TO __SchemaNamePlaceholder___runtime
+GRANT EXECUTE ON OBJECT::__SchemaNamePlaceholder__._RewindInstanceRecursive TO __SchemaNamePlaceholder___runtime
 
 -- Types
-GRANT EXECUTE ON TYPE::{{SchemaNamePlaceholder}}.HistoryEvents TO {{SchemaNamePlaceholder}}_runtime
-GRANT EXECUTE ON TYPE::{{SchemaNamePlaceholder}}.MessageIDs TO {{SchemaNamePlaceholder}}_runtime
-GRANT EXECUTE ON TYPE::{{SchemaNamePlaceholder}}.InstanceIDs TO {{SchemaNamePlaceholder}}_runtime
-GRANT EXECUTE ON TYPE::{{SchemaNamePlaceholder}}.OrchestrationEvents TO {{SchemaNamePlaceholder}}_runtime
-GRANT EXECUTE ON TYPE::{{SchemaNamePlaceholder}}.TaskEvents TO {{SchemaNamePlaceholder}}_runtime
+GRANT EXECUTE ON TYPE::__SchemaNamePlaceholder__.HistoryEvents TO __SchemaNamePlaceholder___runtime
+GRANT EXECUTE ON TYPE::__SchemaNamePlaceholder__.MessageIDs TO __SchemaNamePlaceholder___runtime
+GRANT EXECUTE ON TYPE::__SchemaNamePlaceholder__.InstanceIDs TO __SchemaNamePlaceholder___runtime
+GRANT EXECUTE ON TYPE::__SchemaNamePlaceholder__.OrchestrationEvents TO __SchemaNamePlaceholder___runtime
+GRANT EXECUTE ON TYPE::__SchemaNamePlaceholder__.TaskEvents TO __SchemaNamePlaceholder___runtime
 
 GO

--- a/src/DurableTask.SqlServer/Scripts/schema-1.0.0.sql
+++ b/src/DurableTask.SqlServer/Scripts/schema-1.0.0.sql
@@ -8,27 +8,27 @@
 -- new schema-{major}.{minor}.{patch}.sql scripts.
 
 -- All objects must be created under the "dt" schema or under a custom schema.
-IF NOT EXISTS (SELECT 1 FROM sys.schemas WHERE name = '{{SchemaNamePlaceholder}}')
-    EXEC('CREATE SCHEMA {{SchemaNamePlaceholder}}');
+IF NOT EXISTS (SELECT 1 FROM sys.schemas WHERE name = '__SchemaNamePlaceholder__')
+    EXEC('CREATE SCHEMA __SchemaNamePlaceholder__');
 
 -- Create custom types
-IF TYPE_ID(N'{{SchemaNamePlaceholder}}.InstanceIDs') IS NULL
-    CREATE TYPE {{SchemaNamePlaceholder}}.InstanceIDs AS TABLE (
+IF TYPE_ID(N'__SchemaNamePlaceholder__.InstanceIDs') IS NULL
+    CREATE TYPE __SchemaNamePlaceholder__.InstanceIDs AS TABLE (
         [InstanceID] varchar(100) NOT NULL
     )
 GO
 
-IF TYPE_ID(N'{{SchemaNamePlaceholder}}.MessageIDs') IS NULL
+IF TYPE_ID(N'__SchemaNamePlaceholder__.MessageIDs') IS NULL
     -- WARNING: Reordering fields is a breaking change!
-    CREATE TYPE {{SchemaNamePlaceholder}}.MessageIDs AS TABLE (
+    CREATE TYPE __SchemaNamePlaceholder__.MessageIDs AS TABLE (
         [InstanceID] varchar(100) NULL,
         [SequenceNumber] bigint NULL
     )
 GO
 
-IF TYPE_ID(N'{{SchemaNamePlaceholder}}.HistoryEvents') IS NULL
+IF TYPE_ID(N'__SchemaNamePlaceholder__.HistoryEvents') IS NULL
     -- WARNING: Reordering fields is a breaking change!
-    CREATE TYPE {{SchemaNamePlaceholder}}.HistoryEvents AS TABLE (
+    CREATE TYPE __SchemaNamePlaceholder__.HistoryEvents AS TABLE (
         [InstanceID] varchar(100) NULL,
         [ExecutionID] varchar(50) NULL,
         [SequenceNumber] bigint NULL,
@@ -47,9 +47,9 @@ IF TYPE_ID(N'{{SchemaNamePlaceholder}}.HistoryEvents') IS NULL
     )
 GO
 
-IF TYPE_ID(N'{{SchemaNamePlaceholder}}.OrchestrationEvents') IS NULL
+IF TYPE_ID(N'__SchemaNamePlaceholder__.OrchestrationEvents') IS NULL
     -- WARNING: Reordering fields is a breaking change!
-    CREATE TYPE {{SchemaNamePlaceholder}}.OrchestrationEvents AS TABLE (
+    CREATE TYPE __SchemaNamePlaceholder__.OrchestrationEvents AS TABLE (
         [InstanceID] varchar(100) NULL,
         [ExecutionID] varchar(50) NULL,
         [SequenceNumber] bigint NULL,
@@ -66,9 +66,9 @@ IF TYPE_ID(N'{{SchemaNamePlaceholder}}.OrchestrationEvents') IS NULL
     )
 GO
 
-IF TYPE_ID(N'{{SchemaNamePlaceholder}}.TaskEvents') IS NULL
+IF TYPE_ID(N'__SchemaNamePlaceholder__.TaskEvents') IS NULL
     -- WARNING: Reordering fields is a breaking change!
-    CREATE TYPE {{SchemaNamePlaceholder}}.TaskEvents AS TABLE (
+    CREATE TYPE __SchemaNamePlaceholder__.TaskEvents AS TABLE (
         [InstanceID] varchar(100) NULL,
         [ExecutionID] varchar(50) NULL,
         [Name] varchar(300) NULL,
@@ -90,18 +90,18 @@ GO
 -- Rule #2: Do not use varchar(MAX) except in the Payloads table
 -- Rule #3: Try to follow existing naming and ordering conventions
 
-IF OBJECT_ID(N'{{SchemaNamePlaceholder}}.Versions', 'U') IS NULL
+IF OBJECT_ID(N'__SchemaNamePlaceholder__.Versions', 'U') IS NULL
 BEGIN
-    CREATE TABLE {{SchemaNamePlaceholder}}.Versions (
+    CREATE TABLE __SchemaNamePlaceholder__.Versions (
         SemanticVersion varchar(100) NOT NULL CONSTRAINT PK_Versions_SemanticVersion PRIMARY KEY WITH (IGNORE_DUP_KEY = ON),
         UpgradeTime datetime2 NOT NULL CONSTRAINT DF_Versions_UpgradeTime DEFAULT SYSUTCDATETIME()
     )
 END
 GO
 
-IF OBJECT_ID(N'{{SchemaNamePlaceholder}}.Payloads', 'U') IS NULL
+IF OBJECT_ID(N'__SchemaNamePlaceholder__.Payloads', 'U') IS NULL
 BEGIN
-    CREATE TABLE {{SchemaNamePlaceholder}}.Payloads (
+    CREATE TABLE __SchemaNamePlaceholder__.Payloads (
         [TaskHub] varchar(50) NOT NULL,
         [InstanceID] varchar(100) NOT NULL,
         [PayloadID] uniqueidentifier NOT NULL,
@@ -114,9 +114,9 @@ BEGIN
 END
 GO
 
-IF OBJECT_ID(N'{{SchemaNamePlaceholder}}.Instances', 'U') IS NULL
+IF OBJECT_ID(N'__SchemaNamePlaceholder__.Instances', 'U') IS NULL
 BEGIN
-	CREATE TABLE {{SchemaNamePlaceholder}}.Instances (
+	CREATE TABLE __SchemaNamePlaceholder__.Instances (
 		[TaskHub] varchar(50) NOT NULL,
         [InstanceID] varchar(100) NOT NULL,
 		[ExecutionID] varchar(50) NOT NULL CONSTRAINT DF_Instances_ExecutionID DEFAULT (NEWID()), -- expected to be system generated
@@ -138,17 +138,17 @@ BEGIN
 	)
 
     -- This index is used by LockNext and Purge logic
-    CREATE INDEX IX_Instances_RuntimeStatus ON {{SchemaNamePlaceholder}}.Instances(TaskHub, RuntimeStatus)
+    CREATE INDEX IX_Instances_RuntimeStatus ON __SchemaNamePlaceholder__.Instances(TaskHub, RuntimeStatus)
         INCLUDE ([LockExpiration], [CreatedTime], [CompletedTime])
     
     -- This index is intended to help the performance of multi-instance query
-    CREATE INDEX IX_Instances_CreatedTime ON {{SchemaNamePlaceholder}}.Instances(TaskHub, CreatedTime)
+    CREATE INDEX IX_Instances_CreatedTime ON __SchemaNamePlaceholder__.Instances(TaskHub, CreatedTime)
         INCLUDE ([RuntimeStatus], [CompletedTime], [InstanceID])
 END
 
-IF OBJECT_ID(N'{{SchemaNamePlaceholder}}.NewEvents', 'U') IS NULL
+IF OBJECT_ID(N'__SchemaNamePlaceholder__.NewEvents', 'U') IS NULL
 BEGIN
-    CREATE TABLE {{SchemaNamePlaceholder}}.NewEvents (
+    CREATE TABLE __SchemaNamePlaceholder__.NewEvents (
         [SequenceNumber] bigint IDENTITY NOT NULL, -- order is important for FIFO
         [Timestamp] datetime2 NOT NULL CONSTRAINT DF_NewEvents_Timestamp DEFAULT SYSUTCDATETIME(),
         [VisibleTime] datetime2 NULL, -- for scheduled messages
@@ -168,9 +168,9 @@ BEGIN
     )
 END
 
-IF OBJECT_ID(N'{{SchemaNamePlaceholder}}.History', 'U') IS NULL
+IF OBJECT_ID(N'__SchemaNamePlaceholder__.History', 'U') IS NULL
 BEGIN
-    CREATE TABLE {{SchemaNamePlaceholder}}.History (
+    CREATE TABLE __SchemaNamePlaceholder__.History (
         [TaskHub] varchar(50) NOT NULL,
         [InstanceID] varchar(100) NOT NULL,
 	    [ExecutionID] varchar(50) NOT NULL,
@@ -189,9 +189,9 @@ BEGIN
     )
 END
 
-IF OBJECT_ID(N'{{SchemaNamePlaceholder}}.NewTasks', 'U') IS NULL
+IF OBJECT_ID(N'__SchemaNamePlaceholder__.NewTasks', 'U') IS NULL
 BEGIN
-    CREATE TABLE {{SchemaNamePlaceholder}}.NewTasks (
+    CREATE TABLE __SchemaNamePlaceholder__.NewTasks (
         [TaskHub] varchar(50) NOT NULL,
         [SequenceNumber] bigint IDENTITY NOT NULL,  -- order is important for FIFO
         [InstanceID] varchar(100) NOT NULL,
@@ -211,14 +211,14 @@ BEGIN
     )
 
     -- This index is used by vScaleHints
-    CREATE NONCLUSTERED INDEX IX_NewTasks_InstanceID ON {{SchemaNamePlaceholder}}.NewTasks(TaskHub, InstanceID)
+    CREATE NONCLUSTERED INDEX IX_NewTasks_InstanceID ON __SchemaNamePlaceholder__.NewTasks(TaskHub, InstanceID)
         INCLUDE ([SequenceNumber], [Timestamp], [LockExpiration], [VisibleTime])
 END
 GO
 
-IF OBJECT_ID(N'{{SchemaNamePlaceholder}}.GlobalSettings', 'U') IS NULL
+IF OBJECT_ID(N'__SchemaNamePlaceholder__.GlobalSettings', 'U') IS NULL
 BEGIN
-    CREATE TABLE {{SchemaNamePlaceholder}}.GlobalSettings (
+    CREATE TABLE __SchemaNamePlaceholder__.GlobalSettings (
         [Name] varchar(300) NOT NULL PRIMARY KEY,
         [Value] sql_variant NULL,
         [Timestamp] datetime2 NOT NULL CONSTRAINT DF_GlobalSettings_Timestamp DEFAULT SYSUTCDATETIME(),
@@ -226,6 +226,6 @@ BEGIN
     )
     
     -- Default task hub mode is 1, or "User ID"
-    INSERT INTO {{SchemaNamePlaceholder}}.GlobalSettings ([Name], [Value]) VALUES ('TaskHubMode', 1)
+    INSERT INTO __SchemaNamePlaceholder__.GlobalSettings ([Name], [Value]) VALUES ('TaskHubMode', 1)
 END
 GO

--- a/src/DurableTask.SqlServer/SqlDbManager.cs
+++ b/src/DurableTask.SqlServer/SqlDbManager.cs
@@ -230,7 +230,7 @@ namespace DurableTask.SqlServer
 
             string scriptText = await GetScriptTextAsync(scriptName);
             
-            scriptText = scriptText.Replace("{{SchemaNamePlaceholder}}", this.settings.SchemaName);
+            scriptText = scriptText.Replace("__SchemaNamePlaceholder__", this.settings.SchemaName);
             
             // Split script into distinct executeable commands
             IEnumerable<string> scriptCommands = Regex.Split(scriptText, @"^\s*GO\s*$", RegexOptions.Multiline | RegexOptions.IgnoreCase)


### PR DESCRIPTION
With https://github.com/microsoft/durabletask-mssql/pull/110, IDEs like Visual Studio were no longer able to parse the SQL files because the `{{` and `}}` characters were not valid in many contexts.  This PR replaces `{{` and `}}` with `__` (double underscores) so that IDEs don't flag the placeholders as syntax errors.

With this change, I validated that I was able to execute all the .sql files directly against my local SQL database without doing any text substitution. We'll still do text substitution at runtime. This change is purely to simplify local development of the T-SQL code. 

This PR also adds support for custom schema names to Azure Functions via a new `schemaName` field in the host.json settings.