### PR TITLE
Update Durabletask Dependencies for v1.5.0 Release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## v2.0.0
+## v1.5.0
 
 ### Updates
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## v1.5.0
+
+### New
+* Update Microsoft.Azure.WebJobs.Extensions.DurableTask dependency to 3.0.0 and DurableTask.Core to 3.*. ([#281]https://github.com/microsoft/durabletask-mssql/pull/281)
+
 ## v1.4.0
 
 ### New

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,10 @@
 
 ## v1.5.0
 
-### New
-* Update Microsoft.Azure.WebJobs.Extensions.DurableTask dependency to 3.0.0 and DurableTask.Core to 3.*. ([#281]https://github.com/microsoft/durabletask-mssql/pull/281)
+### Updates
+
+* Updated Microsoft.Azure.WebJobs.Extensions.DurableTask dependency to 3.0.0 and DurableTask.Core to 3.*. ([#281]https://github.com/microsoft/durabletask-mssql/pull/281)
+* Removed `netstandard2.0` TFM from Microsoft.DurableTask.SqlServer.AzureFunctions
 
 ## v1.4.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## v1.5.0
+## v2.0.0
 
 ### Updates
 

--- a/src/DurableTask.SqlServer.AzureFunctions/DurableTask.SqlServer.AzureFunctions.csproj
+++ b/src/DurableTask.SqlServer.AzureFunctions/DurableTask.SqlServer.AzureFunctions.csproj
@@ -4,7 +4,7 @@
   <Import Project="../common.props" />
   
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net6.0</TargetFrameworks>
+    <TargetFrameworks>net6.0</TargetFrameworks>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(TargetFramework)' == 'net6.0'">
@@ -20,7 +20,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.DurableTask" Version="2.13.7" />
+    <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.DurableTask" Version="3.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/DurableTask.SqlServer/DurableTask.SqlServer.csproj
+++ b/src/DurableTask.SqlServer/DurableTask.SqlServer.csproj
@@ -21,7 +21,7 @@
   </ItemGroup>
   
   <ItemGroup>
-    <PackageReference Include="Microsoft.Azure.DurableTask.Core" Version="2.*" />
+    <PackageReference Include="Microsoft.Azure.DurableTask.Core" Version="3.*" />
     <PackageReference Include="Microsoft.Data.SqlClient" Version="3.1.5" />
     <PackageReference Include="SemanticVersion" Version="2.1.0" />
     <PackageReference Include="System.Threading.Channels" Version="4.7.1" />

--- a/src/common.props
+++ b/src/common.props
@@ -15,8 +15,8 @@
 
   <!-- Version settings: https://andrewlock.net/version-vs-versionsuffix-vs-packageversion-what-do-they-all-mean/ -->
   <PropertyGroup>
-    <MajorVersion>2</MajorVersion>
-    <MinorVersion>0</MinorVersion>
+    <MajorVersion>1</MajorVersion>
+    <MinorVersion>5</MinorVersion>
     <PatchVersion>0</PatchVersion>
     <VersionPrefix>$(MajorVersion).$(MinorVersion).$(PatchVersion)</VersionPrefix>
     <VersionSuffix></VersionSuffix>

--- a/src/common.props
+++ b/src/common.props
@@ -16,7 +16,7 @@
   <!-- Version settings: https://andrewlock.net/version-vs-versionsuffix-vs-packageversion-what-do-they-all-mean/ -->
   <PropertyGroup>
     <MajorVersion>1</MajorVersion>
-    <MinorVersion>4</MinorVersion>
+    <MinorVersion>5</MinorVersion>
     <PatchVersion>0</PatchVersion>
     <VersionPrefix>$(MajorVersion).$(MinorVersion).$(PatchVersion)</VersionPrefix>
     <VersionSuffix></VersionSuffix>

--- a/src/common.props
+++ b/src/common.props
@@ -15,8 +15,8 @@
 
   <!-- Version settings: https://andrewlock.net/version-vs-versionsuffix-vs-packageversion-what-do-they-all-mean/ -->
   <PropertyGroup>
-    <MajorVersion>1</MajorVersion>
-    <MinorVersion>5</MinorVersion>
+    <MajorVersion>2</MajorVersion>
+    <MinorVersion>0</MinorVersion>
     <PatchVersion>0</PatchVersion>
     <VersionPrefix>$(MajorVersion).$(MinorVersion).$(PatchVersion)</VersionPrefix>
     <VersionSuffix></VersionSuffix>

--- a/test/DurableTask.SqlServer.Tests/Integration/DatabaseManagement.cs
+++ b/test/DurableTask.SqlServer.Tests/Integration/DatabaseManagement.cs
@@ -502,8 +502,8 @@ namespace DurableTask.SqlServer.Tests.Integration
                 this.output,
                 database.ConnectionString,
                 schemaName);
-            Assert.Equal(1, currentSchemaVersion.Major);
-            Assert.Equal(5, currentSchemaVersion.Minor);
+            Assert.Equal(2, currentSchemaVersion.Major);
+            Assert.Equal(0, currentSchemaVersion.Minor);
             Assert.Equal(0, currentSchemaVersion.Patch);
         }
 

--- a/test/DurableTask.SqlServer.Tests/Integration/DatabaseManagement.cs
+++ b/test/DurableTask.SqlServer.Tests/Integration/DatabaseManagement.cs
@@ -503,7 +503,7 @@ namespace DurableTask.SqlServer.Tests.Integration
                 database.ConnectionString,
                 schemaName);
             Assert.Equal(1, currentSchemaVersion.Major);
-            Assert.Equal(4, currentSchemaVersion.Minor);
+            Assert.Equal(5, currentSchemaVersion.Minor);
             Assert.Equal(0, currentSchemaVersion.Patch);
         }
 

--- a/test/DurableTask.SqlServer.Tests/Integration/DatabaseManagement.cs
+++ b/test/DurableTask.SqlServer.Tests/Integration/DatabaseManagement.cs
@@ -502,8 +502,8 @@ namespace DurableTask.SqlServer.Tests.Integration
                 this.output,
                 database.ConnectionString,
                 schemaName);
-            Assert.Equal(2, currentSchemaVersion.Major);
-            Assert.Equal(0, currentSchemaVersion.Minor);
+            Assert.Equal(1, currentSchemaVersion.Major);
+            Assert.Equal(5, currentSchemaVersion.Minor);
             Assert.Equal(0, currentSchemaVersion.Patch);
         }
 


### PR DESCRIPTION
As titled. This PR updates the below dependencies to start the durabletask mssql backend v1.5.0 release:

Microsoft.Azure.WebJobs.Extensions.DurableTask 2.13.7 -> 3.0.0
Microsoft.Azure.DurableTask.Core 2.*-> 3.*