### PR TITLE
Fix continue-as-new data corruption issue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 * Synchronous reads for improved performance for large payloads ([#134](https://github.com/microsoft/durabletask-mssql/pull/134)) - contributed by [@bhugot](https://github.com/bhugot)
 * Fix for sub-orchestration handling over gRPC ([#149](https://github.com/microsoft/durabletask-mssql/pull/149))
+* Fix continue-as-new data corruption race condition ([#150](https://github.com/microsoft/durabletask-mssql/pull/150))
 
 ## v1.1.0
 

--- a/test/DurableTask.SqlServer.AzureFunctions.Tests/CoreScenarios.cs
+++ b/test/DurableTask.SqlServer.AzureFunctions.Tests/CoreScenarios.cs
@@ -77,7 +77,7 @@ namespace DurableTask.SqlServer.AzureFunctions.Tests
         }
 
         [Fact]
-        public async Task CanInteractWithEntities()
+        public async Task CanClientInteractWithEntities()
         {
             IDurableClient client = this.GetDurableClient();
 
@@ -96,6 +96,14 @@ namespace DurableTask.SqlServer.AzureFunctions.Tests
             result = await client.ReadEntityStateAsync<int>(entityId);
             Assert.True(result.EntityExists);
             Assert.Equal(7, result.EntityState);
+        }
+
+        [Fact]
+        public async Task CanOrchestrationInteractWithEntities()
+        {
+            DurableOrchestrationStatus status = await this.RunOrchestrationAsync(nameof(Functions.IncrementThenGet));
+            Assert.Equal(OrchestrationRuntimeStatus.Completed, status.RuntimeStatus);
+            Assert.Equal(1, (int)status.Output);
         }
 
         [Fact]

--- a/test/DurableTask.SqlServer.Tests/Utils/SharedTestHelpers.cs
+++ b/test/DurableTask.SqlServer.Tests/Utils/SharedTestHelpers.cs
@@ -84,6 +84,8 @@ namespace DurableTask.SqlServer.Tests.Utils
         public static async Task InitializeDatabaseAsync(string schema = DefaultSchema)
         {
             var options = new SqlOrchestrationServiceSettings(GetDefaultConnectionString(), schemaName: schema);
+            options.CreateDatabaseIfNotExists = true;
+
             var service = new SqlOrchestrationService(options);
             await service.CreateIfNotExistsAsync();
         }


### PR DESCRIPTION
Fixes #146 

An issue was discovered where certain message payloads were being lost in certain situations. The root cause ended up being overaggressive purge logic in the SQL stored procedures when an orchestration (or entity) does a ContinueAsNew.

This PR updates the ContinueAsNew T-SQL logic to be more selective in what data it deletes to ensure that unprocessed events are not impacted. This PR also adds a new test-case that was previously able to reproduce the issue reliably.