### PR TITLE
Explicit taskHub parameter for stored procedures

### DIFF
--- a/src/DurableTask.SqlServer.AzureFunctions/SqlDurabilityOptions.cs
+++ b/src/DurableTask.SqlServer.AzureFunctions/SqlDurabilityOptions.cs
@@ -17,7 +17,7 @@ namespace DurableTask.SqlServer.AzureFunctions
         public string ConnectionStringName { get; set; } = "SQLDB_Connection";
 
         [JsonProperty("taskHubName")]
-        public string TaskHubName { get; set; } = "default";
+        public string TaskHubName { get; set; } = SqlOrchestrationServiceSettings.DefaultTaskHubName;
 
         [JsonProperty("taskEventLockTimeout")]
         public TimeSpan TaskEventLockTimeout { get; set; } = TimeSpan.FromMinutes(2);

--- a/src/DurableTask.SqlServer.AzureFunctions/SqlScaleMonitor.cs
+++ b/src/DurableTask.SqlServer.AzureFunctions/SqlScaleMonitor.cs
@@ -26,7 +26,7 @@ namespace DurableTask.SqlServer.AzureFunctions
         public SqlScaleMonitor(SqlOrchestrationService service, string taskHubName)
         {
             this.service = service ?? throw new ArgumentNullException(nameof(service));
-            this.Descriptor = new ScaleMonitorDescriptor($"DurableTask-SqlServer:{taskHubName ?? "default"}");
+            this.Descriptor = new ScaleMonitorDescriptor($"DurableTask-SqlServer:{taskHubName ?? SqlOrchestrationServiceSettings.DefaultTaskHubName}");
         }
 
         /// <inheritdoc />

--- a/src/DurableTask.SqlServer/SqlDbManager.cs
+++ b/src/DurableTask.SqlServer/SqlDbManager.cs
@@ -117,6 +117,17 @@ namespace DurableTask.SqlServer
                 await SqlUtils.ExecuteNonQueryAsync(command, this.traceHelper);
             }
 
+            // Update task hub naming mode
+            using (SqlCommand command = dbLock.CreateCommand())
+            {
+                command.CommandText = $"{this.settings.SchemaName}.SetGlobalSetting";
+                command.CommandType = CommandType.StoredProcedure;
+                command.Parameters.Add("@Name", SqlDbType.VarChar, 300).Value = "TaskHubMode";
+                command.Parameters.Add("@Value", SqlDbType.Variant).Value = this.settings.CreateMultiTennantTaskHub ? 1 : 0;
+
+                await SqlUtils.ExecuteNonQueryAsync(command, this.traceHelper);
+            }
+
             await dbLock.CommitAsync();
         }
 

--- a/src/DurableTask.SqlServer/SqlOrchestrationServiceSettings.cs
+++ b/src/DurableTask.SqlServer/SqlOrchestrationServiceSettings.cs
@@ -15,6 +15,11 @@ namespace DurableTask.SqlServer
     public class SqlOrchestrationServiceSettings
     {
         /// <summary>
+        /// Default value for <see cref="TaskHubName"/> property
+        /// </summary>
+        public static readonly string DefaultTaskHubName = "default";
+
+        /// <summary>
         /// Initializes a new instance of the <see cref="SqlOrchestrationServiceSettings"/> class.
         /// </summary>
         /// <param name="connectionString">The connection string for connecting to the database.</param>
@@ -27,15 +32,10 @@ namespace DurableTask.SqlServer
                 throw new ArgumentNullException(nameof(connectionString));
             }
 
-            this.TaskHubName = taskHubName ?? "default";
+            this.TaskHubName = taskHubName ?? DefaultTaskHubName;
             this.SchemaName = schemaName ?? "dt";
 
-            var builder = new SqlConnectionStringBuilder(connectionString)
-            {
-                // We use the task hub name as the application name so that
-                // stored procedures have easy access to this information.
-                ApplicationName = this.TaskHubName,
-            };
+            var builder = new SqlConnectionStringBuilder(connectionString);
 
             if (string.IsNullOrEmpty(builder.InitialCatalog))
             {
@@ -71,7 +71,8 @@ namespace DurableTask.SqlServer
         public string SchemaName { get; }
 
         /// <summary>
-        /// Gets or sets the name of the app. Used for logging purposes.
+        /// Gets or sets the name of the app. Used as prefix of the lock owner, 
+        /// and need to be unique across machines that connect to the hub.
         /// </summary>
         [JsonProperty("appName")]
         public string AppName { get; set; } = Environment.MachineName;
@@ -101,6 +102,14 @@ namespace DurableTask.SqlServer
         /// </remarks>
         [JsonProperty("createDatabaseIfNotExists")]
         public bool CreateDatabaseIfNotExists { get; set; }
+
+        /// <summary>
+        /// Gets or sets a flag indicating wether task hub is created for multi-tennant naming
+        /// (derived from sql server user name) or for application specified naming.
+        /// </summary>
+        /// <seealso cref="SqlOrchestrationService.CreateAsync(bool)"/>
+        [JsonProperty("createMultiTennantTaskHub ")]
+        public bool CreateMultiTennantTaskHub { get; set; } = true;
 
         /// <summary>
         /// Gets a SQL connection string associated with the configured task hub.

--- a/test/DurableTask.SqlServer.Tests/Integration/DatabaseManagement.cs
+++ b/test/DurableTask.SqlServer.Tests/Integration/DatabaseManagement.cs
@@ -96,7 +96,8 @@ namespace DurableTask.SqlServer.Tests.Integration
                     LogAssert.ExecutedSqlScript("schema-1.0.0.sql"),
                     LogAssert.ExecutedSqlScript("logic.sql"),
                     LogAssert.ExecutedSqlScript("permissions.sql"),
-                    LogAssert.SprocCompleted("dt._UpdateVersion"))
+                    LogAssert.SprocCompleted("dt._UpdateVersion"),
+                    LogAssert.SprocCompleted("dt.SetGlobalSetting"))
                 .EndOfLog();
 
             ValidateDatabaseSchema(testDb);
