### PR TITLE
Update terminate logic to handle scheduled orchestrations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## v1.4.1 (Unreleased)
+
+### Updates
+
+* Fix issue where scheduled orchestrations aren't immediately terminated ([#178](https://github.com/microsoft/durabletask-mssql/issues/178))
+
 ## v1.4.0
 
 ### New

--- a/src/DurableTask.SqlServer/DTUtils.cs
+++ b/src/DurableTask.SqlServer/DTUtils.cs
@@ -196,6 +196,7 @@ namespace DurableTask.SqlServer
             return historyEvent.EventType switch
             {
                 EventType.ExecutionStarted => ((ExecutionStartedEvent)historyEvent).Version,
+                EventType.SubOrchestrationInstanceCreated => ((SubOrchestrationInstanceCreatedEvent)historyEvent).Version,
                 EventType.TaskScheduled => ((TaskScheduledEvent)historyEvent).Version,
                 _ => null,
             };

--- a/src/DurableTask.SqlServer/Scripts/logic.sql
+++ b/src/DurableTask.SqlServer/Scripts/logic.sql
@@ -469,45 +469,70 @@ BEGIN
 
     DECLARE @TaskHub varchar(50) = __SchemaNamePlaceholder__.CurrentTaskHub()
 
-    DECLARE @existingStatus varchar(30) = (
-        SELECT TOP 1 existing.[RuntimeStatus]
-        FROM Instances existing WITH (HOLDLOCK)
-        WHERE [TaskHub] = @TaskHub AND [InstanceID] = @InstanceID
-    )
+    DECLARE @existingStatus varchar(30)
+    DECLARE @existingLockExpiration datetime2(7)
+
+    -- Get the status of an existing orchestration
+    SELECT TOP 1
+        @existingStatus = existing.[RuntimeStatus],
+        @existingLockExpiration = existing.[LockExpiration]
+    FROM Instances existing WITH (HOLDLOCK)
+    WHERE [TaskHub] = @TaskHub AND [InstanceID] = @InstanceID
 
     IF @existingStatus IS NULL
     BEGIN
         ROLLBACK TRANSACTION;
         THROW 50000, 'The instance does not exist.', 1;
     END
-    -- If the instance is already completed, no need to terminate it.
-    IF @existingStatus IN ('Pending', 'Running')
-    BEGIN
-        IF NOT EXISTS (
-            SELECT TOP (1) 1 FROM NewEvents
-            WHERE [TaskHub] = @TaskHub AND [InstanceID] = @InstanceID AND [EventType] = 'ExecutionTerminated'
-        )
-        BEGIN
-            -- Payloads are stored separately from the events
-            DECLARE @PayloadID uniqueidentifier = NULL
-            IF @Reason IS NOT NULL
-            BEGIN
-                -- Note that we don't use the Reason column for the Reason with terminate events
-                SET @PayloadID = NEWID()
-                INSERT INTO Payloads ([TaskHub], [InstanceID], [PayloadID], [Text])
-                VALUES (@TaskHub, @InstanceID, @PayloadID, @Reason)
-            END
 
-            INSERT INTO NewEvents (
-                [TaskHub],
-                [InstanceID],
-                [EventType],
-                [PayloadID]
-            ) VALUES (
-                @TaskHub,
-                @InstanceID,
-                'ExecutionTerminated',
-                @PayloadID)
+    DECLARE @now datetime2(7) = SYSUTCDATETIME()
+
+    IF @existingStatus IN ('Running', 'Pending')
+    BEGIN
+        -- Create a payload to store the reason, if any
+        DECLARE @PayloadID uniqueidentifier = NULL
+        IF @Reason IS NOT NULL
+        BEGIN
+            -- Note that we don't use the Reason column for the Reason with terminate events
+            SET @PayloadID = NEWID()
+            INSERT INTO Payloads ([TaskHub], [InstanceID], [PayloadID], [Text])
+            VALUES (@TaskHub, @InstanceID, @PayloadID, @Reason)
+        END
+
+        -- Check the status of the orchestration to determine which termination path to take
+        IF @existingStatus = 'Pending' AND (@existingLockExpiration IS NULL OR @existingLockExpiration <= @now)
+        BEGIN
+            -- The orchestration hasn't started yet - transition it directly to the Terminated state and delete
+            -- any pending messages
+            UPDATE Instances SET
+                [RuntimeStatus] = 'Terminated',
+                [LastUpdatedTime] = @now,
+                [CompletedTime] = @now,
+                [OutputPayloadID] = @PayloadID,
+                [LockExpiration] = NULL -- release the lock, if any
+            WHERE [TaskHub] = @TaskHub AND [InstanceID] = @InstanceID
+
+            DELETE FROM NewEvents WHERE [TaskHub] = @TaskHub AND [InstanceID] = @InstanceID
+        END
+        ELSE
+        BEGIN
+            -- The orchestration has actually started running in this case
+            IF NOT EXISTS (
+                SELECT TOP (1) 1 FROM NewEvents
+                WHERE [TaskHub] = @TaskHub AND [InstanceID] = @InstanceID AND [EventType] = 'ExecutionTerminated'
+            )
+            BEGIN
+                INSERT INTO NewEvents (
+                    [TaskHub],
+                    [InstanceID],
+                    [EventType],
+                    [PayloadID]
+                ) VALUES (
+                    @TaskHub,
+                    @InstanceID,
+                    'ExecutionTerminated',
+                    @PayloadID)
+            END
         END
     END
 
