### PR TITLE
Support configurable backoff intervals

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## v1.1.2
 
+### New
+
+* Support configurable backoff intervals ([#163](https://github.com/microsoft/durabletask-mssql/pull/163)) - contributed by [@tompostler](https://github.com/tompostler)
+
 ### Updates
 
 * Fix integer overflow issues in GetScaleMetric and QueryManyOrchestrations ([#155](https://github.com/microsoft/durabletask-mssql/pull/155)) - contributed by [@bhugot](https://github.com/bhugot)

--- a/src/DurableTask.SqlServer/SqlOrchestrationService.cs
+++ b/src/DurableTask.SqlServer/SqlOrchestrationService.cs
@@ -24,15 +24,9 @@ namespace DurableTask.SqlServer
 
     public class SqlOrchestrationService : OrchestrationServiceBase
     {
-        readonly BackoffPollingHelper orchestrationBackoffHelper = new BackoffPollingHelper(
-            minimumInterval: TimeSpan.FromMilliseconds(50),
-            maximumInterval: TimeSpan.FromSeconds(3)); // TODO: Configurable
-
-        readonly BackoffPollingHelper activityBackoffHelper = new BackoffPollingHelper(
-            minimumInterval: TimeSpan.FromMilliseconds(50),
-            maximumInterval: TimeSpan.FromSeconds(3)); // TODO: Configurable
-
         readonly SqlOrchestrationServiceSettings settings;
+        readonly BackoffPollingHelper orchestrationBackoffHelper;
+        readonly BackoffPollingHelper activityBackoffHelper;
         readonly LogHelper traceHelper;
         readonly SqlDbManager dbManager;
         readonly string lockedByValue;
@@ -41,6 +35,8 @@ namespace DurableTask.SqlServer
         public SqlOrchestrationService(SqlOrchestrationServiceSettings? settings)
         {
             this.settings = ValidateSettings(settings) ?? throw new ArgumentNullException(nameof(settings));
+            this.orchestrationBackoffHelper = new BackoffPollingHelper(TimeSpan.FromMilliseconds(50), this.settings.MaxOrchestrationPollingInterval);
+            this.activityBackoffHelper = new BackoffPollingHelper(TimeSpan.FromMilliseconds(50), this.settings.MaxActivityPollingInterval);
             this.traceHelper = new LogHelper(this.settings.LoggerFactory.CreateLogger("DurableTask.SqlServer"));
             this.dbManager = new SqlDbManager(this.settings, this.traceHelper);
             this.lockedByValue = $"{this.settings.AppName},{Process.GetCurrentProcess().Id}";

--- a/src/DurableTask.SqlServer/SqlOrchestrationServiceSettings.cs
+++ b/src/DurableTask.SqlServer/SqlOrchestrationServiceSettings.cs
@@ -94,6 +94,22 @@ namespace DurableTask.SqlServer
         public int MaxActiveOrchestrations { get; set; } = Environment.ProcessorCount;
 
         /// <summary>
+        /// Gets or sets the maximum interval to poll for orchestrations.
+        /// Polling interval increases when no orchestrations or activities are found.
+        /// The default value is 3 seconds.
+        /// </summary>
+        [JsonProperty("maxOrchestrationPollingInterval")]
+        public TimeSpan MaxOrchestrationPollingInterval { get; set; } = TimeSpan.FromSeconds(3);
+
+        /// <summary>
+        /// Gets or sets the maximum interval to poll for activities.
+        /// Polling interval increases when no activities are found.
+        /// The default value is 3 seconds.
+        /// </summary>
+        [JsonProperty("maxActivityPollingInterval")]
+        public TimeSpan MaxActivityPollingInterval { get; set; } = TimeSpan.FromSeconds(3);
+
+        /// <summary>
         /// Gets or sets a flag indicating whether the database should be automatically created if it does not exist.
         /// </summary>
         /// <remarks>


### PR DESCRIPTION
I was analyzing the cost of an app service with overall low volume (1-2 orchestrations per week), and right now the cost of the app service telemetry outweighs the cost of the basic app service.

Since the orchestrations I run are very tolerable of delays, I wanted to increase the maximum backoff values here to 5 minutes or more for a ~99% reduction in unnecessary telemetry.

As the orchestrations I run are just a hobby project, I'm not as familiar with the potential consequences of changing these values, especially with how they relate to each other. But I found the todo in the repo and figured I would start with the most basic implementation of passing it through on the settings object.