### PR TITLE
Fix SQL roundtrip issue for history event IDs

### DIFF
--- a/src/DurableTask.SqlServer/SqlUtils.cs
+++ b/src/DurableTask.SqlServer/SqlUtils.cs
@@ -137,7 +137,7 @@ namespace DurableTask.SqlServer
                     historyEvent = new SubOrchestrationInstanceCompletedEvent(eventId: -1, GetTaskId(reader), GetPayloadText(reader));
                     break;
                 case EventType.SubOrchestrationInstanceCreated:
-                    historyEvent = new SubOrchestrationInstanceCreatedEvent(eventId: -1)
+                    historyEvent = new SubOrchestrationInstanceCreatedEvent(eventId)
                     {
                         Input = GetPayloadText(reader),
                         InstanceId = "", // Placeholder - shouldn't technically be needed (adding it requires a SQL schema change)

--- a/src/DurableTask.SqlServer/SqlUtils.cs
+++ b/src/DurableTask.SqlServer/SqlUtils.cs
@@ -134,10 +134,10 @@ namespace DurableTask.SqlServer
                     historyEvent = new OrchestratorStartedEvent(eventId);
                     break;
                 case EventType.SubOrchestrationInstanceCompleted:
-                    historyEvent = new SubOrchestrationInstanceCompletedEvent(eventId, GetTaskId(reader), GetPayloadText(reader));
+                    historyEvent = new SubOrchestrationInstanceCompletedEvent(eventId: -1, GetTaskId(reader), GetPayloadText(reader));
                     break;
                 case EventType.SubOrchestrationInstanceCreated:
-                    historyEvent = new SubOrchestrationInstanceCreatedEvent(eventId)
+                    historyEvent = new SubOrchestrationInstanceCreatedEvent(eventId: -1)
                     {
                         Input = GetPayloadText(reader),
                         InstanceId = "", // Placeholder - shouldn't technically be needed (adding it requires a SQL schema change)
@@ -156,7 +156,7 @@ namespace DurableTask.SqlServer
                     }
 
                     historyEvent = new SubOrchestrationInstanceFailedEvent(
-                        eventId,
+                        eventId: -1,
                         taskScheduledId: GetTaskId(reader),
                         reason: subOrchFailedReason,
                         details: subOrchFailedDetails,
@@ -164,7 +164,7 @@ namespace DurableTask.SqlServer
                     break;
                 case EventType.TaskCompleted:
                     historyEvent = new TaskCompletedEvent(
-                        eventId,
+                        eventId: -1,
                         taskScheduledId: GetTaskId(reader),
                         result: GetPayloadText(reader));
                     break;
@@ -179,7 +179,7 @@ namespace DurableTask.SqlServer
                     }
 
                     historyEvent = new TaskFailedEvent(
-                        eventId,
+                        eventId: -1,
                         taskScheduledId: GetTaskId(reader),
                         reason: taskFailedReason,
                         details: taskFailedDetails,
@@ -201,7 +201,7 @@ namespace DurableTask.SqlServer
                     };
                     break;
                 case EventType.TimerFired:
-                    historyEvent = new TimerFiredEvent(eventId)
+                    historyEvent = new TimerFiredEvent(eventId: -1)
                     {
                         FireAt = GetVisibleTime(reader),
                         TimerId = GetTaskId(reader),


### PR DESCRIPTION
Fixes https://github.com/microsoft/durabletask-mssql/issues/198.

The other issue that resulted in this InvalidCastException is caused by https://github.com/Azure/durabletask/pull/1018. This PR removes the root cause of the issue, which was that we're not correctly round-tripping event IDs for some history events (one of the downsides of custom event serialization). DurableTask.Core was making certain assumptions about the values of event IDs that weren't valid due to this bug.