@@ -1444,7 +1469,7 @@ BEGIN
     -- Instance IDs can be overwritten only if the orchestration is in a terminal state
     IF @existingStatus NOT IN ('Failed')
     BEGIN
-        DECLARE @msg nvarchar(4000) = FORMATMESSAGE('Cannot rewing instance with ID ''%s'' because it is not in a ''Failed'' state, but in ''%s'' state.', @InstanceID, @existingStatus);
+        DECLARE @msg nvarchar(4000) = FORMATMESSAGE('Cannot rewind instance with ID ''%s'' because it is not in a ''Failed'' state, but in ''%s'' state.', @InstanceID, @existingStatus);
         THROW 50001, @msg, 1;
     END
     

--- a/src/DurableTask.SqlServer/SqlOrchestrationService.cs
+++ b/src/DurableTask.SqlServer/SqlOrchestrationService.cs
@@ -335,8 +335,14 @@ namespace DurableTask.SqlServer
             IList<TaskMessage> orchestratorMessages,
             IList<TaskMessage> timerMessages,
             TaskMessage continuedAsNewMessage,
-            OrchestrationState orchestrationState)
+            OrchestrationState? orchestrationState)
         {
+            if (orchestrationState is null || !newRuntimeState.IsValid)
+            {
+                // The work item was invalid. We can't do anything with it so we ignore it.
+                return;
+            }
+
             ExtendedOrchestrationWorkItem currentWorkItem = (ExtendedOrchestrationWorkItem)workItem;
 
             this.traceHelper.CheckpointStarting(orchestrationState);

--- a/src/common.props
+++ b/src/common.props
@@ -17,7 +17,7 @@
   <PropertyGroup>
     <MajorVersion>1</MajorVersion>
     <MinorVersion>4</MinorVersion>
-    <PatchVersion>0</PatchVersion>
+    <PatchVersion>1</PatchVersion>
     <VersionPrefix>$(MajorVersion).$(MinorVersion).$(PatchVersion)</VersionPrefix>
     <VersionSuffix></VersionSuffix>
     <AssemblyVersion>$(MajorVersion).$(MinorVersion).0.0</AssemblyVersion>

--- a/test/DurableTask.SqlServer.Tests/Integration/DatabaseManagement.cs
+++ b/test/DurableTask.SqlServer.Tests/Integration/DatabaseManagement.cs
@@ -504,7 +504,7 @@ namespace DurableTask.SqlServer.Tests.Integration
                 schemaName);
             Assert.Equal(1, currentSchemaVersion.Major);
             Assert.Equal(4, currentSchemaVersion.Minor);
-            Assert.Equal(0, currentSchemaVersion.Patch);
+            Assert.Equal(1, currentSchemaVersion.Patch);
         }
 
         sealed class TestDatabase : IDisposable


### PR DESCRIPTION
Fixes https://github.com/microsoft/durabletask-mssql/issues/178

This updates the SQL-based terminate logic to handle the case where users try to terminate scheduled orchestrations. We can't use the previous approach of sending an `ExecutionTerminated` message because DTFx doesn't know how to handle the case where this message is received and there is no orchestration state (you end up with a repeating NullReferenceException until the scheduled orchestration actually starts).

This PR also includes an integration test for this scenario.