### PR TITLE
Adds config for min and delta backoff poll intervals

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,11 @@
 # Changelog
 
-## v1.1.2
+## Unreleased
 
 ### New
 
-* Support configurable backoff intervals ([#163](https://github.com/microsoft/durabletask-mssql/pull/163)) - contributed by [@tompostler](https://github.com/tompostler)
+* Support configurable max backoff intervals ([#163](https://github.com/microsoft/durabletask-mssql/pull/163)) - contributed by [@tompostler](https://github.com/tompostler)
+* Support configurable min and delta backoff intervals ([#174](https://github.com/microsoft/durabletask-mssql/pull/174)) - contributed by [@dmetzgar](https://github.com/dmetzgar)
 
 ### Updates
 

--- a/src/DurableTask.SqlServer/BackoffPollingHelper.cs
+++ b/src/DurableTask.SqlServer/BackoffPollingHelper.cs
@@ -15,9 +15,9 @@ namespace DurableTask.SqlServer
         readonly RandomizedExponentialBackoffStrategy backoffStrategy;
         readonly AsyncAutoResetEvent resetEvent;
 
-        public BackoffPollingHelper(TimeSpan minimumInterval, TimeSpan maximumInterval)
+        public BackoffPollingHelper(TimeSpan minimumInterval, TimeSpan maximumInterval, TimeSpan deltaBackoff)
         {
-            this.backoffStrategy = new RandomizedExponentialBackoffStrategy(minimumInterval, maximumInterval);
+            this.backoffStrategy = new RandomizedExponentialBackoffStrategy(minimumInterval, maximumInterval, deltaBackoff);
             this.resetEvent = new AsyncAutoResetEvent(signaled: false);
         }
 
@@ -45,11 +45,6 @@ namespace DurableTask.SqlServer
             readonly Random random;
             
             uint backoffExponent;
-
-            public RandomizedExponentialBackoffStrategy(TimeSpan minimumInterval, TimeSpan maximumInterval)
-                : this(minimumInterval, maximumInterval, minimumInterval)
-            {
-            }
 
             public RandomizedExponentialBackoffStrategy(
                 TimeSpan minimumInterval,

--- a/src/DurableTask.SqlServer/SqlOrchestrationService.cs
+++ b/src/DurableTask.SqlServer/SqlOrchestrationService.cs
@@ -35,8 +35,14 @@ namespace DurableTask.SqlServer
         public SqlOrchestrationService(SqlOrchestrationServiceSettings? settings)
         {
             this.settings = ValidateSettings(settings) ?? throw new ArgumentNullException(nameof(settings));
-            this.orchestrationBackoffHelper = new BackoffPollingHelper(TimeSpan.FromMilliseconds(50), this.settings.MaxOrchestrationPollingInterval);
-            this.activityBackoffHelper = new BackoffPollingHelper(TimeSpan.FromMilliseconds(50), this.settings.MaxActivityPollingInterval);
+            this.orchestrationBackoffHelper = new BackoffPollingHelper(
+                this.settings.MinOrchestrationPollingInterval,
+                this.settings.MaxOrchestrationPollingInterval,
+                this.settings.DeltaBackoffOrchestrationPollingInterval);
+            this.activityBackoffHelper = new BackoffPollingHelper(
+                this.settings.MinActivityPollingInterval,
+                this.settings.MaxActivityPollingInterval,
+                this.settings.DeltaBackoffActivityPollingInterval);
             this.traceHelper = new LogHelper(this.settings.LoggerFactory.CreateLogger("DurableTask.SqlServer"));
             this.dbManager = new SqlDbManager(this.settings, this.traceHelper);
             this.lockedByValue = $"{this.settings.AppName},{Process.GetCurrentProcess().Id}";

--- a/src/DurableTask.SqlServer/SqlOrchestrationServiceSettings.cs
+++ b/src/DurableTask.SqlServer/SqlOrchestrationServiceSettings.cs
@@ -94,6 +94,14 @@ namespace DurableTask.SqlServer
         public int MaxActiveOrchestrations { get; set; } = Environment.ProcessorCount;
 
         /// <summary>
+        /// Gets or sets the minimum interval to poll for orchestrations.
+        /// Polling interval increases when no orchestrations or activities are found.
+        /// The default value is 50 milliseconds.
+        /// </summary>
+        [JsonProperty("minOrchestrationPollingInterval")]
+        public TimeSpan MinOrchestrationPollingInterval { get; set; } = TimeSpan.FromMilliseconds(50);
+
+        /// <summary>
         /// Gets or sets the maximum interval to poll for orchestrations.
         /// Polling interval increases when no orchestrations or activities are found.
         /// The default value is 3 seconds.
@@ -102,12 +110,36 @@ namespace DurableTask.SqlServer
         public TimeSpan MaxOrchestrationPollingInterval { get; set; } = TimeSpan.FromSeconds(3);
 
         /// <summary>
+        /// Gets or sets the delta backoff interval to poll for orchestrations.
+        /// Polling interval increases by this delta when no orchestrations are found.
+        /// The default value is 50 milliseconds.
+        /// </summary>
+        [JsonProperty("deltaBackoffOrchestrationPollingInterval")]
+        public TimeSpan DeltaBackoffOrchestrationPollingInterval { get; set; } = TimeSpan.FromMilliseconds(50);
+
+        /// <summary>
+        /// Gets or sets the minimum interval to poll for activities.
+        /// Polling interval increases when no activities are found.
+        /// The default value is 50 milliseconds.
+        /// </summary>
+        [JsonProperty("minActivityPollingInterval")]
+        public TimeSpan MinActivityPollingInterval { get; set; } = TimeSpan.FromMilliseconds(50);
+
+        /// <summary>
         /// Gets or sets the maximum interval to poll for activities.
         /// Polling interval increases when no activities are found.
         /// The default value is 3 seconds.
         /// </summary>
         [JsonProperty("maxActivityPollingInterval")]
         public TimeSpan MaxActivityPollingInterval { get; set; } = TimeSpan.FromSeconds(3);
+
+        /// <summary>
+        /// Gets or sets the delta backoff interval to poll for activities.
+        /// Polling interval increases by this delta when no activities are found.
+        /// The default value is 50 milliseconds.
+        /// </summary>
+        [JsonProperty("deltaBackoffActivityPollingInterval")]
+        public TimeSpan DeltaBackoffActivityPollingInterval { get; set; } = TimeSpan.FromMilliseconds(50);
 
         /// <summary>
         /// Gets or sets a flag indicating whether the database should be automatically created if it does not exist.


### PR DESCRIPTION
PR for #172. Makes the minimum and delta backoff intervals configurable for both activity and orchestration instance polling. For situations where a lot of pods have TaskHubWorkers, the default poll interval of 50ms uses a significant amount of DTU. This can become more prominent when SQL Azure decides to change the query plan due to parameter sniffing. In production, we see 12 polls per second on NewTasks and Instances tables each during averaged over 24 hours.

A behavior we've seen that you might be able to confirm @cgillum is on new task polling. It appears that the behavior of activities scheduled by an orchestration are inserted to the NewTasks table with a lock. The TaskHubWorker that is running the orchestration instance is then also expected to run the activities and only after the lock expires could they be picked up by other workers. I think this is the behavior because when I put orchestration and activity into separate TaskHubWorkers, the activities don't get executed. From my point of view, the time when tasks need to be picked up is when the TaskHubWorker goes down due to failure or deployment or if the task is a timer set further into the future than the lock expiration. Therefore, we have increased the intervals on activity polling to much higher than instance polling.