### PR TITLE
Quick fix for sub-orchestration gRPC serialization issue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Updates
 
 * Synchronous reads for improved performance for large payloads ([#134](https://github.com/microsoft/durabletask-mssql/pull/134)) - contributed by [@bhugot](https://github.com/bhugot)
+* Fix for sub-orchestration handling over gRPC ([#149](https://github.com/microsoft/durabletask-mssql/pull/149))
 
 ## v1.1.0
 

--- a/src/DurableTask.SqlServer/SqlUtils.cs
+++ b/src/DurableTask.SqlServer/SqlUtils.cs
@@ -127,7 +127,7 @@ namespace DurableTask.SqlServer
                     historyEvent = new SubOrchestrationInstanceCreatedEvent(eventId)
                     {
                         Input = GetPayloadText(reader),
-                        InstanceId = null, // TODO
+                        InstanceId = "", // Placeholder - shouldn't technically be needed (adding it requires a SQL schema change)
                         Name = GetName(reader),
                         Version = null,
                     };


### PR DESCRIPTION
Fixes #145 

The issue is specific to protobuf/gRPC serialization of history events used by Azure Functions .NET Isolated and Java. There was a `null` placeholder value for `SubOrchestrationInstanceCreatedEvent.InstanceId`, which was not compatible with the protobuf contract. The quick fix is to use `""` instead of `null`.

There is a potentially larger fix, which is to correctly rehydrate the instance ID value for this history event, but this would require a database schema change, which is a much more expensive process. Per testing, the workaround in this PR should be sufficient to unblock basic sub-orchestration usage.