### PR TITLE
Make SqlScaleMonitor and SqlScaleMetric public for Scale Controller Redesign

### DIFF
--- a/src/DurableTask.SqlServer.AzureFunctions/SqlScaleMetric.cs
+++ b/src/DurableTask.SqlServer.AzureFunctions/SqlScaleMetric.cs
@@ -5,7 +5,10 @@ namespace DurableTask.SqlServer.AzureFunctions
 {
     using Microsoft.Azure.WebJobs.Host.Scale;
 
-    class SqlScaleMetric : ScaleMetrics
+    /// <summary>
+    /// Contains metrics used to make scale decisions for a SqlScaleMetric.
+    /// </summary>
+    public class SqlScaleMetric : ScaleMetrics
     {
         public int RecommendedReplicaCount { get; set; }
     }

--- a/src/DurableTask.SqlServer.AzureFunctions/SqlScaleMonitor.cs
+++ b/src/DurableTask.SqlServer.AzureFunctions/SqlScaleMonitor.cs
@@ -13,7 +13,7 @@ namespace DurableTask.SqlServer.AzureFunctions
     /// <summary>
     /// Azure Functions scale monitor implementation for the Durable Functions SQL backend.
     /// </summary>
-    class SqlScaleMonitor : IScaleMonitor<SqlScaleMetric>
+    public class SqlScaleMonitor : IScaleMonitor<SqlScaleMetric>
     {
         static readonly ScaleStatus ScaleInVote = new ScaleStatus { Vote = ScaleVote.ScaleIn };
         static readonly ScaleStatus NoScaleVote = new ScaleStatus { Vote = ScaleVote.None };
@@ -23,6 +23,12 @@ namespace DurableTask.SqlServer.AzureFunctions
 
         int? previousWorkerCount = -1;
 
+        /// <summary>
+        /// Creates a SqlScaleMonitor instance.
+        /// </summary>
+        /// <param name="service">The SqlOrchestrationService used to create the connection.</param>
+        /// <param name="taskHubName">The name of the monitored task hub.</param>
+        /// <exception cref="ArgumentNullException"></exception>
         public SqlScaleMonitor(SqlOrchestrationService service, string taskHubName)
         {
             this.service = service ?? throw new ArgumentNullException(nameof(service));


### PR DESCRIPTION
We are currently redesigning the scale controller to unify the duplicate scaling logic that resides in each of the extensions (CosmosDB, ServiceBus, EventHubs, Storage, etc.) and the scale controller. As a part of this redesign, scale controller will directly instantiate the ScaleMonitors for each of the above extensions, and call into the GetMetricsAsync and GetScaleStatus methods directly. To support this, we need to make ScaleMonitors, and any dependent classes public in each of the extensions. 

Resources:
- [Azure Functions Scale Controller Redesign.docx](https://microsoft.sharepoint.com/:w:/r/teams/Antares/Shared%20Documents/Functions/Azure%20Functions%20Scale%20Controller%20Redesign.docx?d=wf9ab8e165f9644229184af0bc429587b&csf=1&web=1&e=bpERSt)
- [Azure Functions WebJobs SDK scaling changes.docx](https://microsoft.sharepoint.com/:w:/r/teams/Antares/Shared%20Documents/Functions/Azure%20Functions%20WebJobs%20SDK%20scaling%20changes.docx?d=w52e54eca0ff5459eb2312428921b6e46&csf=1&web=1&e=wMDf8Y)
- [WebJobsSDK that calls into each scale monitor](https://github.com/Azure/azure-webjobs-sdk/pull/2937)
- [Code snippet in v3.x that uses public scale monitor](https://msazure.visualstudio.com/One/_git/AAPT-Antares-ScaleController?path=/src/ScaleController/Triggers/DurableTaskTrigger.cs&version=GBv3.x&line=165&lineEnd=165&lineStartColumn=31&lineEndColumn=51&lineStyle=plain&_a=contents)