### PR TITLE
Fix to (re)enable lower-privilege connection strings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Updates
 
 * Fix SQL retry logic to open a new connection if a previous failure closed the connection ([#221](https://github.com/microsoft/durabletask-mssql/pull/221)) - contributed by [@microrama](https://github.com/microrama)
+* Fix to (re)enable lower-privilege connection strings ([#234](https://github.com/microsoft/durabletask-mssql/pull/234))
 
 ## v1.3.0
 

--- a/src/DurableTask.SqlServer/DTUtils.cs
+++ b/src/DurableTask.SqlServer/DTUtils.cs
@@ -196,6 +196,7 @@ namespace DurableTask.SqlServer
             return historyEvent.EventType switch
             {
                 EventType.ExecutionStarted => ((ExecutionStartedEvent)historyEvent).Version,
+                EventType.SubOrchestrationInstanceCreated => ((SubOrchestrationInstanceCreatedEvent)historyEvent).Version,
                 EventType.TaskScheduled => ((TaskScheduledEvent)historyEvent).Version,
                 _ => null,
             };

--- a/src/DurableTask.SqlServer/Scripts/logic.sql
+++ b/src/DurableTask.SqlServer/Scripts/logic.sql
@@ -1444,7 +1444,7 @@ BEGIN
     -- Instance IDs can be overwritten only if the orchestration is in a terminal state
     IF @existingStatus NOT IN ('Failed')
     BEGIN
-        DECLARE @msg nvarchar(4000) = FORMATMESSAGE('Cannot rewing instance with ID ''%s'' because it is not in a ''Failed'' state, but in ''%s'' state.', @InstanceID, @existingStatus);
+        DECLARE @msg nvarchar(4000) = FORMATMESSAGE('Cannot rewind instance with ID ''%s'' because it is not in a ''Failed'' state, but in ''%s'' state.', @InstanceID, @existingStatus);
         THROW 50001, @msg, 1;
     END
     


### PR DESCRIPTION
Resolves https://github.com/microsoft/durabletask-mssql/issues/233

The fix is to skip the database existence check if the current connection string does not have permission to log into the master database.