### PR TITLE
Fix bug in ETW trace code for AcquiredAppLock

### DIFF
--- a/src/DurableTask.SqlServer/Logging/DefaultEventSource.cs
+++ b/src/DurableTask.SqlServer/Logging/DefaultEventSource.cs
@@ -61,33 +61,12 @@ namespace DurableTask.SqlServer.Logging
             string AppName,
             string ExtensionVersion)
         {
-            this.AcquiredAppLockCore(
+            this.WriteEvent(
                 EventIds.AcquiredAppLock,
                 StatusCode,
                 LatencyMs,
                 AppName,
                 ExtensionVersion);
-        }
-
-        [NonEvent]
-        unsafe void AcquiredAppLockCore(int eventId, int statusCode, long latencyMs, string appName, string extensionVersion)
-        {
-            // This needs to be done manually because the built-in WriteEvent(int, long, long) overload will overwrite data (as shown in testing)
-            fixed (char* appNamePtr = appName)
-            fixed (char* extensionVersionPtr = extensionVersion)
-            {
-                EventData* data = stackalloc EventData[4];
-                data[0].DataPointer = (IntPtr)(&statusCode);
-                data[0].Size = sizeof(int);
-                data[1].DataPointer = (IntPtr)(&latencyMs);
-                data[1].Size = sizeof(long);
-                data[2].DataPointer = (IntPtr)appNamePtr;
-                data[2].Size = (appName.Length + 1) + 2;
-                data[3].DataPointer = (IntPtr)extensionVersionPtr;
-                data[3].Size = (extensionVersion.Length + 1) + 2;
-
-                this.WriteEventCore(eventId, 2, data);
-            }
         }
 
         [Event(EventIds.CheckpointStarting, Level = EventLevel.Informational)]


### PR DESCRIPTION
During an incident investigation, we saw the following error message logged by the ETW provider:

> Event 300 was called with 2 argument(s), but it is defined with 4 parameter(s).

Looking at the code, the problem seemed to be that we were passing a `2` to WriteEventCore when we needed to be passing a `4`. Rather than fixing this directly, I decided we should just not use `WriteEventCore` (which is unsafe) and instead just use `WriteEvent`, which is safer and more consistent with our other logs.

As an aside `WriteEventCore` is useful as a performance optimization. However, this particular log event is written infrequently and therefore doesn't really benefit from a slightly more optimal code path.