### PR TITLE
Increment versions (to v1.2.2)

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -19,19 +19,24 @@ jobs:
 
     steps:
     - uses: actions/checkout@v4
+
     - name: Setup .NET 6
       uses: actions/setup-dotnet@v3
       with:
         dotnet-version: '6.0.x'
       env:
         NUGET_AUTH_TOKEN: RequiredButNotUsed
+
     - name: NuGet Restore
       run: dotnet restore -v n
+
     - name: Build
       run: dotnet build
+
     - name: Setup SQL Server container
       run: test/setup.ps1
       shell: pwsh
+
     - name: Durable framework tests
       run: dotnet test --no-build --verbosity normal --filter Category!=Stress ./test/DurableTask.SqlServer.Tests/DurableTask.SqlServer.Tests.csproj
     - name: Functions runtime tests

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@
 
 (Add new notes here)
 
+## v1.2.2
+
+### Updates
+
+* Fix for NewEvents stuck due to InvalidCastException ([#201](https://github.com/microsoft/durabletask-mssql/pull/201))
+* Fix Functions.Worker.Extensions.DurableTask.SqlServer to reference correct DurableTask.SqlServer.AzureFunctions package ([#202](https://github.com/microsoft/durabletask-mssql/pull/202))
+
 ## v1.2.1
 
 ### New

--- a/src/Functions.Worker.Extensions.DurableTask.SqlServer/Properties/AssemblyInfo.cs
+++ b/src/Functions.Worker.Extensions.DurableTask.SqlServer/Properties/AssemblyInfo.cs
@@ -4,4 +4,4 @@
 using Microsoft.Azure.Functions.Worker.Extensions.Abstractions;
 
 // This must be updated when updating the version of the package
-[assembly: ExtensionInformation("Microsoft.DurableTask.SqlServer.AzureFunctions", "1.1.*", true)]
+[assembly: ExtensionInformation("Microsoft.DurableTask.SqlServer.AzureFunctions", "1.2.*", true)]

--- a/src/common.props
+++ b/src/common.props
@@ -17,7 +17,7 @@
   <PropertyGroup>
     <MajorVersion>1</MajorVersion>
     <MinorVersion>2</MinorVersion>
-    <PatchVersion>1</PatchVersion>
+    <PatchVersion>2</PatchVersion>
     <VersionPrefix>$(MajorVersion).$(MinorVersion).$(PatchVersion)</VersionPrefix>
     <VersionSuffix></VersionSuffix>
     <AssemblyVersion>$(MajorVersion).$(MinorVersion).0.0</AssemblyVersion>

--- a/test/DurableTask.SqlServer.Tests/Integration/DatabaseManagement.cs
+++ b/test/DurableTask.SqlServer.Tests/Integration/DatabaseManagement.cs
@@ -504,7 +504,7 @@ namespace DurableTask.SqlServer.Tests.Integration
                 schemaName);
             Assert.Equal(1, currentSchemaVersion.Major);
             Assert.Equal(2, currentSchemaVersion.Minor);
-            Assert.Equal(1, currentSchemaVersion.Patch);
+            Assert.Equal(2, currentSchemaVersion.Patch);
         }
 
         sealed class TestDatabase : IDisposable

--- a/test/DurableTask.SqlServer.Tests/Integration/Orchestrations.cs
+++ b/test/DurableTask.SqlServer.Tests/Integration/Orchestrations.cs
@@ -753,8 +753,8 @@ namespace DurableTask.SqlServer.Tests.Integration
             Assert.NotEqual(orchestratorSpan.SpanId, subOrchestratorSpan.SpanId); // new span ID
             Assert.Equal("TestTraceState (modified!)", subOrchestratorSpan.TraceStateString);
             Assert.True(subOrchestratorSpan.StartTimeUtc > orchestratorSpan.StartTimeUtc + delay);
-            Assert.True(subOrchestratorSpan.Duration > delay);
-            Assert.True(subOrchestratorSpan.Duration < delay * 2);
+            Assert.True(subOrchestratorSpan.Duration > delay, $"Unexpected duration: {subOrchestratorSpan.Duration}");
+            Assert.True(subOrchestratorSpan.Duration < delay * 2, $"Unexpected duration: {subOrchestratorSpan.Duration}");
 
             // Validate the activity span, which should be a subset of the sub-orchestration span
             Activity activitySpan = exportedItems.LastOrDefault(


### PR DESCRIPTION
Updating versions prior to doing a patch release.

Also fixes an inconsistency where the .NET Isolated project was incorrectly referencing the v1.1.* version of the WebJobs package when it should have been referencing the v1.2.* versions.