### PR TITLE
Implement support for suspend/resume

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@
  
 ### Updates
 
-* SqlOrchestrationService.WaitForInstanceAsync no longer throws `TimeoutException` - only `OperationCanceledException` (previously could be either, depending on timing)
+* SqlOrchestrationService.WaitForInstanceAsync no longer throws `TimeoutException` - only `OperationCanceledException` (previously could be either, depending on timing)* Fix default DateTime values to have DateTimeKind of UTC (instead of Unspecified)
 
 ## v1.2.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,8 @@
  
 ### Updates
 
-* SqlOrchestrationService.WaitForInstanceAsync no longer throws `TimeoutException` - only `OperationCanceledException` (previously could be either, depending on timing)* Fix default DateTime values to have DateTimeKind of UTC (instead of Unspecified)
+* SqlOrchestrationService.WaitForInstanceAsync no longer throws `TimeoutException` - only `OperationCanceledException` (previously could be either, depending on timing)
+* Fix default DateTime values to have DateTimeKind of UTC (instead of Unspecified)
 
 ## v1.2.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@
 
 (Add new notes here)
 
+## v1.2.1
+
+### New
+
+* Support suspend/resume of orchestrations
+ 
+### Updates
+
+* SqlOrchestrationService.WaitForInstanceAsync no longer throws `TimeoutException` - only `OperationCanceledException` (previously could be either, depending on timing)
+
 ## v1.2.0
 
 ### New

--- a/src/DurableTask.SqlServer/Scripts/logic.sql
+++ b/src/DurableTask.SqlServer/Scripts/logic.sql
@@ -630,7 +630,6 @@ BEGIN
             E.[InstanceID] = I.[InstanceID]
     WHERE
         I.TaskHub = @TaskHub AND
-        I.[RuntimeStatus] NOT IN ('Suspended') AND
 	    (I.[LockExpiration] IS NULL OR I.[LockExpiration] < @now) AND
         (E.[VisibleTime] IS NULL OR E.[VisibleTime] < @now)
 

--- a/src/DurableTask.SqlServer/SqlOrchestrationService.cs
+++ b/src/DurableTask.SqlServer/SqlOrchestrationService.cs
@@ -205,6 +205,7 @@ namespace DurableTask.SqlServer
                             currentStatus = SqlUtils.GetRuntimeStatus(reader);
                             isRunning =
                                 currentStatus == OrchestrationStatus.Running ||
+                                currentStatus == OrchestrationStatus.Suspended ||
                                 currentStatus == OrchestrationStatus.Pending;
                         }
                         else
@@ -570,19 +571,7 @@ namespace DurableTask.SqlServer
                     return state;
                 }
 
-                try
-                {
-                    await Task.Delay(TimeSpan.FromSeconds(1), combinedCts.Token);
-                }
-                catch (TaskCanceledException)
-                {
-                    if (timeoutCts.Token.IsCancellationRequested)
-                    {
-                        throw new TimeoutException($"A caller-specified timeout of {timeout} has expired, but instance '{instanceId}' is still in an {state?.OrchestrationStatus.ToString() ?? "unknown"} state.");
-                    }
-
-                    throw;
-                }
+                await Task.Delay(TimeSpan.FromSeconds(1), combinedCts.Token);
             }
         }
 

--- a/src/DurableTask.SqlServer/SqlUtils.cs
+++ b/src/DurableTask.SqlServer/SqlUtils.cs
@@ -207,6 +207,12 @@ namespace DurableTask.SqlServer
                         TimerId = GetTaskId(reader),
                     };
                     break;
+                case EventType.ExecutionSuspended:
+                    historyEvent = new ExecutionSuspendedEvent(eventId, GetPayloadText(reader));
+                    break;
+                case EventType.ExecutionResumed:
+                    historyEvent = new ExecutionResumedEvent(eventId, GetPayloadText(reader));
+                    break;
                 default:
                     throw new InvalidOperationException($"Don't know how to interpret '{eventType}'.");
             }

--- a/src/common.props
+++ b/src/common.props
@@ -17,7 +17,7 @@
   <PropertyGroup>
     <MajorVersion>1</MajorVersion>
     <MinorVersion>2</MinorVersion>
-    <PatchVersion>0</PatchVersion>
+    <PatchVersion>1</PatchVersion>
     <VersionPrefix>$(MajorVersion).$(MinorVersion).$(PatchVersion)</VersionPrefix>
     <VersionSuffix></VersionSuffix>
     <AssemblyVersion>$(MajorVersion).$(MinorVersion).0.0</AssemblyVersion>

--- a/test/DurableTask.SqlServer.Tests/Integration/DatabaseManagement.cs
+++ b/test/DurableTask.SqlServer.Tests/Integration/DatabaseManagement.cs
@@ -504,7 +504,7 @@ namespace DurableTask.SqlServer.Tests.Integration
                 schemaName);
             Assert.Equal(1, currentSchemaVersion.Major);
             Assert.Equal(2, currentSchemaVersion.Minor);
-            Assert.Equal(0, currentSchemaVersion.Patch);
+            Assert.Equal(1, currentSchemaVersion.Patch);
         }
 
         sealed class TestDatabase : IDisposable

--- a/test/DurableTask.SqlServer.Tests/Utils/TestInstance.cs
+++ b/test/DurableTask.SqlServer.Tests/Utils/TestInstance.cs
@@ -71,9 +71,13 @@ namespace DurableTask.SqlServer.Tests.Utils
             OrchestrationStatus expectedStatus = OrchestrationStatus.Completed,
             object expectedOutput = null,
             string expectedOutputRegex = null,
-            bool continuedAsNew = false)
+            bool continuedAsNew = false,
+            bool doNotAdjustTimeout = false)
         {
-            AdjustTimeout(ref timeout);
+            if (!doNotAdjustTimeout)
+            {
+                AdjustTimeout(ref timeout);
+            }
 
             OrchestrationState state = await this.client.WaitForOrchestrationAsync(this.GetInstanceForAnyExecution(), timeout);
             Assert.NotNull(state);
@@ -156,6 +160,17 @@ namespace DurableTask.SqlServer.Tests.Utils
             this.input = newInput;
             this.startTime = DateTime.UtcNow;
             this.instance.ExecutionId = newInstance.ExecutionId;
+        }
+
+
+        internal Task SuspendAsync(string reason = null)
+        {
+            return this.client.SuspendInstanceAsync(this.instance, reason);
+        }
+
+        internal Task ResumeAsync(string reason = null)
+        {
+            return this.client.ResumeInstanceAsync(this.instance, reason);
         }
 
         static void AdjustTimeout(ref TimeSpan timeout)


### PR DESCRIPTION
Fixes https://github.com/microsoft/durabletask-mssql/issues/181

The MSSQL backend was missing support for suspend/resume. It also made some bad assumptions about how it would eventually behave when introduced, so some existing logic needed to be removed.

I also bundled a couple additional minor fixes into this PR:

* Fixed inconsistent exception throwing in SqlOrchestrationService.WaitForOrchestrationAsync (realized this was a problem while writing my suspend/resume test)
* Fixed minor issue with default DateTime handling (force it to always be UTC) - this is an issue with certain kinds of serializers, like protobuf, which reject DateTime values that aren't explicitly UTC (found this doing some unrelated exploratory prototyping).