### PR TITLE
Replace hardcoded version string + globs with build variables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## v1.3.0 (Unreleased)
+
+### Updates
+
+* Replace hardcoded version string + globs with build variables ([#213](https://github.com/microsoft/durabletask-mssql/pull/213))
+
 ## v1.2.3
 
 ### Updates

--- a/src/Functions.Worker.Extensions.DurableTask.SqlServer/Functions.Worker.Extensions.DurableTask.SqlServer.csproj
+++ b/src/Functions.Worker.Extensions.DurableTask.SqlServer/Functions.Worker.Extensions.DurableTask.SqlServer.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <!-- Import common properties for all shipping packages-->
   <Import Project="../common.props" />
@@ -20,4 +20,14 @@
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.Abstractions" Version="1.3.0" />
   </ItemGroup>
 
+  <!-- This tells the .NET Isolated Worker SDK which WebJobs extension this package depends on -->
+  <ItemGroup>
+    <AssemblyAttribute Include="Microsoft.Azure.Functions.Worker.Extensions.Abstractions.ExtensionInformationAttribute">
+      <_Parameter1>Microsoft.DurableTask.SqlServer.AzureFunctions</_Parameter1>
+      <_Parameter2>$(PackageVersion)</_Parameter2>
+      <_Parameter3>true</_Parameter3>
+      <_Parameter3_IsLiteral>true</_Parameter3_IsLiteral>
+    </AssemblyAttribute>
+  </ItemGroup>
+  
 </Project>

--- a/src/Functions.Worker.Extensions.DurableTask.SqlServer/Properties/AssemblyInfo.cs
+++ b/src/Functions.Worker.Extensions.DurableTask.SqlServer/Properties/AssemblyInfo.cs
@@ -1,7 +1,0 @@
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
-
-using Microsoft.Azure.Functions.Worker.Extensions.Abstractions;
-
-// This must be updated when updating the version of the package
-[assembly: ExtensionInformation("Microsoft.DurableTask.SqlServer.AzureFunctions", "1.2.*", true)]

--- a/src/common.props
+++ b/src/common.props
@@ -16,8 +16,8 @@
   <!-- Version settings: https://andrewlock.net/version-vs-versionsuffix-vs-packageversion-what-do-they-all-mean/ -->
   <PropertyGroup>
     <MajorVersion>1</MajorVersion>
-    <MinorVersion>2</MinorVersion>
-    <PatchVersion>3</PatchVersion>
+    <MinorVersion>3</MinorVersion>
+    <PatchVersion>0</PatchVersion>
     <VersionPrefix>$(MajorVersion).$(MinorVersion).$(PatchVersion)</VersionPrefix>
     <VersionSuffix></VersionSuffix>
     <AssemblyVersion>$(MajorVersion).$(MinorVersion).0.0</AssemblyVersion>

--- a/test/DurableTask.SqlServer.Tests/Integration/DatabaseManagement.cs
+++ b/test/DurableTask.SqlServer.Tests/Integration/DatabaseManagement.cs
@@ -503,8 +503,8 @@ namespace DurableTask.SqlServer.Tests.Integration
                 database.ConnectionString,
                 schemaName);
             Assert.Equal(1, currentSchemaVersion.Major);
-            Assert.Equal(2, currentSchemaVersion.Minor);
-            Assert.Equal(3, currentSchemaVersion.Patch);
+            Assert.Equal(3, currentSchemaVersion.Minor);
+            Assert.Equal(0, currentSchemaVersion.Patch);
         }
 
         sealed class TestDatabase : IDisposable


### PR DESCRIPTION
Resolves https://github.com/microsoft/durabletask-mssql/issues/212

This PR does two things:

- Removes the usage of version globs when referencing the WebJobs extension (see #212).
- Removes the need to update hardcoded strings by putting this version configuration into the build.

Note that we're including this pas part of a 1.3.x release since only 1.2.x versions are affected by the version glob issue.