### PR TITLE
Fix error handling propagation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 ### Updates
 
 * Fix integer overflow issues in GetScaleMetric and QueryManyOrchestrations ([#155](https://github.com/microsoft/durabletask-mssql/pull/155)) - contributed by [@bhugot](https://github.com/bhugot)
+* Fix error propagation to correctly expose detailed error info ([#188](https://github.com/microsoft/durabletask-mssql/pull/188))
 
 ## v1.1.1
 

--- a/src/DurableTask.SqlServer.AzureFunctions/DurableTask.SqlServer.AzureFunctions.csproj
+++ b/src/DurableTask.SqlServer.AzureFunctions/DurableTask.SqlServer.AzureFunctions.csproj
@@ -16,7 +16,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.DurableTask" Version="2.9.*" />
+    <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.DurableTask" Version="2.*" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/DurableTask.SqlServer/DbTaskEvent.cs
+++ b/src/DurableTask.SqlServer/DbTaskEvent.cs
@@ -6,7 +6,7 @@ namespace DurableTask.SqlServer
     using System;
     using DurableTask.Core;
 
-    struct DbTaskEvent
+    readonly struct DbTaskEvent
     {
         readonly DateTime timestamp;
 

--- a/src/DurableTask.SqlServer/SqlOrchestrationService.cs
+++ b/src/DurableTask.SqlServer/SqlOrchestrationService.cs
@@ -626,7 +626,7 @@ namespace DurableTask.SqlServer
             using DbDataReader reader = await SqlUtils.ExecuteReaderAsync(command, this.traceHelper, instanceId);
 
             List<HistoryEvent> history = ReadHistoryEvents(reader, executionIdFilter);
-            return JsonConvert.SerializeObject(history);
+            return DTUtils.SerializeToJson(history);
         }
 
         static List<HistoryEvent> ReadHistoryEvents(

--- a/test/DurableTask.SqlServer.Tests/Integration/DatabaseManagement.cs
+++ b/test/DurableTask.SqlServer.Tests/Integration/DatabaseManagement.cs
@@ -316,7 +316,6 @@ namespace DurableTask.SqlServer.Tests.Integration
         /// <summary>
         /// Verifies that CreateIfNotExistsAsync is thread-safe.
         /// </summary>
-        /// <returns></returns>
         [Theory]
         [InlineData(true)]
         [InlineData(false)]

--- a/test/DurableTask.SqlServer.Tests/Integration/LegacyErrorPropagation.cs
+++ b/test/DurableTask.SqlServer.Tests/Integration/LegacyErrorPropagation.cs
@@ -1,0 +1,105 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+namespace DurableTask.SqlServer.Tests.Integration
+{
+    using System;
+    using System.Threading.Tasks;
+    using DurableTask.Core.Exceptions;
+    using DurableTask.Core;
+    using DurableTask.SqlServer.Tests.Utils;
+    using Newtonsoft.Json;
+    using Xunit;
+    using Xunit.Abstractions;
+
+    public class LegacyErrorPropagation : IAsyncLifetime
+    {
+        readonly TestService testService;
+
+        public LegacyErrorPropagation(ITestOutputHelper output)
+        {
+            this.testService = new TestService(output);
+        }
+
+        Task IAsyncLifetime.InitializeAsync() => this.testService.InitializeAsync(legacyErrorPropagation: true);
+
+        Task IAsyncLifetime.DisposeAsync() => this.testService.DisposeAsync();
+
+        [Fact]
+        public async Task UncaughtOrchestrationException()
+        {
+            string errorMessage = "Kah-BOOOOOM!!!";
+
+            // The exception is expected to fail the orchestration execution
+            TestInstance<string> instance = await this.testService.RunOrchestration<string, string>(
+                null,
+                orchestrationName: "OrchestrationWithException",
+                implementation: (ctx, input) => throw new ApplicationException(errorMessage));
+
+            await instance.WaitForCompletion(expectedOutput: errorMessage, expectedStatus: OrchestrationStatus.Failed);
+        }
+
+        [Fact]
+        public async Task UncaughtActivityException()
+        {
+            var exceptionToThrow = new ApplicationException("Kah-BOOOOOM!!!");
+
+            // Schedules a task that throws an uncaught exception
+            TestInstance<string> instance = await this.testService.RunOrchestration(
+                null as string,
+                orchestrationName: "OrchestrationWithActivityFailure",
+                implementation: (ctx, input) => ctx.ScheduleTask<string>("Throw", ""),
+                activities: new[] {
+                    ("Throw", TestService.MakeActivity<string, string>((ctx, input) => throw exceptionToThrow)),
+                });
+
+            OrchestrationState state = await instance.WaitForCompletion(expectedStatus: OrchestrationStatus.Failed);
+            Assert.Equal(exceptionToThrow.Message, state.Output);
+        }
+
+        [Fact]
+        public async Task CatchActivityException()
+        {
+            var innerException = new InvalidOperationException("Oops");
+            var exceptionToThrow = new ApplicationException("Kah-BOOOOOM!!!", innerException);
+
+            // Schedules a task that throws an exception, which is then caught by the orchestration
+            TestInstance<string> instance = await this.testService.RunOrchestration(
+                null as string,
+                orchestrationName: "OrchestrationWithActivityFailure",
+                implementation: async (ctx, input) =>
+                {
+                    try
+                    {
+                        await ctx.ScheduleTask<string>("Throw", "");
+                        return null; // not expected
+                    }
+                    catch (TaskFailedException e)
+                    {
+                        return e.InnerException;
+                    }
+                },
+                activities: new[] {
+                    ("Throw", TestService.MakeActivity<string, string>((ctx, input) => throw exceptionToThrow)),
+                });
+
+            OrchestrationState state = await instance.WaitForCompletion();
+
+            Assert.NotNull(state.Output);
+
+            // The output should be a serialized ApplicationException.
+            // NOTE: Need to specify TypeNameHandling.All to get the exception types to be honored.
+            Exception caughtException = JsonConvert.DeserializeObject<Exception>(
+                state.Output,
+                new JsonSerializerSettings { TypeNameHandling = TypeNameHandling.All });
+            Assert.NotNull(caughtException);
+            Assert.Equal(exceptionToThrow.Message, caughtException.Message);
+            Assert.IsType<ApplicationException>(caughtException);
+
+            // Check that the inner exception was correctly preserved.
+            Assert.NotNull(caughtException.InnerException);
+            Exception caughtInnerException = Assert.IsType<InvalidOperationException>(caughtException.InnerException);
+            Assert.Equal(innerException.Message, caughtInnerException.Message);
+        }
+    }
+}


### PR DESCRIPTION
Resolves https://github.com/microsoft/durabletask-mssql/issues/161

For whatever reason, we forgot to fully implement exception propagation in this MSSQL backend for the Durable Task Framework. Fundamentally, the reason this is easy to miss is because the MSSQL provided doesn't serialize history events, but rather manually reads and writes them into structured SQL tables.

In this PR, we implement handling for both `ErrorPropagationMode.SerializeExceptions` (which we call "legacy") and `ErrorPropagationMode.UseFailureDetails` (which I'm treating as the new default).

To summarize the changes in this PR, we:
* Make sure to read/write failure details to and from the database as JSON
* Make sure we surface error details in the right way in the public API
* Add new tests or improve existing tests to verify that we flow exception details in expected ways
