### PR TITLE
Add dotnet-isolated extensions package

### DIFF
--- a/DurableTask.SqlServer.sln
+++ b/DurableTask.SqlServer.sln
@@ -33,6 +33,8 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "test", "test", "{4A7226CF-5
 		test\setup.ps1 = test\setup.ps1
 	EndProjectSection
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Functions.Worker.Extensions.DurableTask.SqlServer", "src\Functions.Worker.Extensions.DurableTask.SqlServer\Functions.Worker.Extensions.DurableTask.SqlServer.csproj", "{307C5A62-9943-48B8-8513-BBCDF0FBC3D0}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -59,6 +61,10 @@ Global
 		{DD1E1B3F-4FA2-4F3A-9AE1-6B2A0B864AAF}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{DD1E1B3F-4FA2-4F3A-9AE1-6B2A0B864AAF}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{DD1E1B3F-4FA2-4F3A-9AE1-6B2A0B864AAF}.Release|Any CPU.Build.0 = Release|Any CPU
+		{307C5A62-9943-48B8-8513-BBCDF0FBC3D0}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{307C5A62-9943-48B8-8513-BBCDF0FBC3D0}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{307C5A62-9943-48B8-8513-BBCDF0FBC3D0}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{307C5A62-9943-48B8-8513-BBCDF0FBC3D0}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -69,6 +75,7 @@ Global
 		{FC03BDA8-8A73-45F4-8D21-25F739BFF9E1} = {D33AB157-04B9-4BAD-B580-C3C87C17828C}
 		{1809EEF7-0772-404A-96C2-D76D80F1D191} = {4A7226CF-57BF-4CA3-A4AC-91A398A1D84B}
 		{DD1E1B3F-4FA2-4F3A-9AE1-6B2A0B864AAF} = {4A7226CF-57BF-4CA3-A4AC-91A398A1D84B}
