### PR TITLE
Revert "Make SqlScaleMonitor and SqlScaleMetric public for Scale Controller Redesign

### DIFF
--- a/src/DurableTask.SqlServer.AzureFunctions/SqlScaleMetric.cs
+++ b/src/DurableTask.SqlServer.AzureFunctions/SqlScaleMetric.cs
@@ -5,10 +5,7 @@ namespace DurableTask.SqlServer.AzureFunctions
 {
     using Microsoft.Azure.WebJobs.Host.Scale;
 
-    /// <summary>
-    /// Contains metrics used to make scale decisions for a SqlScaleMetric.
-    /// </summary>
-    public class SqlScaleMetric : ScaleMetrics
+    class SqlScaleMetric : ScaleMetrics
     {
         public int RecommendedReplicaCount { get; set; }
     }

--- a/src/DurableTask.SqlServer.AzureFunctions/SqlScaleMonitor.cs
+++ b/src/DurableTask.SqlServer.AzureFunctions/SqlScaleMonitor.cs
@@ -13,7 +13,7 @@ namespace DurableTask.SqlServer.AzureFunctions
     /// <summary>
     /// Azure Functions scale monitor implementation for the Durable Functions SQL backend.
     /// </summary>
-    public class SqlScaleMonitor : IScaleMonitor<SqlScaleMetric>
+    class SqlScaleMonitor : IScaleMonitor<SqlScaleMetric>
     {
         static readonly ScaleStatus ScaleInVote = new ScaleStatus { Vote = ScaleVote.ScaleIn };
         static readonly ScaleStatus NoScaleVote = new ScaleStatus { Vote = ScaleVote.None };
@@ -23,12 +23,6 @@ namespace DurableTask.SqlServer.AzureFunctions
 
         int? previousWorkerCount = -1;
 
-        /// <summary>
-        /// Creates a SqlScaleMonitor instance.
-        /// </summary>
-        /// <param name="service">The SqlOrchestrationService used to create the connection.</param>
-        /// <param name="taskHubName">The name of the monitored task hub.</param>
-        /// <exception cref="ArgumentNullException"></exception>
         public SqlScaleMonitor(SqlOrchestrationService service, string taskHubName)
         {
             this.service = service ?? throw new ArgumentNullException(nameof(service));


### PR DESCRIPTION
Reverts microsoft/durabletask-mssql#139

To incorporate new work by Alexey, we are instead creating IScalerFactory implementations across all extensions to keep the ScaleMonitors and Metrics internal