### PR TITLE
Update taskhubs.md with correct storageProvider type value

### DIFF
--- a/docs/taskhubs.md
+++ b/docs/taskhubs.md
@@ -25,7 +25,7 @@ For Durable Functions apps, explicit task hub names are configured in the `exten
     "durableTask": {
       "hubName": "MyTaskHub",
       "storageProvider": {
-        "type": "MicrosoftSQL",
+        "type": "mssql",
         "connectionStringName": "SQLDB_Connection"
       }
     }


### PR DESCRIPTION
It appears there was a mistake in one of the code samples in the documentation, showing "MicrosoftSQL" as the `storageProvider/type` value in host.json when it should actually be "mssql". This commit fixes the doc mistake.