### PR TITLE
Synchronous reads for improved performance for large payloads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Updates
 
-* Synchronous reads for improved performance for large payloads ((#134)[https://github.com/microsoft/durabletask-mssql/pull/134])
+* Synchronous reads for improved performance for large payloads ([#134](https://github.com/microsoft/durabletask-mssql/pull/134)) - contributed by [@bhugot](https://github.com/bhugot)
 
 ## v1.1.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## v1.1.1
+
+### Updates
+
+* Synchronous reads for improved performance for large payloads ((#134)[https://github.com/microsoft/durabletask-mssql/pull/134])
+
 ## v1.1.0
 
 ### New

--- a/src/DurableTask.SqlServer/SqlOrchestrationService.cs
+++ b/src/DurableTask.SqlServer/SqlOrchestrationService.cs
@@ -252,7 +252,7 @@ namespace DurableTask.SqlServer
                     IList<HistoryEvent> history;
                     if (await reader.NextResultAsync(cancellationToken))
                     {
-                        history = await ReadHistoryEventsAsync(reader, executionIdFilter: null, cancellationToken);
+                        history = ReadHistoryEvents(reader, executionIdFilter: null, cancellationToken);
                     }
                     else
                     {
@@ -615,17 +615,17 @@ namespace DurableTask.SqlServer
 
             using DbDataReader reader = await SqlUtils.ExecuteReaderAsync(command, this.traceHelper, instanceId);
 
-            List<HistoryEvent> history = await ReadHistoryEventsAsync(reader, executionIdFilter);
+            List<HistoryEvent> history = ReadHistoryEvents(reader, executionIdFilter);
             return JsonConvert.SerializeObject(history);
         }
 
-        static async Task<List<HistoryEvent>> ReadHistoryEventsAsync(
+        static List<HistoryEvent> ReadHistoryEvents(
             DbDataReader reader,
             string? executionIdFilter = null,
             CancellationToken cancellationToken = default)
         {
             var history = new List<HistoryEvent>(capacity: 128);
-            while (!cancellationToken.IsCancellationRequested &&  reader.Read())
+            while (!cancellationToken.IsCancellationRequested && reader.Read())
             {
                 string executionId = SqlUtils.GetExecutionId(reader)!;
                 HistoryEvent e = reader.GetHistoryEvent(isOrchestrationHistory: true);

--- a/src/DurableTask.SqlServer/SqlUtils.cs
+++ b/src/DurableTask.SqlServer/SqlUtils.cs
@@ -398,7 +398,7 @@ namespace DurableTask.SqlServer
                 command,
                 traceHelper,
                 instanceId,
-                cmd => cmd.ExecuteReader());
+                cmd => cmd.ExecuteReaderAsync(cancellationToken));
         }
 
         public static Task<int> ExecuteNonQueryAsync(
@@ -432,32 +432,6 @@ namespace DurableTask.SqlServer
             LogHelper traceHelper,
             string? instanceId,
             Func<DbCommand, Task<T>> executor)
-        {
-            var context = new SprocExecutionContext();
-            try
-            {
-                return await WithRetry(() => executor(command), context, traceHelper, instanceId);
-            }
-            finally
-            {
-                context.LatencyStopwatch.Stop();
-                switch (command.CommandType)
-                {
-                    case CommandType.StoredProcedure:
-                        traceHelper.SprocCompleted(command.CommandText, context.LatencyStopwatch, context.RetryCount, instanceId);
-                        break;
-                    default:
-                        traceHelper.CommandCompleted(command.CommandText, context.LatencyStopwatch, context.RetryCount, instanceId);
-                        break;
-                }
-            }
-        }
-
-        static async Task<T> ExecuteSprocAndTraceAsync<T>(
-            DbCommand command,
-            LogHelper traceHelper,
-            string? instanceId,
-            Func<DbCommand, T> executor)
         {
             var context = new SprocExecutionContext();
             try

--- a/src/DurableTask.SqlServer/SqlUtils.cs
+++ b/src/DurableTask.SqlServer/SqlUtils.cs
@@ -529,50 +529,6 @@ namespace DurableTask.SqlServer
             }
         }
 
-        static async Task<T> WithRetry<T>(Func<T> func, SprocExecutionContext context, LogHelper traceHelper, string? instanceId, int maxRetries = 5)
-        {
-            context.RetryCount = 0;
-
-            while (true)
-            {
-                try
-                {
-                    return func();
-                }
-                catch (Exception e)
-                {
-                    if (!IsTransient(e))
-                    {
-                        // Not a retriable exception
-                        throw;
-                    }
-
-                    if (context.RetryCount >= maxRetries)
-                    {
-                        // Maxed out on retries. The layer above may do its own retries later.
-                        throw;
-                    }
-
-                    // Linear backoff where we add 1 second each time, so for retryCount = 5
-                    // we could delay as long as 0 + 1 + 2 + 3 + 4 = 10 total seconds.
-                    TimeSpan delay = TimeSpan.FromSeconds(context.RetryCount);
-                    lock (random)
-                    {
-                        // Add a small amount of random delay to distribute concurrent retries 
-                        delay += TimeSpan.FromMilliseconds(random.Next(100));
-                    }
-
-                    // Log a warning so that these issues can be properly investigated
-                    traceHelper.TransientDatabaseFailure(e, instanceId, context.RetryCount);
-
-                    await Task.Delay(delay);
-
-                    context.RetryCount++;
-                }
-            }
-        }
-
-
         static bool IsTransient(Exception exception)
         {
             if (exception is SqlException sqlException)

--- a/src/common.props
+++ b/src/common.props
@@ -17,7 +17,7 @@
   <PropertyGroup>
     <MajorVersion>1</MajorVersion>
     <MinorVersion>1</MinorVersion>
-    <PatchVersion>0</PatchVersion>
+    <PatchVersion>1</PatchVersion>
     <VersionPrefix>$(MajorVersion).$(MinorVersion).$(PatchVersion)</VersionPrefix>
     <VersionSuffix></VersionSuffix>
     <AssemblyVersion>$(MajorVersion).$(MinorVersion).0.0</AssemblyVersion>

--- a/test/DurableTask.SqlServer.AzureFunctions.Tests/Utils.cs
+++ b/test/DurableTask.SqlServer.AzureFunctions.Tests/Utils.cs
@@ -72,7 +72,7 @@ namespace DurableTask.SqlServer.AzureFunctions.Tests
                     return status;
                 }
 
-                await Task.Delay(TimeSpan.FromMilliseconds(500));
+                await Task.Delay(TimeSpan.FromMilliseconds(500), cancellationToken);
             }
 
             cancellationToken.ThrowIfCancellationRequested();

--- a/test/DurableTask.SqlServer.Tests/Integration/StressTests.cs
+++ b/test/DurableTask.SqlServer.Tests/Integration/StressTests.cs
@@ -5,6 +5,7 @@ namespace DurableTask.SqlServer.Tests.Integration
 {
     using System;
     using System.Collections.Generic;
+    using System.Linq;
     using System.Threading.Tasks;
     using DurableTask.SqlServer.Tests.Utils;
     using Xunit;
@@ -28,17 +29,17 @@ namespace DurableTask.SqlServer.Tests.Integration
         Task IAsyncLifetime.InitializeAsync() => this.testService.InitializeAsync();
 
         Task IAsyncLifetime.DisposeAsync() => this.testService.DisposeAsync();
-
+        static string bigString = string.Join("",  Enumerable.Range(0, 1024 * 1024 * 10).Select(x => "1"));
         // This test has previously been used to uncover various deadlock issues by stressing the code paths
         // related to foreign keys that point to the Instances and Payloads tables.
         // Example: https://github.com/microsoft/durabletask-mssql/issues/45 
-        [Theory]
+        [Theory(Timeout = 1_000_000)]
         [InlineData(10)]
         [InlineData(2000)]
         public async Task ParallelSubOrchestrations(int subOrchestrationCount)
         {
             const string SubOrchestrationName = "SubOrchestration";
-
+           
             this.testService.RegisterInlineOrchestration<DateTime, string>(
                 orchestrationName: SubOrchestrationName,
                 version: "",
@@ -61,6 +62,46 @@ namespace DurableTask.SqlServer.Tests.Integration
                             version: "",
                             instanceId: $"suborchestration[{i}]",
                             input: $"{i}");
+                        listInstances.Add(instance);
+                    }
+
+                    DateTime[] results = await Task.WhenAll(listInstances);
+                    return new List<DateTime>(results);
+                });
+
+            // On a fast Windows desktop machine, a 2000 sub-orchestration test should complete in 30-40 seconds.
+            // On slower CI machines, this test could take several minutes to complete.
+            await testInstance.WaitForCompletion(TimeSpan.FromMinutes(5));
+        }
+
+        [Theory(Timeout = 100_000)]
+        [InlineData(10)]
+        public async Task ParallelWithBigPayload(int subOrchestrationCount)
+        {
+            const string SubOrchestrationName = "SubOrchestration";
+           
+            this.testService.RegisterInlineOrchestration<DateTime, string>(
+                orchestrationName: SubOrchestrationName,
+                version: "",
+                implementation: async (ctx, input) =>
+                {
+                    await ctx.CreateTimer(DateTime.MinValue, input);
+                    return ctx.CurrentUtcDateTime;
+                });
+
+            TestInstance<int> testInstance = await this.testService.RunOrchestration(
+                input: 1,
+                orchestrationName: nameof(ParallelSubOrchestrations),
+                implementation: async (ctx, input) =>
+                {
+                    var listInstances = new List<Task<DateTime>>();
+                    for (int i = 0; i < subOrchestrationCount; i++)
+                    {
+                        Task<DateTime> instance = ctx.CreateSubOrchestrationInstance<DateTime>(
+                            name: SubOrchestrationName,
+                            version: "",
+                            instanceId: $"suborchestration[{i}]",
+                            input: $"{i}-{bigString}");
                         listInstances.Add(instance);
                     }
 

--- a/test/DurableTask.SqlServer.Tests/Integration/StressTests.cs
+++ b/test/DurableTask.SqlServer.Tests/Integration/StressTests.cs
@@ -29,7 +29,7 @@ namespace DurableTask.SqlServer.Tests.Integration
         Task IAsyncLifetime.InitializeAsync() => this.testService.InitializeAsync();
 
         Task IAsyncLifetime.DisposeAsync() => this.testService.DisposeAsync();
-        static string bigString = string.Join("",  Enumerable.Range(0, 1024 * 1024 * 10).Select(x => "1"));
+        static readonly string BigString = string.Join("",  Enumerable.Range(0, 1024 * 1024 * 10).Select(x => "1"));
         // This test has previously been used to uncover various deadlock issues by stressing the code paths
         // related to foreign keys that point to the Instances and Payloads tables.
         // Example: https://github.com/microsoft/durabletask-mssql/issues/45 
@@ -101,7 +101,7 @@ namespace DurableTask.SqlServer.Tests.Integration
                             name: SubOrchestrationName,
                             version: "",
                             instanceId: $"suborchestration[{i}]",
-                            input: $"{i}-{bigString}");
+                            input: $"{i}-{BigString}");
                         listInstances.Add(instance);
                     }
 


### PR DESCRIPTION
…on  because of mssql client async bug [sqlcli](https://github.com/dotnet/SqlClient/issues/593)

It should be easy to switch back when the fix is done
It should also fix #126