### PR TITLE
Fix timeout arg exception in WaitForOrchestrationAsync

### DIFF
--- a/src/DurableTask.SqlServer/SqlOrchestrationService.cs
+++ b/src/DurableTask.SqlServer/SqlOrchestrationService.cs
@@ -538,7 +538,10 @@ namespace DurableTask.SqlServer
             TimeSpan timeout,
             CancellationToken cancellationToken)
         {
-            using var timeoutCts = new CancellationTokenSource(timeout);
+            using var timeoutCts = timeout < TimeSpan.MaxValue && timeout >= TimeSpan.Zero ?
+                new CancellationTokenSource(timeout) :
+                new CancellationTokenSource();
+
             using var combinedCts = CancellationTokenSource.CreateLinkedTokenSource(
                 timeoutCts.Token,
                 cancellationToken);

--- a/test/DurableTask.SqlServer.AzureFunctions.Tests/Utils.cs
+++ b/test/DurableTask.SqlServer.AzureFunctions.Tests/Utils.cs
@@ -39,7 +39,7 @@ namespace DurableTask.SqlServer.AzureFunctions.Tests
                         return status;
                 }
 
-                await Task.Delay(TimeSpan.FromMilliseconds(500));
+                await Task.Delay(TimeSpan.FromMilliseconds(500), cancellationToken);
             }
 
             cancellationToken.ThrowIfCancellationRequested();


### PR DESCRIPTION
Resolves #121 

Handling the case where `TimeSpan.MaxValue` or `TimeSpan.MinValue` are used for the timeout value in `WaitForOrchestrationAsync(...)`. In both cases, we treat it as meaning "no timeout".