### PR TITLE
Issue217 - Rollback transaction in CreateInstance stored proc to prevent deadlocks

### DIFF
--- a/src/DurableTask.SqlServer/Scripts/logic.sql
+++ b/src/DurableTask.SqlServer/Scripts/logic.sql
@@ -260,6 +260,7 @@ BEGIN
         IF @existingStatus IN (SELECT value FROM STRING_SPLIT(@DedupeStatuses, ','))
         BEGIN
             DECLARE @msg nvarchar(4000) = FORMATMESSAGE('Cannot create instance with ID ''%s'' because a pending or running instance with ID already exists.', @InstanceID);
+            ROLLBACK TRANSACTION;
             THROW 50001, @msg, 1;
         END
         ELSE IF @existingStatus IS NOT NULL


### PR DESCRIPTION
Issue217 - Rollback transaction before throwing error when an orchestration instance has already been created by another process/thread. This is to prevent deadlocks as explained in the issue.
