### PR TITLE
Clear NuGet security warnings

### DIFF
--- a/nuget.config
+++ b/nuget.config
@@ -4,6 +4,5 @@
   <packageSources>
     <clear/>
     <add key="nuget.org" value="https://www.nuget.org/api/v2/" />
-    <add key="azure-appservice" value="https://www.myget.org/F/azure-appservice/api/v3/index.json" />
   </packageSources>
 </configuration>

--- a/nuget.config
+++ b/nuget.config
@@ -2,8 +2,8 @@
 
 <configuration>
   <packageSources>
+    <clear/>
     <add key="nuget.org" value="https://www.nuget.org/api/v2/" />
-    <add key="azure-appservice-staging" value="https://www.myget.org/F/azure-appservice-staging/api/v3/index.json" />
     <add key="azure-appservice" value="https://www.myget.org/F/azure-appservice/api/v3/index.json" />
   </packageSources>
 </configuration>


### PR DESCRIPTION
This is the DTFx-MSSQL version of this PR: https://github.com/Azure/azure-functions-durable-extension/pull/2842

As part of the 1ES migration, we have new supply chain requirements around our repo's nuget.config files.

In particular, we're getting errors due to use MyGet. This PR removes our MyGet usage. It also addresses warnings regarding missing `<clear/>` statements.