### PR TITLE
Update Durable Functions extension dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,8 +9,10 @@
 ### Updates
 
 * Updated [Microsoft.Azure.DurableTask.Core](https://www.nuget.org/packages/Microsoft.Azure.DurableTask.Core) dependency to v2.10.0.
+* Updated [Microsoft.Azure.WebJobs.Extensions.DurableTask](https://www.nuget.org/packages/Microsoft.Azure.WebJobs.Extensions.DurableTask) dependency to v2.9.0.
 * Fixed issue where de-dupe status values on orchestration creation were being ignored ([#120](https://github.com/microsoft/durabletask-mssql/issues/120)).
 * Fixed issue where external client ignores task hub name configuration ([#128](https://github.com/microsoft/durabletask-mssql/issues/128)) - contributed by [@bhugot](https://github.com/bhugot)
+* Enable implicit entity deletion for Durable Entities ([#119](https://github.com/microsoft/durabletask-mssql/issues/119))
 
 ### Breaking changes
 

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -2,42 +2,21 @@
 
 ## Azure Functions
 
-For local development using Azure Functions, select one of the [tools available for local development](https://docs.microsoft.com/azure/azure-functions/functions-develop-local). To configure the Durable SQL provider, you'll need to add the [Microsoft.DurableTask.SqlServer.AzureFunction](https://www.nuget.org/packages/Microsoft.DurableTask.SqlServer.AzureFunctions) NuGet package reference to your project.
-
-!> At the time of writing, the Durable SQL provider is in its early stages and does not yet work with the Azure Functions Consumption plan. It does work with the Azure Functions Elastic Premium plan but you must enable [Runtime Scale Monitoring](https://docs.microsoft.com/azure/azure-functions/functions-networking-options#premium-plan-with-virtual-network-triggers) to get automatic scaling. App Service plans are also supported. Consumption plan support and Scale Controller support for Elastic Premium is coming in a later release.
+For local development using Azure Functions, select one of the [tools available for local development](https://docs.microsoft.com/azure/azure-functions/functions-develop-local). To configure the Durable SQL provider, you'll need to add the [Microsoft.DurableTask.SqlServer.AzureFunctions](https://www.nuget.org/packages/Microsoft.DurableTask.SqlServer.AzureFunctions) NuGet package reference to your project.
 
 ### .NET
 
-Durable Functions projects targeting the .NET in-process worker can add the [Microsoft.DurableTask.SqlServer.AzureFunction](https://www.nuget.org/packages/Microsoft.DurableTask.SqlServer.AzureFunctions) package by running the following `dotnet` CLI command:
+Durable Functions projects targeting the .NET in-process worker can add the [Microsoft.DurableTask.SqlServer.AzureFunctions](https://www.nuget.org/packages/Microsoft.DurableTask.SqlServer.AzureFunctions) package by running the following `dotnet` CLI command:
 
 ```bash
-dotnet add package Microsoft.DurableTask.SqlServer.AzureFunctions --prerelease
+dotnet add package Microsoft.DurableTask.SqlServer.AzureFunctions
 ```
 
-!> Durable Functions is not currently supported in the .NET Isolated worker.
+!> Durable Functions is not currently supported in the .NET Isolated worker (but support is coming [soon](https://github.com/microsoft/durabletask-mssql/pull/136)).
 
 ### JavaScript, Python, Java, and PowerShell
 
-JavaScript, Python, and PowerShell projects can add the [Microsoft.DurableTask.SqlServer.AzureFunction](https://www.nuget.org/packages/Microsoft.DurableTask.SqlServer.AzureFunctions) package by running the following `func` CLI command. Note that in addition to the Azure Functions Core Tools, you must also have a recent [.NET SDK](https://dotnet.microsoft.com/download) installed locally.
-
-```bash
-func extensions install -p Microsoft.DurableTask.SqlServer.AzureFunctions -v 1.1.0
-```
-
-?> Check [here](https://www.nuget.org/packages/Microsoft.DurableTask.SqlServer.AzureFunctions) to see if newer versions of the SQL provider package are available, and update the above command to reference the latest available version.
-
-!> The Durable SQL backend is not currently supported with extension bundles. Support for extension bundles will be available at or before the *General Availability* release.
-
-This command will generate a file named **extensions.csproj** in the local directory, or update the file if one already exists. At the time of writing, you'll need to make an additional edit to this file to work around [this Azure Functions tooling issue](https://github.com/Azure/azure-functions-host/issues/6925#issuecomment-885253901):
-
-```xml
-  <!-- Workaround for https://github.com/Azure/azure-functions-host/issues/6925 -->
-  <Target Name="PostBuild" AfterTargets="PostBuildEvent">
-    <Move SourceFiles="$(OutDir)/extensions.deps.json" DestinationFiles="$(OutDir)/function.deps.json" />
-  </Target>
-```
-
-This ensures that all native dependencies are available when you try to start up the Function app.
+JavaScript, Python, Java, and PowerShell projects automatically get access to the MSSQL backend extension when they use the latest version of v3 or v4 extension bundles.
 
 ### Host.json configuration
 

--- a/src/DurableTask.SqlServer.AzureFunctions/DurableTask.SqlServer.AzureFunctions.csproj
+++ b/src/DurableTask.SqlServer.AzureFunctions/DurableTask.SqlServer.AzureFunctions.csproj
@@ -16,7 +16,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.DurableTask" Version="2.7.*" />
+    <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.DurableTask" Version="2.9.*" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/DurableTask.SqlServer.AzureFunctions/SqlDurabilityProvider.cs
+++ b/src/DurableTask.SqlServer.AzureFunctions/SqlDurabilityProvider.cs
@@ -35,6 +35,8 @@ namespace DurableTask.SqlServer.AzureFunctions
         
         public override bool GuaranteesOrderedDelivery => true;
 
+        public override bool SupportsImplicitEntityDeletion => true;
+
         public override JObject ConfigurationJson => JObject.FromObject(this.durabilityOptions);
 
         public override TimeSpan MaximumDelayTime { get; set; } = TimeSpan.MaxValue;

--- a/src/common.props
+++ b/src/common.props
@@ -19,6 +19,7 @@
     <MinorVersion>1</MinorVersion>
     <PatchVersion>0</PatchVersion>
     <VersionPrefix>$(MajorVersion).$(MinorVersion).$(PatchVersion)</VersionPrefix>
+    <VersionSuffix>rc</VersionSuffix>
     <AssemblyVersion>$(MajorVersion).$(MinorVersion).0.0</AssemblyVersion>
     <FileVersion>$(VersionPrefix).0</FileVersion>
     <!-- FileVersionRevision is expected to be set by the CI. This is useful for distinguishing between multiple builds of the same version. -->


### PR DESCRIPTION
Several quick changes in this PR:

* Update Durable Functions extension dependency to v2.9
* Update Durable Functions quickstart docs to reflect latest language compatibility information
* Enable `SupportsImplicitEntityDeletion` for Durable Entities
* Set package version to have `-rc` suffix to enable a quick non-production reader release