### PR TITLE
Add CodeQL checks

### DIFF
--- a/.github/workflows/codeQL.yml
+++ b/.github/workflows/codeQL.yml
@@ -1,0 +1,82 @@
+# This workflow generates weekly CodeQL reports for this repo, a security requirements.
+# The workflow is adapted from the following reference: https://github.com/Azure-Samples/azure-functions-python-stream-openai/pull/2/files
+# Generic comments on how to modify these file are left intactfor future maintenance.
+
+# For most projects, this workflow file will not need changing; you simply need
+# to commit it to your repository.
+#
+# You may wish to alter this file to override the set of languages analyzed,
+# or to provide custom queries or build logic.
+#
+# ******** NOTE ********
+# We have attempted to detect the languages in your repository. Please check
+# the `language` matrix defined below to confirm you have the correct set of
+# supported CodeQL languages.
+#
+name: "CodeQL"
+
+on:
+  push:
+    branches:
+      - main
+      - 'feature/**'
+  pull_request:
+    # Run on all Pull Requests
+    branches: [ "**" ]
+  schedule:
+    - cron: '0 0 * * 1'
+    # Weekly Monday run, needed for weekly reports
+
+jobs:
+  analyze:
+    name: Analyze
+    runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      contents: read
+      security-events: write
+
+    strategy:
+      fail-fast: false
+      matrix:
+        language: ['csharp']
+        # CodeQL supports [ 'cpp', 'csharp', 'go', 'java', 'javascript', 'python', 'ruby' ]
+        # Learn more about CodeQL language support at https://aka.ms/codeql-docs/language-support
+
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v3
+
+    # Initializes the CodeQL tools for scanning.
+    - name: Initialize CodeQL
+      uses: github/codeql-action/init@v3
+      with:
+        languages: ${{ matrix.language }}
+        # If you wish to specify custom queries, you can do so here or in a config file.
+        # By default, queries listed here will override any specified in a config file.
+        # Prefix the list here with "+" to use these queries and those in the config file.
+
+        # Details on CodeQL's query packs refer to : https://docs.github.com/en/code-security/code-scanning/automatically-scanning-your-code-for-vulnerabilities-and-errors/configuring-code-scanning#using-queries-in-ql-packs
+        # queries: security-extended,security-and-quality
+
+
+    # Autobuild attempts to build any compiled languages  (C/C++, C#, Go, or Java).
+    # If this step fails, then you should remove it and run the build manually (see below)
+    - name: Autobuild
+      uses: github/codeql-action/autobuild@v2
+
+    # ℹ️ Command-line programs to run using the OS shell.
+    # 📚 See https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstepsrun
+
+    #   If the Autobuild fails above, remove it and uncomment the following three lines.
+    #   modify them (or add more) to build your code if your project, please refer to the EXAMPLE below for guidance.
+
+    # - run: |
+    #   echo "Run, Build Application using script"
+    #   ./location_of_script_within_repo/buildscript.sh
+
+    # Perform CodeQL analysis
+    - name: Perform CodeQL Analysis
+      uses: github/codeql-action/analyze@v3
+      with:
+        category: "/language:${{matrix.language}}"

--- a/eng/ci/official-build.yml
+++ b/eng/ci/official-build.yml
@@ -10,6 +10,17 @@ trigger:
 # CI only, does not trigger on PRs.
 pr: none
 
+schedules:
+# Build nightly to catch any new CVEs and report SDL often.
+# We are also required to generated CodeQL reports weekly, so this
+# helps us meet that.
+- cron: "0 0 * * *"
+  displayName: Nightly Build
+  branches:
+    include:
+    - main
+  always: true
+
 resources:
     repositories:
         - repository: 1es


### PR DESCRIPTION
As part of our 1ES migration, we need to add "CodeQL" (Code Query Language?) checks to our repos. This CodeQL service effectively checks against CVEs and other compliance requirements using static analysis of our source code. This needs to run in two places:

(1) Directly in the GitHub repo
(2) In our 1ES code-mirror

It needs to run in these two places because CodeQL doesn't realize our 1ES ADO repo is a clone of the GitHub repo. Additionally, CodeQL needs to run at least weekly.

To tackle these requirements, this PR does the following:
(1) Add GitHub action that runs CodeQL checks directly in GitHub. This runs weekly.
(2) It makes our 1ES Official pipeline, which automatically adds injects CodeQL checks, run weekly.

That's all.