### PR TITLE
Fix SqlUtils.WithRetry() to open a new connection if the last attempt closed the connection due to network issues.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 # Changelog
 
-## v1.3.0 (Unreleased)
+## v1.3.1 (Unreleased)
+
+### Updates
+
+* Fix SQL retry logic to open a new connection if a previous failure closed the connection ([#221](https://github.com/microsoft/durabletask-mssql/pull/221)) - contributed by [@microrama](https://github.com/microrama)
+
+## v1.3.0
 
 ### Updates
 


### PR DESCRIPTION
Pass the DBCommand to the SqlUtils.WithRetry() method and let the method check the DBCommand connection state and open if needed before attempting the next attempt. This way, we avoid throwing an Error back when there is a intermittent network connectivity issue.