### PR TITLE
Fix Az Func dotnet-isolated extension

### DIFF
--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -16,7 +16,15 @@ The `Microsoft.Azure.Functions.Worker.Extensions.DurableTask.SqlServer` package 
 
 ### .NET Isolated
 
-The SQL provider does not yet support Durable Functions on the .NET Isolated worker. See [this GitHub issue](https://github.com/microsoft/durabletask-mssql/issues/106) for the latest updates.
+!> Durable Functions is currently in preview for .NET isolated.
+
+Durable Functions projects targeting the .NET isolated worker can add the [Microsoft.Azure.Functions.Worker.Extensions.DurableTask.SqlServer](https://www.nuget.org/packages/Microsoft.Azure.Functions.Worker.Extensions.DurableTask.SqlServer) NuGet package by running the following `dotnet` CLI command:
+
+```bash
+dotnet add package Microsoft.Azure.Functions.Worker.Extensions.DurableTask.SqlServer
+```
+
+!> The `Microsoft.DurableTask.SqlServer.AzureFunctions` package from .NET InProc should **not** be added. This package is only appropriate for the legacy .NET in-process worker.
 
 ### JavaScript, Python, Java, and PowerShell
 
@@ -36,7 +44,7 @@ You can configure the Durable SQL provider by updating the `extensions/durableTa
         "connectionStringName": "SQLDB_Connection",
         "taskEventLockTimeout": "00:02:00",
         "createDatabaseIfNotExists": true,
-        "schemaName": null
+        "schemaName": "dt"
       }
     }
   }

--- a/src/Functions.Worker.Extensions.DurableTask.SqlServer/Functions.Worker.Extensions.DurableTask.SqlServer.csproj
+++ b/src/Functions.Worker.Extensions.DurableTask.SqlServer/Functions.Worker.Extensions.DurableTask.SqlServer.csproj
@@ -5,11 +5,12 @@
   
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0</TargetFrameworks>
+    <AssemblyName>Microsoft.Azure.Functions.Worker.Extensions.DurableTask.SqlServer</AssemblyName>
   </PropertyGroup>
   
   <!-- NuGet package settings -->
   <PropertyGroup>
-    <PackageId>Microsoft.Azure.Functions.Worker.Extensions.DurableTask.SqlServer</PackageId>
+    <PackageId>$(AssemblyName)</PackageId>
     <Title>Azure Durable Functions SQL Provider</Title>
     <Description>Microsoft SQL provider for Azure Durable Functions.</Description>
     <PackageTags>Microsoft;Azure;Functions;Durable;Task;Orchestration;Workflow;Activity;Reliable;SQL</PackageTags>

--- a/src/Functions.Worker.Extensions.DurableTask.SqlServer/Properties/AssemblyInfo.cs
+++ b/src/Functions.Worker.Extensions.DurableTask.SqlServer/Properties/AssemblyInfo.cs
@@ -4,4 +4,4 @@
 using Microsoft.Azure.Functions.Worker.Extensions.Abstractions;
 
 // This must be updated when updating the version of the package
-[assembly: ExtensionInformation("Microsoft.Azure.DurableTask.SqlServer.AzureFunctions", "1.1.*")]
+[assembly: ExtensionInformation("Microsoft.DurableTask.SqlServer.AzureFunctions", "1.1.*", true)]


### PR DESCRIPTION
Two fixes:
1. Make sure assembly name and package name match (for consistency)
2. Add `enableImplicitRegistration = true` to the extension attribute.
    - This is because our package has 0 binding attributes in it, the build task skips it unless this is set to `true`.