@@ -155,7 +156,8 @@ namespace DurableTask.SqlServer.Tests.Integration
                     LogAssert.ExecutedSqlScript("schema-1.0.0.sql"),
                     LogAssert.ExecutedSqlScript("logic.sql"),
                     LogAssert.ExecutedSqlScript("permissions.sql"),
-                    LogAssert.SprocCompleted($"{schemaName}._UpdateVersion"))
+                    LogAssert.SprocCompleted($"{schemaName}._UpdateVersion"),
+                    LogAssert.SprocCompleted($"{schemaName}.SetGlobalSetting"))
                 .EndOfLog();
             
             ValidateDatabaseSchema(testDb, schemaName);
@@ -216,7 +218,8 @@ namespace DurableTask.SqlServer.Tests.Integration
                     LogAssert.ExecutedSqlScript("schema-1.0.0.sql"),
                     LogAssert.ExecutedSqlScript("logic.sql"),
                     LogAssert.ExecutedSqlScript("permissions.sql"),
-                    LogAssert.SprocCompleted($"{firstTestSchemaName}._UpdateVersion"))
+                    LogAssert.SprocCompleted($"{firstTestSchemaName}._UpdateVersion"), 
+                    LogAssert.SprocCompleted($"{firstTestSchemaName}.SetGlobalSetting"))
                 .Expect(
                     LogAssert.CheckedDatabase())
                 .Expect(
@@ -225,7 +228,8 @@ namespace DurableTask.SqlServer.Tests.Integration
                     LogAssert.ExecutedSqlScript("schema-1.0.0.sql"),
                     LogAssert.ExecutedSqlScript("logic.sql"),
                     LogAssert.ExecutedSqlScript("permissions.sql"),
-                    LogAssert.SprocCompleted($"{secondTestSchemaName}._UpdateVersion"))
+                    LogAssert.SprocCompleted($"{secondTestSchemaName}._UpdateVersion"),
+                    LogAssert.SprocCompleted($"{secondTestSchemaName}.SetGlobalSetting"))
                 .EndOfLog();
             
             ValidateDatabaseSchema(testDb, secondTestSchemaName);
@@ -307,7 +311,8 @@ namespace DurableTask.SqlServer.Tests.Integration
                     LogAssert.ExecutedSqlScript("schema-1.0.0.sql"),
                     LogAssert.ExecutedSqlScript("logic.sql"),
                     LogAssert.ExecutedSqlScript("permissions.sql"),
-                    LogAssert.SprocCompleted("dt._UpdateVersion"))
+                    LogAssert.SprocCompleted("dt._UpdateVersion"),
+                    LogAssert.SprocCompleted("dt.SetGlobalSetting"))
                 .EndOfLog();
 
             ValidateDatabaseSchema(testDb);
@@ -364,6 +369,7 @@ namespace DurableTask.SqlServer.Tests.Integration
                     LogAssert.ExecutedSqlScript("logic.sql"),
                     LogAssert.ExecutedSqlScript("permissions.sql"),
                     LogAssert.SprocCompleted("dt._UpdateVersion"),
+                    LogAssert.SprocCompleted("dt.SetGlobalSetting"),
                     // 2nd
                     LogAssert.AcquiredAppLock(),
                     LogAssert.SprocCompleted("dt._GetVersions"),

--- a/test/DurableTask.SqlServer.Tests/Utils/TestService.cs
+++ b/test/DurableTask.SqlServer.Tests/Utils/TestService.cs
@@ -261,7 +261,7 @@ namespace DurableTask.SqlServer.Tests.Utils
         public async Task<string> GetTaskHubNameAsync()
         {
             return (string)await SharedTestHelpers.ExecuteSqlAsync(
-                "SELECT dt.CurrentTaskHub()",
+                "SELECT dt.CurrentTaskHub(null)",
                 this.testCredential.ConnectionString);
         }
 


### PR DESCRIPTION
Resolves issue #162.
Add TaskHubName parameter to all relevant SPs. 
Add parameter to initialize TaskHubMode to the settings class. 
NOTE: Breaking changes in vInstance and vHistory views usage in case of TaskHubMode=0.

