### PR TITLE
Add sourcelink reconstruction task in msbuild

### DIFF
--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -1,0 +1,37 @@
+<Project>
+  <!-- This is copied from:https://github.com/Azure/azure-functions-host/blob/dev/eng/build/RepositoryInfo.targets -->
+  <!-- The following build target allows us to reconstruct source-link information when building in 1ES -->
+
+  <!--
+    The convention for names of Azure DevOps repositories mirrored from GitHub is "{GitHub org name}.{GitHub repository name}".
+  -->
+  <PropertyGroup>
+    <!-- There are quite a few git repo forms:
+      https://azfunc@dev.azure.com/azfunc/internal/_git/azure.azure-functions-host
+      https://dev.azure.com/azfunc/internal/_git/azure.azure-functions-host
+      https://azfunc.visualstudio.com/internal/_git/azure.azure-functions-host
+      azfunc@vs-ssh.visualstudio.com:v3/azfunc/internal/azure.azure-functions-host
+      git@ssh.dev.azure.com:v3/azfunc/internal/azure.azure-functions-host
+    -->
+    <!-- Set DisableSourceLinkUrlTranslation to true when building a tool for internal use where sources only come from internal URIs -->
+    <DisableSourceLinkUrlTranslation Condition="'$(DisableSourceLinkUrlTranslation)' == ''">false</DisableSourceLinkUrlTranslation>
+    <_TranslateUrlPattern>(https://azfunc%40dev\.azure\.com/azfunc/internal/_git|https://dev\.azure\.com/azfunc/internal/_git|https://azfunc\.visualstudio\.com/internal/_git|azfunc%40vs-ssh\.visualstudio\.com:v3/azfunc/internal|git%40ssh\.dev\.azure\.com:v3/azfunc/internal)/([^/\.]+)\.(.+)</_TranslateUrlPattern>
+    <_TranslateUrlReplacement>https://github.com/$2/$3</_TranslateUrlReplacement>
+  </PropertyGroup>
+
+  <!-- When building from Azure Devops we update SourceLink to point back to the GitHub repo. -->
+  <Target Name="_TranslateAzureDevOpsUrlToGitHubUrl"
+    Condition="'$(DisableSourceLinkUrlTranslation)' == 'false'"
+    DependsOnTargets="$(SourceControlManagerUrlTranslationTargets)"
+    BeforeTargets="SourceControlManagerPublishTranslatedUrls">
+    <PropertyGroup>
+      <ScmRepositoryUrl>$([System.Text.RegularExpressions.Regex]::Replace($(ScmRepositoryUrl), $(_TranslateUrlPattern), $(_TranslateUrlReplacement)))</ScmRepositoryUrl>
+    </PropertyGroup>
+    <ItemGroup>
+      <SourceRoot Update="@(SourceRoot)">
+          <ScmRepositoryUrl>$([System.Text.RegularExpressions.Regex]::Replace(%(SourceRoot.ScmRepositoryUrl), $(_TranslateUrlPattern), $(_TranslateUrlReplacement)))</ScmRepositoryUrl>
+      </SourceRoot>
+    </ItemGroup>
+  </Target>
+
+</Project>

--- a/DurableTask.SqlServer.sln
+++ b/DurableTask.SqlServer.sln
@@ -15,6 +15,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 		.github\workflows\build-and-test.yml = .github\workflows\build-and-test.yml
 		CHANGELOG.md = CHANGELOG.md
 		src\common.props = src\common.props
+		Directory.Build.targets = Directory.Build.targets
 		nuget.config = nuget.config
 		README.md = README.md
 		sign.snk = sign.snk
@@ -33,11 +34,11 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "test", "test", "{4A7226CF-5
 		test\setup.ps1 = test\setup.ps1
 	EndProjectSection
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "TestDBGenerator", "tools\TestDBGenerator\TestDBGenerator.csproj", "{28117755-60C3-463D-A32D-E0A38E9E4ADA}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "TestDBGenerator", "tools\TestDBGenerator\TestDBGenerator.csproj", "{28117755-60C3-463D-A32D-E0A38E9E4ADA}"
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "tools", "tools", "{C6E6ACAB-F123-4D18-891E-DE9C44539153}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Functions.Worker.Extensions.DurableTask.SqlServer", "src\Functions.Worker.Extensions.DurableTask.SqlServer\Functions.Worker.Extensions.DurableTask.SqlServer.csproj", "{307C5A62-9943-48B8-8513-BBCDF0FBC3D0}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Functions.Worker.Extensions.DurableTask.SqlServer", "src\Functions.Worker.Extensions.DurableTask.SqlServer\Functions.Worker.Extensions.DurableTask.SqlServer.csproj", "{307C5A62-9943-48B8-8513-BBCDF0FBC3D0}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution


### PR DESCRIPTION
When building in 1ES, source-link information gets lost due to the code-mirror'ing. This creates issues during debugging, as Visual Studio would be unable to determine where to download the source code from. This PR aims to fix that by following conventions set by the Azure Functions Host.

This is the durabletask-dotnet version of this DTFx PR: https://github.com/Azure/durabletask/pull/1147