### PR TITLE
Fix CI: update sqlcmd to new location: /opt/mssql-tools18

### DIFF
--- a/docs/kubernetes.md
+++ b/docs/kubernetes.md
@@ -74,7 +74,7 @@ $mssqlPod = kubectl get pods -n mssql -o jsonpath='{.items[0].metadata.name}'
 
 # Use sqlcmd.exe to create a database named "DurableDB".
 # Replace 'PLACEHOLDER' with the password you used earlier
-kubectl exec -n mssql $mssqlPod -- /opt/mssql-tools/bin/sqlcmd -S . -U sa -P "PLACEHOLDER" -Q "CREATE DATABASE [DurableDB] COLLATE Latin1_General_100_BIN2_UTF8"
+kubectl exec -n mssql $mssqlPod -- /opt/mssql-tools18/bin/sqlcmd -S . -U sa -P "PLACEHOLDER" -Q "CREATE DATABASE [DurableDB] COLLATE Latin1_General_100_BIN2_UTF8"
 ```
 
 ?> If you have an old version of the database already deployed, you may want to first delete that one using `DROP DATABASE [DurableDB]` SQL command. This should only be necessary when using alpha builds of the Durable Task SQL provider. Newer builds will take care of database schema upgrades automatically.

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -164,7 +164,7 @@ docker run --name mssql-server \
 # wait a few seconds for the container to start...
 
 # create the database with strict binary collation
-docker exec -d mssql-server /opt/mssql-tools/bin/sqlcmd \
+docker exec -d mssql-server /opt/mssql-tools18/bin/sqlcmd \
     -S . \
     -U sa \
     -P "$pw" \

--- a/test/setup.ps1
+++ b/test/setup.ps1
@@ -30,4 +30,4 @@ docker ps
 
 # Create the database with strict binary collation
 Write-Host "Creating '$dbname' database with '$collation' collation" -ForegroundColor DarkYellow
-docker exec -d mssql-server /opt/mssql-tools/bin/sqlcmd -S . -U sa -P "$pw" -Q "CREATE DATABASE [$dbname] COLLATE $collation"
+docker exec -d mssql-server /opt/mssql-tools18/bin/sqlcmd -S . -U sa -P "$pw" -Q "CREATE DATABASE [$dbname] COLLATE $collation"


### PR DESCRIPTION
In [this PR](https://github.com/microsoft/durabletask-mssql/pull/235) the CI is failing because the `sqlcmd` utility cannot be found under `/opt/mssql-tools/bin/sqlcmd`.

We had discovered a similar issue in the MSSQL E2E test of the DF Extension a few weeks back. The issue is newer versions of the MSSQL docker image now place `sqlcmd` inside `/opt/mssql-tools18/bin/`.

This PR updates the `sqlcmd` reference to reflect this change.