### PR TITLE
Fixes for deduple behavior on orchestration create

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,15 @@
 
 * Support multiple schemas in a single database ([#110](https://github.com/microsoft/durabletask-mssql/pull/110)) - contributed by [@AndreiRR24](https://github.com/AndreiRR24)
 
+### Updates
+
+* Updated [Microsoft.Azure.DurableTask.Core](https://www.nuget.org/packages/Microsoft.Azure.DurableTask.Core) dependency to v2.10.0.
+* Fixed issue where de-dupe status values on orchestration creation were being ignored ([#120](https://github.com/microsoft/durabletask-mssql/issues/120)).
+
+### Breaking changes
+
+* Attempting to recreate a running orchestration with the same instance ID now throws `OrchestrationAlreadyExistsException` instead of `InvalidOperationException`. In most cases, this will be non-breaking since `OrchestrationAlreadyExistsException` is a sub-class of `InvalidOperationException`.
+
 ## v1.0.1
 
 ### Updates

--- a/src/DurableTask.SqlServer/Scripts/logic.sql
+++ b/src/DurableTask.SqlServer/Scripts/logic.sql
@@ -149,7 +149,8 @@ CREATE OR ALTER PROCEDURE __SchemaNamePlaceholder__.CreateInstance
     @InstanceID varchar(100) = NULL,
     @ExecutionID varchar(50) = NULL,
     @InputText varchar(MAX) = NULL,
-    @StartTime datetime2 = NULL
+    @StartTime datetime2 = NULL,
+    @DedupeStatuses varchar(MAX) = 'Pending,Running'
 AS
 BEGIN
     DECLARE @TaskHub varchar(50) = __SchemaNamePlaceholder__.CurrentTaskHub()
@@ -172,7 +173,8 @@ BEGIN
         )
 
         -- Instance IDs can be overwritten only if the orchestration is in a terminal state
-        IF @existingStatus IN ('Pending', 'Running')
+        --IF @existingStatus IN ('Pending', 'Running')
+        IF @existingStatus IN (SELECT value FROM STRING_SPLIT(@DedupeStatuses, ','))
         BEGIN
             DECLARE @msg nvarchar(4000) = FORMATMESSAGE('Cannot create instance with ID ''%s'' because a pending or running instance with ID already exists.', @InstanceID);
             THROW 50001, @msg, 1;

--- a/test/DurableTask.SqlServer.Tests/Utils/TestInstance.cs
+++ b/test/DurableTask.SqlServer.Tests/Utils/TestInstance.cs
@@ -143,13 +143,15 @@ namespace DurableTask.SqlServer.Tests.Utils
             return this.client.TerminateInstanceAsync(this.instance, reason);
         }
 
-        internal async Task RestartAsync(TInput newInput)
+        internal async Task RestartAsync(TInput newInput, OrchestrationStatus[] dedupeStatuses = null)
         {
             OrchestrationInstance newInstance = await this.client.CreateOrchestrationInstanceAsync(
                 this.name,
                 this.version,
                 this.InstanceId,
-                newInput);
+                newInput,
+                tags: null,
+                dedupeStatuses);
 
             this.input = newInput;
             this.startTime = DateTime.UtcNow;


### PR DESCRIPTION
Fixes https://github.com/microsoft/durabletask-mssql/issues/120

Note that this change may be breaking, depending on how exception handling logic is written. I suspect in most, if not all cases, the change from `InvalidOperationException` to `OrchestrationAlreadyExistsException` should be non-breaking, hence, I'm releasing this fix as part of a minor version update instead of a major version update.