+		{307C5A62-9943-48B8-8513-BBCDF0FBC3D0} = {D33AB157-04B9-4BAD-B580-C3C87C17828C}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {238A9613-5411-41CF-BDEC-168CCD5C03FB}

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -6,7 +6,7 @@ For local development using Azure Functions, select one of the [tools available 
 
 !> At the time of writing, the Durable SQL provider is in its early stages and does not yet work with the Azure Functions Consumption plan. It does work with the Azure Functions Elastic Premium plan but you must enable [Runtime Scale Monitoring](https://docs.microsoft.com/azure/azure-functions/functions-networking-options#premium-plan-with-virtual-network-triggers) to get automatic scaling. App Service plans are also supported. Consumption plan support and Scale Controller support for Elastic Premium is coming in a later release.
 
-### .NET
+### .NET InProc
 
 Durable Functions projects targeting the .NET in-process worker can add the [Microsoft.DurableTask.SqlServer.AzureFunction](https://www.nuget.org/packages/Microsoft.DurableTask.SqlServer.AzureFunctions) package by running the following `dotnet` CLI command:
 
@@ -14,7 +14,19 @@ Durable Functions projects targeting the .NET in-process worker can add the [Mic
 dotnet add package Microsoft.DurableTask.SqlServer.AzureFunctions --prerelease
 ```
 
-!> Durable Functions is not currently supported in the .NET Isolated worker.
+The `Microsoft.Azure.Functions.Worker.Extensions.DurableTask.SqlServer` package from .NET isolated should **not** be added.
+
+### .NET Isolated
+
+!> Durable Functions is in preview for dotnet isolated.
+
+Durable Functions projects targeting the .NET isolated worker can add the [Microsoft.Azure.Functions.Worker.Extensions.DurableTask.SqlServer](https://www.nuget.org/packages/Microsoft.Azure.Functions.Worker.Extensions.DurableTask.SqlServer) package by running the following `dotnet` CLI command:
+
+```bash
+dotnet add package Microsoft.Azure.Functions.Worker.Extensions.DurableTask.SqlServer --prerelease
+```
+
+The `Microsoft.DurableTask.SqlServer.AzureFunctions` package from .NET InProc should **not** be added.
 
 ### JavaScript, Python, Java, and PowerShell
 

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -11,7 +11,7 @@ For local development using Azure Functions, select one of the [tools available 
 Durable Functions projects targeting the .NET in-process worker can add the [Microsoft.DurableTask.SqlServer.AzureFunction](https://www.nuget.org/packages/Microsoft.DurableTask.SqlServer.AzureFunctions) package by running the following `dotnet` CLI command:
 
 ```bash
-dotnet add package Microsoft.DurableTask.SqlServer.AzureFunctions --prerelease
+dotnet add package Microsoft.DurableTask.SqlServer.AzureFunctions
 ```
 
 The `Microsoft.Azure.Functions.Worker.Extensions.DurableTask.SqlServer` package from .NET isolated should **not** be added.
@@ -23,7 +23,7 @@ The `Microsoft.Azure.Functions.Worker.Extensions.DurableTask.SqlServer` package 
 Durable Functions projects targeting the .NET isolated worker can add the [Microsoft.Azure.Functions.Worker.Extensions.DurableTask.SqlServer](https://www.nuget.org/packages/Microsoft.Azure.Functions.Worker.Extensions.DurableTask.SqlServer) package by running the following `dotnet` CLI command:
 
 ```bash
-dotnet add package Microsoft.Azure.Functions.Worker.Extensions.DurableTask.SqlServer --prerelease
+dotnet add package Microsoft.Azure.Functions.Worker.Extensions.DurableTask.SqlServer
 ```
 
 The `Microsoft.DurableTask.SqlServer.AzureFunctions` package from .NET InProc should **not** be added.

--- a/src/Functions.Worker.Extensions.DurableTask.SqlServer/Functions.Worker.Extensions.DurableTask.SqlServer.csproj
+++ b/src/Functions.Worker.Extensions.DurableTask.SqlServer/Functions.Worker.Extensions.DurableTask.SqlServer.csproj
@@ -1,0 +1,22 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <!-- Import common properties for all shipping packages-->
+  <Import Project="../common.props" />
+  
+  <PropertyGroup>
+    <TargetFrameworks>netstandard2.0</TargetFrameworks>
+  </PropertyGroup>
+  
+  <!-- NuGet package settings -->
+  <PropertyGroup>
+    <PackageId>Microsoft.Azure.Functions.Worker.Extensions.DurableTask.SqlServer</PackageId>
+    <Title>Azure Durable Functions SQL Provider</Title>
+    <Description>Microsoft SQL provider for Azure Durable Functions.</Description>
+    <PackageTags>Microsoft;Azure;Functions;Durable;Task;Orchestration;Workflow;Activity;Reliable;SQL</PackageTags>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.Abstractions" Version="1.1.0" />
+  </ItemGroup>
+
+</Project>

--- a/src/Functions.Worker.Extensions.DurableTask.SqlServer/Properties/AssemblyInfo.cs
+++ b/src/Functions.Worker.Extensions.DurableTask.SqlServer/Properties/AssemblyInfo.cs
@@ -1,0 +1,7 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using Microsoft.Azure.Functions.Worker.Extensions.Abstractions;
+
+// This must be updated when updating the version of the package
+[assembly: ExtensionInformation("Microsoft.Azure.DurableTask.SqlServer.AzureFunctions", "1.1.0")]

--- a/src/Functions.Worker.Extensions.DurableTask.SqlServer/Properties/AssemblyInfo.cs
+++ b/src/Functions.Worker.Extensions.DurableTask.SqlServer/Properties/AssemblyInfo.cs
@@ -4,4 +4,4 @@
 using Microsoft.Azure.Functions.Worker.Extensions.Abstractions;
 
 // This must be updated when updating the version of the package
-[assembly: ExtensionInformation("Microsoft.Azure.DurableTask.SqlServer.AzureFunctions", "1.1.0")]
+[assembly: ExtensionInformation("Microsoft.Azure.DurableTask.SqlServer.AzureFunctions", "1.1.0-rc")]


### PR DESCRIPTION
This PR enables mssql usage in Azure functions dotnet isolated. 

- Adds a new project and nuget package `Microsoft.Azure.Functions.Worker.Extensions.DurableTask.SqlServer`, which has a single attribute that tells the host to load the `Microsoft.Azure.DurableTask.SqlServer.AzureFunctions` package.
    - Customers will reference this package in their dotnet isolated projects (and _not_ `Microsoft.Azure.DurableTask.SqlServer.AzureFunctions`)