### PR TITLE
Preserve durable trace context in SQL history

### DIFF
--- a/src/DurableTask.SqlServer/SqlUtils.cs
+++ b/src/DurableTask.SqlServer/SqlUtils.cs
@@ -24,6 +24,10 @@ namespace DurableTask.SqlServer
     {
         static readonly Random random = new Random();
         static readonly char[] TraceContextSeparators = new char[] { '\n' };
+        const string TraceContextTraceStatePrefix = "@tracestate=";
+        const string TraceContextIdPrefix = "@id=";
+        const string TraceContextSpanIdPrefix = "@spanid=";
+        const string TraceContextClientSpanIdPrefix = "@clientspanid=";
         const int MaxTagsPayloadSize = 8000;
 
         public static string? GetStringOrNull(this DbDataReader reader, int columnIndex)
@@ -135,6 +139,7 @@ namespace DurableTask.SqlServer
                     {
                         Input = GetPayloadText(reader),
                         InstanceId = "", // Placeholder - shouldn't technically be needed (adding it requires a SQL schema change)
+                        ClientSpanId = GetSubOrchestrationClientSpanId(reader),
                         Name = GetName(reader),
                         Version = null,
                     };
@@ -441,6 +446,16 @@ namespace DurableTask.SqlServer
 
         internal static SqlString GetTraceContext(HistoryEvent e)
         {
+            if (e is SubOrchestrationInstanceCreatedEvent subOrchestrationEvent)
+            {
+                if (string.IsNullOrEmpty(subOrchestrationEvent.ClientSpanId))
+                {
+                    return SqlString.Null;
+                }
+
+                return new SqlString($"{TraceContextClientSpanIdPrefix}{subOrchestrationEvent.ClientSpanId}");
+            }
+
             if (e is not ISupportsDurableTraceContext eventWithTraceContext ||
                 eventWithTraceContext.ParentTraceContext == null)
             {
@@ -452,7 +467,24 @@ namespace DurableTask.SqlServer
             // We prefer a simple format instead of JSON because external callers may interact with this
             // data and we don't want to expose them to some internal JSON serialization format.
             var sb = new StringBuilder(traceContext.TraceParent, capacity: 800);
-            if (!string.IsNullOrEmpty(traceContext.TraceState))
+            if (!string.IsNullOrEmpty(traceContext.Id) || !string.IsNullOrEmpty(traceContext.SpanId))
+            {
+                if (!string.IsNullOrEmpty(traceContext.TraceState))
+                {
+                    sb.Append('\n').Append(TraceContextTraceStatePrefix).Append(traceContext.TraceState);
+                }
+
+                if (!string.IsNullOrEmpty(traceContext.Id))
+                {
+                    sb.Append('\n').Append(TraceContextIdPrefix).Append(traceContext.Id);
+                }
+
+                if (!string.IsNullOrEmpty(traceContext.SpanId))
+                {
+                    sb.Append('\n').Append(TraceContextSpanIdPrefix).Append(traceContext.SpanId);
+                }
+            }
+            else if (!string.IsNullOrEmpty(traceContext.TraceState))
             {
                 sb.Append('\n').Append(traceContext.TraceState);
             }
@@ -474,16 +506,64 @@ namespace DurableTask.SqlServer
                 return null;
             }
 
-            string[] parts = text.Split(TraceContextSeparators, count: 2, StringSplitOptions.RemoveEmptyEntries);
+            string[] parts = text.Split(TraceContextSeparators, StringSplitOptions.None);
             var traceContext = new DistributedTraceContext(traceParent: parts[0]);
 
-            if (parts.Length > 1)
+            for (int i = 1; i < parts.Length; i++)
             {
-                traceContext.TraceState = parts[1];
+                string part = parts[i];
+                if (string.IsNullOrEmpty(part))
+                {
+                    continue;
+                }
+
+                if (part.StartsWith(TraceContextTraceStatePrefix, StringComparison.Ordinal))
+                {
+                    traceContext.TraceState = part.Substring(TraceContextTraceStatePrefix.Length);
+                }
+                else if (part.StartsWith(TraceContextIdPrefix, StringComparison.Ordinal))
+                {
+                    traceContext.Id = part.Substring(TraceContextIdPrefix.Length);
+                }
+                else if (part.StartsWith(TraceContextSpanIdPrefix, StringComparison.Ordinal))
+                {
+                    traceContext.SpanId = part.Substring(TraceContextSpanIdPrefix.Length);
+                }
+                else if (traceContext.TraceState == null)
+                {
+                    // Preserve the legacy format, where the optional second line stored only tracestate.
+                    traceContext.TraceState = part;
+                }
             }
 
             traceContext.ActivityStartTime = GetTimestamp(reader);
             return traceContext;
+        }
+
+        static string? GetSubOrchestrationClientSpanId(DbDataReader reader)
+        {
+            int ordinal = reader.GetOrdinal("TraceContext");
+            if (reader.IsDBNull(ordinal))
+            {
+                return null;
+            }
+
+            string text = reader.GetString(ordinal);
+            if (string.IsNullOrEmpty(text))
+            {
+                return null;
+            }
+
+            string[] parts = text.Split(TraceContextSeparators, StringSplitOptions.None);
+            foreach (string part in parts)
+            {
+                if (part.StartsWith(TraceContextClientSpanIdPrefix, StringComparison.Ordinal))
+                {
+                    return part.Substring(TraceContextClientSpanIdPrefix.Length);
+                }
+            }
+
+            return null;
         }
 
         internal static IDictionary<string, string>? GetTags(DbDataReader reader)

--- a/src/DurableTask.SqlServer/SqlUtils.cs
+++ b/src/DurableTask.SqlServer/SqlUtils.cs
@@ -453,10 +453,13 @@ namespace DurableTask.SqlServer
                     return SqlString.Null;
                 }
 
-                // Reserve line 1 for traceparent (empty here) so all TraceContext payloads share
-                // a single parsing contract: parts[0] is always traceparent (possibly empty),
-                // and subsequent lines carry typed @key=value fields like @clientspanid=.
-                return new SqlString($"\n{TraceContextClientSpanIdPrefix}{subOrchestrationEvent.ClientSpanId}");
+                // Rolling-upgrade safe layout:
+                //   line 1: empty (no traceparent for a sub-orch-only payload)
+                //   line 2: empty (reserved tracestate slot — older readers see "" here, not @clientspanid=)
+                //   line 3: @clientspanid=...
+                // Older workers, which only inspect parts[0]/parts[1], will see empty traceparent
+                // and empty tracestate and therefore not produce a malformed DistributedTraceContext.
+                return new SqlString($"\n\n{TraceContextClientSpanIdPrefix}{subOrchestrationEvent.ClientSpanId}");
             }
 
             if (e is not ISupportsDurableTraceContext eventWithTraceContext ||
@@ -467,29 +470,42 @@ namespace DurableTask.SqlServer
 
             DistributedTraceContext traceContext = eventWithTraceContext.ParentTraceContext;
 
-            // We prefer a simple format instead of JSON because external callers may interact with this
-            // data and we don't want to expose them to some internal JSON serialization format.
+            // Wire format (rolling-upgrade safe):
+            //   line 1: traceparent
+            //   line 2 (optional): tracestate, RAW with no prefix — matches the legacy format
+            //                      so older workers reading new rows still extract tracestate correctly.
+            //                      An empty placeholder line is written when tracestate is empty but
+            //                      Id/SpanId follow, so newer @-prefixed lines never land on line 2.
+            //   line 3+ (optional): @id=..., @spanid=... (and @clientspanid= for sub-orchestration rows)
+            //                      Older workers ignore lines beyond the second one.
+            // We prefer this simple line-based format over JSON because external callers may interact
+            // with this data and we don't want to expose them to some internal serialization format.
             var sb = new StringBuilder(traceContext.TraceParent, capacity: 800);
-            if (!string.IsNullOrEmpty(traceContext.Id) || !string.IsNullOrEmpty(traceContext.SpanId))
+
+            bool hasId = !string.IsNullOrEmpty(traceContext.Id);
+            bool hasSpanId = !string.IsNullOrEmpty(traceContext.SpanId);
+            bool hasTraceState = !string.IsNullOrEmpty(traceContext.TraceState);
+
+            if (hasTraceState || hasId || hasSpanId)
             {
-                if (!string.IsNullOrEmpty(traceContext.TraceState))
+                // Always reserve line 2 for tracestate (raw, possibly empty) so older readers,
+                // which only look at parts[0]/parts[1], never see an "@key=" prefix line and
+                // misinterpret it as the tracestate value during a rolling upgrade.
+                sb.Append('\n');
+                if (hasTraceState)
                 {
-                    sb.Append('\n').Append(TraceContextTraceStatePrefix).Append(traceContext.TraceState);
+                    sb.Append(traceContext.TraceState);
                 }
 
-                if (!string.IsNullOrEmpty(traceContext.Id))
+                if (hasId)
                 {
                     sb.Append('\n').Append(TraceContextIdPrefix).Append(traceContext.Id);
                 }
 
-                if (!string.IsNullOrEmpty(traceContext.SpanId))
+                if (hasSpanId)
                 {
                     sb.Append('\n').Append(TraceContextSpanIdPrefix).Append(traceContext.SpanId);
                 }
-            }
-            else if (!string.IsNullOrEmpty(traceContext.TraceState))
-            {
-                sb.Append('\n').Append(traceContext.TraceState);
             }
 
             return sb.ToString();

--- a/src/DurableTask.SqlServer/SqlUtils.cs
+++ b/src/DurableTask.SqlServer/SqlUtils.cs
@@ -24,10 +24,21 @@ namespace DurableTask.SqlServer
     {
         static readonly Random random = new Random();
         static readonly char[] TraceContextSeparators = new char[] { '\n' };
-        const string TraceContextTraceStatePrefix = "@tracestate=";
-        const string TraceContextIdPrefix = "@id=";
-        const string TraceContextSpanIdPrefix = "@spanid=";
-        const string TraceContextClientSpanIdPrefix = "@clientspanid=";
+
+        // Durable Task MSSQL provider's W3C tracestate vendor key. The extended trace-context
+        // fields (durable orchestration span identity, sub-orchestration client span id) are
+        // carried as values of this single tracestate entry so the on-the-wire payload is
+        // rolling-upgrade safe: older workers preserve the entire tracestate string (W3C spec
+        // requires unknown vendor keys to be propagated unchanged), and newer workers know
+        // to extract our fields out of it.
+        const string TracestateVendorKey = "durabletask-mssql";
+        const string TracestateVendorKeyEquals = TracestateVendorKey + "=";
+
+        // Field names inside the vendor key's value. Format: "id:...;span:...;client:..."
+        const string VendorFieldId = "id";
+        const string VendorFieldSpanId = "span";
+        const string VendorFieldClientSpanId = "client";
+
         const int MaxTagsPayloadSize = 8000;
 
         public static string? GetStringOrNull(this DbDataReader reader, int columnIndex)
@@ -453,13 +464,14 @@ namespace DurableTask.SqlServer
                     return SqlString.Null;
                 }
 
-                // Rolling-upgrade safe layout:
-                //   line 1: empty (no traceparent for a sub-orch-only payload)
-                //   line 2: empty (reserved tracestate slot — older readers see "" here, not @clientspanid=)
-                //   line 3: @clientspanid=...
-                // Older workers, which only inspect parts[0]/parts[1], will see empty traceparent
-                // and empty tracestate and therefore not produce a malformed DistributedTraceContext.
-                return new SqlString($"\n\n{TraceContextClientSpanIdPrefix}{subOrchestrationEvent.ClientSpanId}");
+                // Wire format for sub-orchestration rows:
+                //   "durabletask-mssql=client:<spanId>"
+                // This is a single line — no traceparent, no newlines. The pre-PR reader never
+                // inspected the TraceContext column for sub-orchestration rows (only the new
+                // SqlUtils.GetSubOrchestrationClientSpanId helper does), so this payload is
+                // only ever parsed by code that knows about the vendor key.
+                return new SqlString(
+                    BuildVendorKeyValue(id: null, spanId: null, clientSpanId: subOrchestrationEvent.ClientSpanId));
             }
 
             if (e is not ISupportsDurableTraceContext eventWithTraceContext ||
@@ -470,41 +482,48 @@ namespace DurableTask.SqlServer
 
             DistributedTraceContext traceContext = eventWithTraceContext.ParentTraceContext;
 
-            // Wire format (rolling-upgrade safe):
-            //   line 1: traceparent
-            //   line 2 (optional): tracestate, RAW with no prefix — matches the legacy format
-            //                      so older workers reading new rows still extract tracestate correctly.
-            //                      An empty placeholder line is written when tracestate is empty but
-            //                      Id/SpanId follow, so newer @-prefixed lines never land on line 2.
-            //   line 3+ (optional): @id=..., @spanid=... (and @clientspanid= for sub-orchestration rows)
-            //                      Older workers ignore lines beyond the second one.
-            // We prefer this simple line-based format over JSON because external callers may interact
-            // with this data and we don't want to expose them to some internal serialization format.
+            // Wire format (rolling-upgrade safe, fully W3C-compatible):
+            //   line 1: traceparent (unchanged)
+            //   line 2: tracestate, optionally with our "durabletask-mssql=..." vendor key
+            //           prepended. The legacy reader uses
+            //           Split({'\n'}, count: 2, RemoveEmptyEntries) and assigns parts[1] to
+            //           TraceState wholesale, so the line MUST be a single W3C-valid tracestate
+            //           (no embedded newlines, no equals/comma except at the standard positions).
+            //
+            // The Id, SpanId, and (for sub-orch rows) ClientSpanId fields ride inside the
+            // vendor key's value. W3C tracestate explicitly requires unknown vendor keys to
+            // be preserved and propagated, so an older worker on a new row reads the entire
+            // tracestate string (vendor key included), assigns it to Activity.TraceStateString,
+            // and forwards it downstream untouched.
+            //
+            // Format of the vendor key value:
+            //   id:<durable-id>;span:<durable-spanid>[;client:<client-span-id>]
+            // Field separator is ';' (allowed in W3C tracestate values).
             var sb = new StringBuilder(traceContext.TraceParent, capacity: 800);
 
             bool hasId = !string.IsNullOrEmpty(traceContext.Id);
             bool hasSpanId = !string.IsNullOrEmpty(traceContext.SpanId);
-            bool hasTraceState = !string.IsNullOrEmpty(traceContext.TraceState);
+            bool hasUserTraceState = !string.IsNullOrEmpty(traceContext.TraceState);
 
-            if (hasTraceState || hasId || hasSpanId)
+            string? vendorValue = (hasId || hasSpanId)
+                ? BuildVendorKeyValue(traceContext.Id, traceContext.SpanId, clientSpanId: null)
+                : null;
+
+            if (vendorValue != null || hasUserTraceState)
             {
-                // Always reserve line 2 for tracestate (raw, possibly empty) so older readers,
-                // which only look at parts[0]/parts[1], never see an "@key=" prefix line and
-                // misinterpret it as the tracestate value during a rolling upgrade.
                 sb.Append('\n');
-                if (hasTraceState)
+                if (vendorValue != null)
+                {
+                    sb.Append(vendorValue);
+                    if (hasUserTraceState)
+                    {
+                        // Multiple tracestate entries are comma-separated per W3C spec.
+                        sb.Append(',').Append(traceContext.TraceState);
+                    }
+                }
+                else
                 {
                     sb.Append(traceContext.TraceState);
-                }
-
-                if (hasId)
-                {
-                    sb.Append('\n').Append(TraceContextIdPrefix).Append(traceContext.Id);
-                }
-
-                if (hasSpanId)
-                {
-                    sb.Append('\n').Append(TraceContextSpanIdPrefix).Append(traceContext.SpanId);
                 }
             }
 
@@ -512,9 +531,52 @@ namespace DurableTask.SqlServer
         }
 
         /// <summary>
-        /// Parsed result of a TraceContext column payload. Centralizes the on-the-wire format
-        /// (line 1 = traceparent, subsequent lines = typed @key=value fields) so all callers
-        /// share the same parsing contract.
+        /// Builds the value portion of the "durabletask-mssql=..." W3C tracestate vendor key.
+        /// Output looks like one of:
+        ///   durabletask-mssql=id:...;span:...
+        ///   durabletask-mssql=id:...;span:...;client:...
+        ///   durabletask-mssql=client:...
+        /// </summary>
+        static string BuildVendorKeyValue(string? id, string? spanId, string? clientSpanId)
+        {
+            var sb = new StringBuilder(TracestateVendorKeyEquals, capacity: 200);
+            bool first = true;
+
+            void AppendField(string fieldName, string value)
+            {
+                if (!first)
+                {
+                    sb.Append(';');
+                }
+
+                sb.Append(fieldName).Append(':').Append(value);
+                first = false;
+            }
+
+            if (!string.IsNullOrEmpty(id))
+            {
+                AppendField(VendorFieldId, id!);
+            }
+
+            if (!string.IsNullOrEmpty(spanId))
+            {
+                AppendField(VendorFieldSpanId, spanId!);
+            }
+
+            if (!string.IsNullOrEmpty(clientSpanId))
+            {
+                AppendField(VendorFieldClientSpanId, clientSpanId!);
+            }
+
+            return sb.ToString();
+        }
+
+        /// <summary>
+        /// Parsed result of a TraceContext column payload. The on-the-wire format mirrors the
+        /// legacy "traceparent\ntracestate" layout, with the extended Durable Task MSSQL fields
+        /// (Id, SpanId, ClientSpanId) carried inside the tracestate as a single W3C vendor key
+        /// named "durabletask-mssql". Centralizing parsing here keeps every reader in lock-step
+        /// with the writer's wire-format contract.
         /// </summary>
         struct ParsedTraceContext
         {
@@ -539,67 +601,135 @@ namespace DurableTask.SqlServer
                 return null;
             }
 
-            string[] parts = text.Split(TraceContextSeparators, StringSplitOptions.None);
+            // Use the same split semantics as the pre-PR reader so all readers (old and new)
+            // see identical (traceparent, tracestate) pairs for any given on-the-wire payload.
+            string[] parts = text.Split(TraceContextSeparators, count: 2, StringSplitOptions.RemoveEmptyEntries);
 
             string? traceParent = null;
-            string? traceState = null;
+            string? rawTraceState = null;
+
+            if (parts.Length == 0)
+            {
+                return null;
+            }
+            else if (parts.Length == 1)
+            {
+                // Either a single-line "durabletask-mssql=client:..." payload (new sub-orchestration
+                // wire format) or a one-line legacy payload that only contained a traceparent.
+                if (parts[0].StartsWith(TracestateVendorKeyEquals, StringComparison.Ordinal))
+                {
+                    rawTraceState = parts[0];
+                }
+                else
+                {
+                    traceParent = parts[0];
+                }
+            }
+            else
+            {
+                traceParent = parts[0];
+                rawTraceState = parts[1];
+            }
+
+            // Extract the durabletask-mssql vendor key from the tracestate, leaving any
+            // user-supplied tracestate entries intact in the returned TraceState value.
+            string? userTraceState = rawTraceState;
             string? id = null;
             string? spanId = null;
             string? clientSpanId = null;
 
-            // Line 1 is reserved for traceparent. Older histories may have written a typed
-            // "@key=value" prefix on line 1 (legacy sub-orchestration payload). Detect that
-            // case by checking for the @ sentinel; otherwise treat parts[0] as traceparent.
-            int startIndex;
-            if (!string.IsNullOrEmpty(parts[0]) && parts[0][0] != '@')
+            if (!string.IsNullOrEmpty(rawTraceState))
             {
-                traceParent = parts[0];
-                startIndex = 1;
-            }
-            else
-            {
-                startIndex = 0;
-            }
-
-            for (int i = startIndex; i < parts.Length; i++)
-            {
-                string part = parts[i];
-                if (string.IsNullOrEmpty(part))
-                {
-                    continue;
-                }
-
-                if (part.StartsWith(TraceContextTraceStatePrefix, StringComparison.Ordinal))
-                {
-                    traceState = part.Substring(TraceContextTraceStatePrefix.Length);
-                }
-                else if (part.StartsWith(TraceContextIdPrefix, StringComparison.Ordinal))
-                {
-                    id = part.Substring(TraceContextIdPrefix.Length);
-                }
-                else if (part.StartsWith(TraceContextSpanIdPrefix, StringComparison.Ordinal))
-                {
-                    spanId = part.Substring(TraceContextSpanIdPrefix.Length);
-                }
-                else if (part.StartsWith(TraceContextClientSpanIdPrefix, StringComparison.Ordinal))
-                {
-                    clientSpanId = part.Substring(TraceContextClientSpanIdPrefix.Length);
-                }
-                else if (traceState == null && i > 0)
-                {
-                    // Preserve the legacy format, where the optional second line stored only tracestate.
-                    traceState = part;
-                }
+                userTraceState = ExtractVendorFields(
+                    rawTraceState!,
+                    out id,
+                    out spanId,
+                    out clientSpanId);
             }
 
             return new ParsedTraceContext
             {
                 TraceParent = traceParent,
-                TraceState = traceState,
+                TraceState = string.IsNullOrEmpty(userTraceState) ? null : userTraceState,
                 Id = id,
                 SpanId = spanId,
                 ClientSpanId = clientSpanId,
             };
+        }
+
+        /// <summary>
+        /// Scans a W3C tracestate string for the "durabletask-mssql=..." vendor key, splits its
+        /// value into id/span/client fields, and returns the tracestate with that vendor key
+        /// removed (so the caller can hand the unmodified user tracestate downstream).
+        /// </summary>
+        static string? ExtractVendorFields(
+            string tracestate,
+            out string? id,
+            out string? spanId,
+            out string? clientSpanId)
+        {
+            id = null;
+            spanId = null;
+            clientSpanId = null;
+
+            // W3C tracestate entries are comma-separated. Use a List<string> so the order of
+            // user-supplied entries is preserved when reconstructing the user tracestate.
+            string[] entries = tracestate.Split(',');
+            List<string>? userEntries = null;
+
+            for (int i = 0; i < entries.Length; i++)
+            {
+                string entry = entries[i].Trim();
+                if (entry.Length == 0)
+                {
+                    continue;
+                }
+
+                if (entry.StartsWith(TracestateVendorKeyEquals, StringComparison.Ordinal))
+                {
+                    string vendorValue = entry.Substring(TracestateVendorKeyEquals.Length);
+                    ParseVendorFields(vendorValue, out id, out spanId, out clientSpanId);
+                }
+                else
+                {
+                    userEntries ??= new List<string>(entries.Length);
+                    userEntries.Add(entry);
+                }
+            }
+
+            return userEntries != null ? string.Join(",", userEntries) : null;
+        }
+
+        static void ParseVendorFields(string vendorValue, out string? id, out string? spanId, out string? clientSpanId)
+        {
+            id = null;
+            spanId = null;
+            clientSpanId = null;
+
+            foreach (string field in vendorValue.Split(';'))
+            {
+                int colonIndex = field.IndexOf(':');
+                if (colonIndex <= 0)
+                {
+                    continue;
+                }
+
+                string fieldName = field.Substring(0, colonIndex);
+                string fieldValue = field.Substring(colonIndex + 1);
+
+                if (string.Equals(fieldName, VendorFieldId, StringComparison.Ordinal))
+                {
+                    id = fieldValue;
+                }
+                else if (string.Equals(fieldName, VendorFieldSpanId, StringComparison.Ordinal))
+                {
+                    spanId = fieldValue;
+                }
+                else if (string.Equals(fieldName, VendorFieldClientSpanId, StringComparison.Ordinal))
+                {
+                    clientSpanId = fieldValue;
+                }
+            }
         }
 
         static DistributedTraceContext? GetTraceContext(DbDataReader reader)

--- a/src/DurableTask.SqlServer/SqlUtils.cs
+++ b/src/DurableTask.SqlServer/SqlUtils.cs
@@ -453,7 +453,10 @@ namespace DurableTask.SqlServer
                     return SqlString.Null;
                 }
 
-                return new SqlString($"{TraceContextClientSpanIdPrefix}{subOrchestrationEvent.ClientSpanId}");
+                // Reserve line 1 for traceparent (empty here) so all TraceContext payloads share
+                // a single parsing contract: parts[0] is always traceparent (possibly empty),
+                // and subsequent lines carry typed @key=value fields like @clientspanid=.
+                return new SqlString($"\n{TraceContextClientSpanIdPrefix}{subOrchestrationEvent.ClientSpanId}");
             }
 
             if (e is not ISupportsDurableTraceContext eventWithTraceContext ||
@@ -492,7 +495,21 @@ namespace DurableTask.SqlServer
             return sb.ToString();
         }
 
-        static DistributedTraceContext? GetTraceContext(DbDataReader reader)
+        /// <summary>
+        /// Parsed result of a TraceContext column payload. Centralizes the on-the-wire format
+        /// (line 1 = traceparent, subsequent lines = typed @key=value fields) so all callers
+        /// share the same parsing contract.
+        /// </summary>
+        struct ParsedTraceContext
+        {
+            public string? TraceParent { get; set; }
+            public string? TraceState { get; set; }
+            public string? Id { get; set; }
+            public string? SpanId { get; set; }
+            public string? ClientSpanId { get; set; }
+        }
+
+        static ParsedTraceContext? ParseTraceContext(DbDataReader reader)
         {
             int ordinal = reader.GetOrdinal("TraceContext");
             if (reader.IsDBNull(ordinal))
@@ -507,9 +524,28 @@ namespace DurableTask.SqlServer
             }
 
             string[] parts = text.Split(TraceContextSeparators, StringSplitOptions.None);
-            var traceContext = new DistributedTraceContext(traceParent: parts[0]);
 
-            for (int i = 1; i < parts.Length; i++)
+            string? traceParent = null;
+            string? traceState = null;
+            string? id = null;
+            string? spanId = null;
+            string? clientSpanId = null;
+
+            // Line 1 is reserved for traceparent. Older histories may have written a typed
+            // "@key=value" prefix on line 1 (legacy sub-orchestration payload). Detect that
+            // case by checking for the @ sentinel; otherwise treat parts[0] as traceparent.
+            int startIndex;
+            if (!string.IsNullOrEmpty(parts[0]) && parts[0][0] != '@')
+            {
+                traceParent = parts[0];
+                startIndex = 1;
+            }
+            else
+            {
+                startIndex = 0;
+            }
+
+            for (int i = startIndex; i < parts.Length; i++)
             {
                 string part = parts[i];
                 if (string.IsNullOrEmpty(part))
@@ -519,51 +555,61 @@ namespace DurableTask.SqlServer
 
                 if (part.StartsWith(TraceContextTraceStatePrefix, StringComparison.Ordinal))
                 {
-                    traceContext.TraceState = part.Substring(TraceContextTraceStatePrefix.Length);
+                    traceState = part.Substring(TraceContextTraceStatePrefix.Length);
                 }
                 else if (part.StartsWith(TraceContextIdPrefix, StringComparison.Ordinal))
                 {
-                    traceContext.Id = part.Substring(TraceContextIdPrefix.Length);
+                    id = part.Substring(TraceContextIdPrefix.Length);
                 }
                 else if (part.StartsWith(TraceContextSpanIdPrefix, StringComparison.Ordinal))
                 {
-                    traceContext.SpanId = part.Substring(TraceContextSpanIdPrefix.Length);
+                    spanId = part.Substring(TraceContextSpanIdPrefix.Length);
                 }
-                else if (traceContext.TraceState == null)
+                else if (part.StartsWith(TraceContextClientSpanIdPrefix, StringComparison.Ordinal))
+                {
+                    clientSpanId = part.Substring(TraceContextClientSpanIdPrefix.Length);
+                }
+                else if (traceState == null && i > 0)
                 {
                     // Preserve the legacy format, where the optional second line stored only tracestate.
-                    traceContext.TraceState = part;
+                    traceState = part;
                 }
             }
 
-            traceContext.ActivityStartTime = GetTimestamp(reader);
+            return new ParsedTraceContext
+            {
+                TraceParent = traceParent,
+                TraceState = traceState,
+                Id = id,
+                SpanId = spanId,
+                ClientSpanId = clientSpanId,
+            };
+        }
+
+        static DistributedTraceContext? GetTraceContext(DbDataReader reader)
+        {
+            ParsedTraceContext? parsed = ParseTraceContext(reader);
+            if (parsed == null || string.IsNullOrEmpty(parsed.Value.TraceParent))
+            {
+                // No traceparent means this row carries only sub-orchestration-specific data
+                // (e.g. @clientspanid=...) which is not a DistributedTraceContext.
+                return null;
+            }
+
+            ParsedTraceContext value = parsed.Value;
+            var traceContext = new DistributedTraceContext(traceParent: value.TraceParent!)
+            {
+                TraceState = value.TraceState,
+                Id = value.Id,
+                SpanId = value.SpanId,
+                ActivityStartTime = GetTimestamp(reader),
+            };
             return traceContext;
         }
 
         static string? GetSubOrchestrationClientSpanId(DbDataReader reader)
         {
-            int ordinal = reader.GetOrdinal("TraceContext");
-            if (reader.IsDBNull(ordinal))
-            {
-                return null;
-            }
-
-            string text = reader.GetString(ordinal);
-            if (string.IsNullOrEmpty(text))
-            {
-                return null;
-            }
-
-            string[] parts = text.Split(TraceContextSeparators, StringSplitOptions.None);
-            foreach (string part in parts)
-            {
-                if (part.StartsWith(TraceContextClientSpanIdPrefix, StringComparison.Ordinal))
-                {
-                    return part.Substring(TraceContextClientSpanIdPrefix.Length);
-                }
-            }
-
-            return null;
+            return ParseTraceContext(reader)?.ClientSpanId;
         }
 
         internal static IDictionary<string, string>? GetTags(DbDataReader reader)

--- a/src/DurableTask.SqlServer/SqlUtils.cs
+++ b/src/DurableTask.SqlServer/SqlUtils.cs
@@ -464,12 +464,13 @@ namespace DurableTask.SqlServer
                     return SqlString.Null;
                 }
 
-                // Wire format for sub-orchestration rows:
+                // Wire format for SubOrchestrationInstanceCreated history rows:
                 //   "durabletask-mssql=client:<spanId>"
-                // This is a single line — no traceparent, no newlines. The pre-PR reader never
-                // inspected the TraceContext column for sub-orchestration rows (only the new
-                // SqlUtils.GetSubOrchestrationClientSpanId helper does), so this payload is
-                // only ever parsed by code that knows about the vendor key.
+                // This is a single line — no traceparent, no newlines. SQL history queries return
+                // the TraceContext column together with the row's EventType, and legacy readers
+                // do not call GetTraceContext for SubOrchestrationInstanceCreated. The payload is
+                // not projected into ExecutionStarted/EventRaised/TaskScheduled rows, so legacy
+                // workers never interpret this vendor key as a traceparent.
                 return new SqlString(
                     BuildVendorKeyValue(id: null, spanId: null, clientSpanId: subOrchestrationEvent.ClientSpanId));
             }
@@ -672,22 +673,26 @@ namespace DurableTask.SqlServer
             spanId = null;
             clientSpanId = null;
 
-            // W3C tracestate entries are comma-separated. Use a List<string> so the order of
-            // user-supplied entries is preserved when reconstructing the user tracestate.
+            // W3C tracestate entries are comma-separated. Use a List<string> so the order and
+            // optional whitespace of user-supplied entries are preserved when reconstructing the
+            // user tracestate.
             string[] entries = tracestate.Split(',');
             List<string>? userEntries = null;
+            bool foundVendorKey = false;
 
             for (int i = 0; i < entries.Length; i++)
             {
-                string entry = entries[i].Trim();
-                if (entry.Length == 0)
+                string entry = entries[i];
+                string trimmedEntry = entry.Trim();
+                if (trimmedEntry.Length == 0)
                 {
                     continue;
                 }
 
-                if (entry.StartsWith(TracestateVendorKeyEquals, StringComparison.Ordinal))
+                if (trimmedEntry.StartsWith(TracestateVendorKeyEquals, StringComparison.Ordinal))
                 {
-                    string vendorValue = entry.Substring(TracestateVendorKeyEquals.Length);
+                    foundVendorKey = true;
+                    string vendorValue = trimmedEntry.Substring(TracestateVendorKeyEquals.Length);
                     ParseVendorFields(vendorValue, out id, out spanId, out clientSpanId);
                 }
                 else
@@ -697,7 +702,19 @@ namespace DurableTask.SqlServer
                 }
             }
 
-            return userEntries != null ? string.Join(",", userEntries) : null;
+            if (!foundVendorKey)
+            {
+                return tracestate;
+            }
+
+            if (userEntries == null)
+            {
+                return null;
+            }
+
+            userEntries[0] = userEntries[0].TrimStart();
+            userEntries[userEntries.Count - 1] = userEntries[userEntries.Count - 1].TrimEnd();
+            return string.Join(",", userEntries);
         }
 
         static void ParseVendorFields(string vendorValue, out string? id, out string? spanId, out string? clientSpanId)
@@ -738,7 +755,7 @@ namespace DurableTask.SqlServer
             if (parsed == null || string.IsNullOrEmpty(parsed.Value.TraceParent))
             {
                 // No traceparent means this row carries only sub-orchestration-specific data
-                // (e.g. @clientspanid=...) which is not a DistributedTraceContext.
+                // (e.g. durabletask-mssql=client:...) which is not a DistributedTraceContext.
                 return null;
             }
 

--- a/test/DurableTask.SqlServer.Tests/Integration/Orchestrations.cs
+++ b/test/DurableTask.SqlServer.Tests/Integration/Orchestrations.cs
@@ -690,6 +690,12 @@ namespace DurableTask.SqlServer.Tests.Integration
             await parentInstance.WaitForCompletion(expectedOutput: true);
         }
 
+        // This regression locks down the expected DurableTask span shape for a simple
+        // parent orchestration -> sub-orchestration -> activity flow. The important
+        // nuance is that an activity under a sub-orchestration is nested via an
+        // activity client span, so the hierarchy is:
+        // parent orchestration server -> sub-orchestration client -> sub-orchestration server
+        // -> activity client -> activity server.
         [Fact]
         public async Task TraceContextFlowCorrectly()
         {
@@ -800,6 +806,15 @@ namespace DurableTask.SqlServer.Tests.Integration
             Assert.True(subOrchestratorSpan.Duration > delay, $"Unexpected duration: {subOrchestratorSpan.Duration}");
             Assert.True(subOrchestratorSpan.Duration < delay * 2, $"Unexpected duration: {subOrchestratorSpan.Duration}");
 
+            Activity subOrchestratorClientSpan = exportedItems.LastOrDefault(
+                span => span.OperationName == $"orchestration:{subOrchestrationName}" && span.Kind == ActivityKind.Client);
+            Assert.NotNull(subOrchestratorClientSpan);
+
+            // The sub-orchestration execution span hangs off the sub-orchestration client span,
+            // which in turn hangs off the parent orchestration execution span.
+            Assert.Equal(orchestratorSpan.SpanId, subOrchestratorClientSpan.ParentSpanId);
+            Assert.Equal(subOrchestratorClientSpan.SpanId, subOrchestratorSpan.ParentSpanId);
+
             // Validate the activity span, which should be a subset of the sub-orchestration span
             Activity activitySpan = exportedItems.LastOrDefault(
                 span => span.OperationName == $"activity:{activityName}" && span.Kind == ActivityKind.Server);
@@ -811,6 +826,299 @@ namespace DurableTask.SqlServer.Tests.Integration
             Assert.True(activitySpan.Duration < subOrchestratorSpan.Duration);
             Assert.True(activitySpan.Duration > delay);
             Assert.True(activitySpan.Duration < delay * 2);
+
+            Activity activityClientSpan = exportedItems.LastOrDefault(
+                span => span.OperationName == $"activity:{activityName}" && span.Kind == ActivityKind.Client);
+            Assert.NotNull(activityClientSpan);
+
+            // This is the key shape for selling the trace fix: an activity scheduled by a
+            // sub-orchestrator must remain inside that sub-orchestrator's execution span
+            // hierarchy rather than floating at the root with a dangling parent.
+            Assert.Equal(subOrchestratorSpan.SpanId, activityClientSpan.ParentSpanId);
+            Assert.Equal(activityClientSpan.SpanId, activitySpan.ParentSpanId);
+        }
+
+        // This regression protects the SQL-specific bug where an orchestration reload could
+        // generate a fresh execution span ID, leaving later activity completion and timer
+        // spans pointing at a parent that no longer exists in the exported trace.
+        [Fact]
+        public async Task TraceContextMaintainsStableOrchestrationSpanAcrossContinuations()
+        {
+            string traceSourceName = "MyTraceSource";
+            string orchestrationName = "ContinuationTraceContextOrchestration";
+            string[] activityNames = { "FirstActivity", "SecondActivity" };
+            TimeSpan delay = TimeSpan.FromMilliseconds(250);
+
+            var exportedItems = new List<Activity>();
+            using TracerProvider tracerProvider = Sdk.CreateTracerProviderBuilder()
+                .AddSource(traceSourceName, "DurableTask.Core")
+                .ConfigureResource(r => r.AddService("Test"))
+                .AddInMemoryExporter(exportedItems)
+                .Build();
+
+            using var traceSource = new ActivitySource(traceSourceName);
+            using var clientSpan = traceSource.StartActivity("TestSpan");
+            clientSpan.TraceStateString = "TestTraceState";
+
+            TestInstance<string> instance = await this.testService.RunOrchestration<string, string>(
+                input: "input",
+                orchestrationName: orchestrationName,
+                implementation: async (ctx, input) =>
+                {
+                    string first = await ctx.ScheduleTask<string>(activityNames[0], "", input);
+                    await ctx.CreateTimer(ctx.CurrentUtcDateTime.Add(delay), "");
+                    string second = await ctx.ScheduleTask<string>(activityNames[1], "", input);
+                    await ctx.CreateTimer(ctx.CurrentUtcDateTime.Add(delay), "");
+                    return string.Join(",", first, second);
+                },
+                activities: new[]
+                {
+                    (activityNames[0], TestService.MakeActivity((TaskContext ctx, string input) => $"first-{input}")),
+                    (activityNames[1], TestService.MakeActivity((TaskContext ctx, string input) => $"second-{input}")),
+                });
+
+            await instance.WaitForCompletion(expectedOutput: "first-input,second-input");
+
+            clientSpan.Stop();
+            tracerProvider.ForceFlush();
+
+            Activity[] orchestrationSpans = exportedItems
+                .Where(span => span.OperationName == $"orchestration:{orchestrationName}" && span.Kind == ActivityKind.Server)
+                .ToArray();
+            Assert.NotEmpty(orchestrationSpans);
+
+            ActivitySpanId[] orchestrationSpanIds = orchestrationSpans
+                .Select(span => span.SpanId)
+                .Distinct()
+                .ToArray();
+            Assert.Single(orchestrationSpanIds);
+
+            ActivitySpanId orchestrationSpanId = orchestrationSpanIds[0];
+            var activityOperationNames = new HashSet<string>(activityNames.Select(name => $"activity:{name}"));
+
+            Activity[] completionSpans = exportedItems
+                .Where(span => span.Kind == ActivityKind.Client && activityOperationNames.Contains(span.OperationName))
+                .ToArray();
+            Assert.Equal(2, completionSpans.Length);
+            Assert.All(completionSpans, span => Assert.Equal(orchestrationSpanId, span.ParentSpanId));
+
+            Activity[] timerSpans = exportedItems
+                .Where(span => span.Kind == ActivityKind.Internal && span.OperationName == $"orchestration:{orchestrationName}:timer")
+                .ToArray();
+            Assert.Equal(2, timerSpans.Length);
+            Assert.All(timerSpans, span => Assert.Equal(orchestrationSpanId, span.ParentSpanId));
+        }
+
+        // This test observes raw Activity objects directly, without relying on exporter
+        // behavior, so it can fail fast if any emitted ParentSpanId refers to a span that
+        // was never actually produced. The hierarchy intentionally exercises nested
+        // sub-orchestrations plus an activity at the deepest level.
+        [Fact]
+        public async Task ActivityListenerCapturesNestedSubOrchestrationHierarchyWithoutMissingParents()
+        {
+            string traceSourceName = "ActivityListenerNestedTraceSource";
+            string parentOrchestrationName = "ActivityListenerParentOrchestration";
+            string childOrchestrationName = "ActivityListenerChildOrchestration";
+            string grandchildOrchestrationName = "ActivityListenerGrandchildOrchestration";
+            string[] activityNames =
+            {
+                "ActivityListenerParentActivity",
+                "ActivityListenerChildActivity",
+                "ActivityListenerGrandchildActivity",
+                "ActivityListenerAfterSubOrchestrationActivity",
+            };
+            TimeSpan delay = TimeSpan.FromMilliseconds(150);
+
+            using var listener = new ActivityCaptureListener(traceSourceName, "DurableTask.Core");
+            using var traceSource = new ActivitySource(traceSourceName);
+            using Activity incomingRequest = traceSource.StartActivity("IncomingRequest") ??
+                throw new InvalidOperationException("Failed to start the incoming request activity.");
+
+            this.testService.RegisterInlineOrchestration<string, string>(
+                grandchildOrchestrationName,
+                implementation: async (ctx, input) =>
+                {
+                    await ctx.CreateTimer(ctx.CurrentUtcDateTime.Add(delay), string.Empty);
+                    return await ctx.ScheduleTask<string>(activityNames[2], version: string.Empty, input);
+                });
+
+            this.testService.RegisterInlineOrchestration<string, string>(
+                childOrchestrationName,
+                implementation: async (ctx, input) =>
+                {
+                    string childActivity = await ctx.ScheduleTask<string>(activityNames[1], version: string.Empty, input);
+                    await ctx.CreateTimer(ctx.CurrentUtcDateTime.Add(delay), string.Empty);
+                    string grandchild = await ctx.CreateSubOrchestrationInstance<string>(grandchildOrchestrationName, version: string.Empty, input);
+                    return string.Join("|", childActivity, grandchild);
+                });
+
+            TestInstance<string> instance = await this.testService.RunOrchestration<string, string>(
+                input: "payload",
+                orchestrationName: parentOrchestrationName,
+                implementation: async (ctx, input) =>
+                {
+                    string parentActivity = await ctx.ScheduleTask<string>(activityNames[0], version: string.Empty, input);
+                    await ctx.CreateTimer(ctx.CurrentUtcDateTime.Add(delay), string.Empty);
+                    string child = await ctx.CreateSubOrchestrationInstance<string>(childOrchestrationName, version: string.Empty, input);
+                    await ctx.CreateTimer(ctx.CurrentUtcDateTime.Add(delay), string.Empty);
+                    string afterChild = await ctx.ScheduleTask<string>(activityNames[3], version: string.Empty, input);
+                    return string.Join("|", parentActivity, child, afterChild);
+                },
+                activities: new[]
+                {
+                    (activityNames[0], TestService.MakeActivity((TaskContext ctx, string input) => $"parent-{input}")),
+                    (activityNames[1], TestService.MakeActivity((TaskContext ctx, string input) => $"child-{input}")),
+                    (activityNames[2], TestService.MakeActivity((TaskContext ctx, string input) => $"grandchild-{input}")),
+                    (activityNames[3], TestService.MakeActivity((TaskContext ctx, string input) => $"after-{input}")),
+                });
+
+            await instance.WaitForCompletion(expectedOutput: "parent-payload|child-payload|grandchild-payload|after-payload");
+
+            incomingRequest.Stop();
+
+            CapturedActivity[] traceActivities = listener.GetActivities(incomingRequest.TraceId);
+            this.WriteCapturedActivities(traceActivities);
+
+            // The bug we are guarding against is "parentSpanId emitted, but the parent span
+            // does not exist". This assertion checks exactly that against the raw listener feed.
+            AssertNoMissingParents(traceActivities);
+
+            CapturedActivity parentOrchestration = GetUniqueSpan(
+                traceActivities,
+                $"orchestration:{parentOrchestrationName}",
+                ActivityKind.Server);
+            CapturedActivity childOrchestrationClient = GetUniqueSpan(
+                traceActivities,
+                $"orchestration:{childOrchestrationName}",
+                ActivityKind.Client);
+            CapturedActivity childOrchestrationServer = GetUniqueSpan(
+                traceActivities,
+                $"orchestration:{childOrchestrationName}",
+                ActivityKind.Server);
+            CapturedActivity grandchildOrchestrationClient = GetUniqueSpan(
+                traceActivities,
+                $"orchestration:{grandchildOrchestrationName}",
+                ActivityKind.Client);
+            CapturedActivity grandchildOrchestrationServer = GetUniqueSpan(
+                traceActivities,
+                $"orchestration:{grandchildOrchestrationName}",
+                ActivityKind.Server);
+            CapturedActivity grandchildActivityClient = GetUniqueSpan(
+                traceActivities,
+                $"activity:{activityNames[2]}",
+                ActivityKind.Client);
+            CapturedActivity grandchildActivityServer = GetUniqueSpan(
+                traceActivities,
+                $"activity:{activityNames[2]}",
+                ActivityKind.Server);
+
+            // Expected nesting:
+            // parent orchestration server
+            //   -> child sub-orchestration client
+            //     -> child sub-orchestration server
+            //       -> grandchild sub-orchestration client
+            //         -> grandchild sub-orchestration server
+            //           -> grandchild activity client
+            //             -> grandchild activity server
+            Assert.Equal(parentOrchestration.SpanId, childOrchestrationClient.ParentSpanId);
+            Assert.Equal(childOrchestrationClient.SpanId, childOrchestrationServer.ParentSpanId);
+            Assert.Equal(childOrchestrationServer.SpanId, grandchildOrchestrationClient.ParentSpanId);
+            Assert.Equal(grandchildOrchestrationClient.SpanId, grandchildOrchestrationServer.ParentSpanId);
+            Assert.Equal(grandchildOrchestrationServer.SpanId, grandchildActivityClient.ParentSpanId);
+            Assert.Equal(grandchildActivityClient.SpanId, grandchildActivityServer.ParentSpanId);
+        }
+
+        // This test covers sibling sub-orchestrations that run under the same parent. It
+        // ensures each invocation gets its own client/server pair and that the activities
+        // inside each child orchestration remain attached to the corresponding child span
+        // instead of pointing to a missing or reused parent.
+        [Fact]
+        public async Task ActivityListenerCapturesRepeatedSubOrchestrationsWithoutMissingParents()
+        {
+            string traceSourceName = "ActivityListenerRepeatedTraceSource";
+            string parentOrchestrationName = "ActivityListenerRepeatedParentOrchestration";
+            string childOrchestrationName = "ActivityListenerRepeatedChildOrchestration";
+            string childActivityName = "ActivityListenerRepeatedChildActivity";
+            TimeSpan delay = TimeSpan.FromMilliseconds(125);
+
+            using var listener = new ActivityCaptureListener(traceSourceName, "DurableTask.Core");
+            using var traceSource = new ActivitySource(traceSourceName);
+            using Activity incomingRequest = traceSource.StartActivity("IncomingRequest") ??
+                throw new InvalidOperationException("Failed to start the incoming request activity.");
+
+            this.testService.RegisterInlineOrchestration<string, string>(
+                childOrchestrationName,
+                implementation: async (ctx, input) =>
+                {
+                    string activityResult = await ctx.ScheduleTask<string>(childActivityName, version: string.Empty, input);
+                    await ctx.CreateTimer(ctx.CurrentUtcDateTime.Add(delay), string.Empty);
+                    return activityResult;
+                });
+
+            TestInstance<string> instance = await this.testService.RunOrchestration<string, string>(
+                input: "payload",
+                orchestrationName: parentOrchestrationName,
+                implementation: async (ctx, input) =>
+                {
+                    string first = await ctx.CreateSubOrchestrationInstance<string>(childOrchestrationName, version: string.Empty, input: $"{input}-1");
+                    await ctx.CreateTimer(ctx.CurrentUtcDateTime.Add(delay), string.Empty);
+                    string second = await ctx.CreateSubOrchestrationInstance<string>(childOrchestrationName, version: string.Empty, input: $"{input}-2");
+                    return string.Join("|", first, second);
+                },
+                activities: new[]
+                {
+                    (childActivityName, TestService.MakeActivity((TaskContext ctx, string input) => $"child-{input}")),
+                });
+
+            await instance.WaitForCompletion(expectedOutput: "child-payload-1|child-payload-2");
+
+            incomingRequest.Stop();
+
+            CapturedActivity[] traceActivities = listener.GetActivities(incomingRequest.TraceId);
+            this.WriteCapturedActivities(traceActivities);
+
+            // Every non-root ParentSpanId emitted for this trace must resolve to another
+            // captured span, otherwise Geneva can show the child span at the root.
+            AssertNoMissingParents(traceActivities);
+
+            CapturedActivity parentOrchestration = GetUniqueSpan(
+                traceActivities,
+                $"orchestration:{parentOrchestrationName}",
+                ActivityKind.Server);
+            CapturedActivity[] childOrchestrationClientSpans = GetDistinctSpans(
+                traceActivities,
+                $"orchestration:{childOrchestrationName}",
+                ActivityKind.Client);
+            CapturedActivity[] childOrchestrationServerSpans = GetDistinctSpans(
+                traceActivities,
+                $"orchestration:{childOrchestrationName}",
+                ActivityKind.Server);
+            CapturedActivity[] childActivityClientSpans = GetDistinctSpans(
+                traceActivities,
+                $"activity:{childActivityName}",
+                ActivityKind.Client);
+            CapturedActivity[] childActivityServerSpans = GetDistinctSpans(
+                traceActivities,
+                $"activity:{childActivityName}",
+                ActivityKind.Server);
+
+            Assert.Equal(2, childOrchestrationClientSpans.Length);
+            Assert.Equal(2, childOrchestrationServerSpans.Length);
+            Assert.Equal(2, childActivityClientSpans.Length);
+            Assert.Equal(2, childActivityServerSpans.Length);
+
+            // Each sibling sub-orchestration should attach to the same parent orchestration,
+            // but keep its own distinct client/server/activity chain below that parent.
+            Assert.All(childOrchestrationClientSpans, span => Assert.Equal(parentOrchestration.SpanId, span.ParentSpanId));
+
+            var childOrchestrationClientIds = childOrchestrationClientSpans.Select(span => span.SpanId).ToHashSet();
+            Assert.All(childOrchestrationServerSpans, span => Assert.Contains(span.ParentSpanId, childOrchestrationClientIds));
+
+            var childOrchestrationServerIds = childOrchestrationServerSpans.Select(span => span.SpanId).ToHashSet();
+            Assert.All(childActivityClientSpans, span => Assert.Contains(span.ParentSpanId, childOrchestrationServerIds));
+
+            var childActivityClientIds = childActivityClientSpans.Select(span => span.SpanId).ToHashSet();
+            Assert.All(childActivityServerSpans, span => Assert.Contains(span.ParentSpanId, childActivityClientIds));
         }
 
         [Fact]
@@ -1371,6 +1679,115 @@ namespace DurableTask.SqlServer.Tests.Integration
             Assert.Equal("staging", capturedTags["env"]);
             Assert.Equal("platform", capturedTags["team"]);
             Assert.Equal("high", capturedTags["priority"]);
+        }
+
+        void WriteCapturedActivities(IEnumerable<CapturedActivity> activities)
+        {
+            foreach (CapturedActivity activity in activities.OrderBy(a => a.StartTimeUtc))
+            {
+                this.outputHelper.WriteLine(
+                    $"{activity.TraceId}/{activity.SpanId} parent={activity.ParentSpanId} kind={activity.Kind} source={activity.SourceName} op={activity.OperationName}");
+            }
+        }
+
+        static void AssertNoMissingParents(IReadOnlyCollection<CapturedActivity> activities)
+        {
+            var knownSpanIds = activities.Select(activity => activity.SpanId).ToHashSet();
+            CapturedActivity[] missingParents = activities
+                .Where(activity => activity.ParentSpanId != default && !knownSpanIds.Contains(activity.ParentSpanId))
+                .ToArray();
+
+            Assert.True(
+                missingParents.Length == 0,
+                "Captured activities have missing parents:" + Environment.NewLine +
+                string.Join(
+                    Environment.NewLine,
+                    missingParents.Select(activity =>
+                        $"{activity.OperationName} [{activity.Kind}] span={activity.SpanId} parent={activity.ParentSpanId}")));
+        }
+
+        static CapturedActivity GetUniqueSpan(
+            IEnumerable<CapturedActivity> activities,
+            string operationName,
+            ActivityKind kind)
+        {
+            CapturedActivity[] matchingSpans = GetDistinctSpans(activities, operationName, kind);
+            Assert.Single(matchingSpans);
+            return matchingSpans[0];
+        }
+
+        static CapturedActivity[] GetDistinctSpans(
+            IEnumerable<CapturedActivity> activities,
+            string operationName,
+            ActivityKind kind)
+        {
+            return activities
+                .Where(activity => activity.OperationName == operationName && activity.Kind == kind)
+                .GroupBy(activity => activity.SpanId)
+                .Select(group => group.OrderByDescending(activity => activity.Duration).First())
+                .ToArray();
+        }
+
+        sealed class ActivityCaptureListener : IDisposable
+        {
+            readonly object sync = new object();
+            readonly HashSet<string> sourceNames;
+            readonly List<CapturedActivity> activities = new List<CapturedActivity>();
+            readonly ActivityListener listener;
+
+            public ActivityCaptureListener(params string[] sourceNames)
+            {
+                this.sourceNames = new HashSet<string>(sourceNames, StringComparer.Ordinal);
+                this.listener = new ActivityListener
+                {
+                    ShouldListenTo = source => this.sourceNames.Contains(source.Name),
+                    Sample = static (ref ActivityCreationOptions<ActivityContext> options) => ActivitySamplingResult.AllDataAndRecorded,
+                    SampleUsingParentId = static (ref ActivityCreationOptions<string> options) => ActivitySamplingResult.AllDataAndRecorded,
+                    ActivityStopped = activity =>
+                    {
+                        lock (this.sync)
+                        {
+                            this.activities.Add(CapturedActivity.From(activity));
+                        }
+                    },
+                };
+
+                ActivitySource.AddActivityListener(this.listener);
+            }
+
+            public CapturedActivity[] GetActivities(ActivityTraceId traceId)
+            {
+                lock (this.sync)
+                {
+                    return this.activities.Where(activity => activity.TraceId == traceId).ToArray();
+                }
+            }
+
+            public void Dispose() => this.listener.Dispose();
+        }
+
+        sealed record CapturedActivity(
+            string SourceName,
+            string OperationName,
+            ActivityKind Kind,
+            ActivityTraceId TraceId,
+            ActivitySpanId SpanId,
+            ActivitySpanId ParentSpanId,
+            DateTime StartTimeUtc,
+            TimeSpan Duration)
+        {
+            public static CapturedActivity From(Activity activity)
+            {
+                return new CapturedActivity(
+                    activity.Source.Name,
+                    activity.OperationName,
+                    activity.Kind,
+                    activity.TraceId,
+                    activity.SpanId,
+                    activity.ParentSpanId,
+                    activity.StartTimeUtc,
+                    activity.Duration);
+            }
         }
     }
 }

--- a/test/DurableTask.SqlServer.Tests/Integration/Orchestrations.cs
+++ b/test/DurableTask.SqlServer.Tests/Integration/Orchestrations.cs
@@ -809,8 +809,9 @@ namespace DurableTask.SqlServer.Tests.Integration
             // The test schedules exactly one sub-orchestration, so there must be exactly one
             // matching client span. Asserting uniqueness (instead of LastOrDefault) makes this
             // regression fail loudly if a future change ever causes a duplicate emission.
-            Activity subOrchestratorClientSpan = Assert.Single(exportedItems.Where(
-                span => span.OperationName == $"orchestration:{subOrchestrationName}" && span.Kind == ActivityKind.Client));
+            Activity subOrchestratorClientSpan = Assert.Single(
+                exportedItems,
+                span => span.OperationName == $"orchestration:{subOrchestrationName}" && span.Kind == ActivityKind.Client);
             Assert.NotNull(subOrchestratorClientSpan);
 
             // The sub-orchestration execution span hangs off the sub-orchestration client span,
@@ -832,8 +833,9 @@ namespace DurableTask.SqlServer.Tests.Integration
 
             // Same uniqueness rationale as the sub-orchestration client span above: the test
             // schedules a single activity, so any duplicate client span would be a regression.
-            Activity activityClientSpan = Assert.Single(exportedItems.Where(
-                span => span.OperationName == $"activity:{activityName}" && span.Kind == ActivityKind.Client));
+            Activity activityClientSpan = Assert.Single(
+                exportedItems,
+                span => span.OperationName == $"activity:{activityName}" && span.Kind == ActivityKind.Client);
             Assert.NotNull(activityClientSpan);
 
             // This is the key shape for selling the trace fix: an activity scheduled by a

--- a/test/DurableTask.SqlServer.Tests/Integration/Orchestrations.cs
+++ b/test/DurableTask.SqlServer.Tests/Integration/Orchestrations.cs
@@ -806,8 +806,11 @@ namespace DurableTask.SqlServer.Tests.Integration
             Assert.True(subOrchestratorSpan.Duration > delay, $"Unexpected duration: {subOrchestratorSpan.Duration}");
             Assert.True(subOrchestratorSpan.Duration < delay * 2, $"Unexpected duration: {subOrchestratorSpan.Duration}");
 
-            Activity subOrchestratorClientSpan = exportedItems.LastOrDefault(
-                span => span.OperationName == $"orchestration:{subOrchestrationName}" && span.Kind == ActivityKind.Client);
+            // The test schedules exactly one sub-orchestration, so there must be exactly one
+            // matching client span. Asserting uniqueness (instead of LastOrDefault) makes this
+            // regression fail loudly if a future change ever causes a duplicate emission.
+            Activity subOrchestratorClientSpan = Assert.Single(exportedItems.Where(
+                span => span.OperationName == $"orchestration:{subOrchestrationName}" && span.Kind == ActivityKind.Client));
             Assert.NotNull(subOrchestratorClientSpan);
 
             // The sub-orchestration execution span hangs off the sub-orchestration client span,
@@ -827,8 +830,10 @@ namespace DurableTask.SqlServer.Tests.Integration
             Assert.True(activitySpan.Duration > delay);
             Assert.True(activitySpan.Duration < delay * 2);
 
-            Activity activityClientSpan = exportedItems.LastOrDefault(
-                span => span.OperationName == $"activity:{activityName}" && span.Kind == ActivityKind.Client);
+            // Same uniqueness rationale as the sub-orchestration client span above: the test
+            // schedules a single activity, so any duplicate client span would be a regression.
+            Activity activityClientSpan = Assert.Single(exportedItems.Where(
+                span => span.OperationName == $"activity:{activityName}" && span.Kind == ActivityKind.Client));
             Assert.NotNull(activityClientSpan);
 
             // This is the key shape for selling the trace fix: an activity scheduled by a

--- a/test/DurableTask.SqlServer.Tests/Unit/SqlUtilsTraceContextTests.cs
+++ b/test/DurableTask.SqlServer.Tests/Unit/SqlUtilsTraceContextTests.cs
@@ -1,0 +1,158 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+namespace DurableTask.SqlServer.Tests.Unit
+{
+    using System;
+    using System.Data;
+    using System.Data.SqlTypes;
+    using DurableTask.Core;
+    using DurableTask.Core.History;
+    using DurableTask.Core.Tracing;
+    using Xunit;
+
+    public class SqlUtilsTraceContextTests
+    {
+        [Fact]
+        public void GetTraceContext_RoundTripsExtendedTraceContextFields()
+        {
+            DateTime timestamp = new DateTime(2026, 04, 15, 22, 30, 00, DateTimeKind.Utc);
+            var traceContext = new DistributedTraceContext(
+                traceParent: "00-0123456789abcdef0123456789abcdef-0123456789abcdef-01",
+                traceState: "vendor=value")
+            {
+                Id = "00-0123456789abcdef0123456789abcdef-fedcba9876543210-01",
+                SpanId = "fedcba9876543210",
+            };
+
+            var startedEvent = new ExecutionStartedEvent(-1, input: null)
+            {
+                Name = "TestOrchestration",
+                OrchestrationInstance = new OrchestrationInstance
+                {
+                    InstanceId = "instance",
+                    ExecutionId = "execution",
+                },
+                ParentTraceContext = traceContext,
+                Timestamp = timestamp,
+            };
+
+            SqlString serialized = SqlUtils.GetTraceContext(startedEvent);
+            Assert.False(serialized.IsNull);
+            Assert.Equal(
+                "00-0123456789abcdef0123456789abcdef-0123456789abcdef-01\n@tracestate=vendor=value\n@id=00-0123456789abcdef0123456789abcdef-fedcba9876543210-01\n@spanid=fedcba9876543210",
+                serialized.Value);
+
+            using var reader = CreateExecutionStartedReader(serialized.Value, timestamp);
+            Assert.True(reader.Read());
+
+            var roundTrippedEvent = Assert.IsType<ExecutionStartedEvent>(reader.GetHistoryEvent());
+            Assert.NotNull(roundTrippedEvent.ParentTraceContext);
+            Assert.Equal(traceContext.TraceParent, roundTrippedEvent.ParentTraceContext.TraceParent);
+            Assert.Equal(traceContext.TraceState, roundTrippedEvent.ParentTraceContext.TraceState);
+            Assert.Equal(traceContext.Id, roundTrippedEvent.ParentTraceContext.Id);
+            Assert.Equal(traceContext.SpanId, roundTrippedEvent.ParentTraceContext.SpanId);
+            Assert.Equal(new DateTimeOffset(timestamp), roundTrippedEvent.ParentTraceContext.ActivityStartTime);
+        }
+
+        [Fact]
+        public void GetHistoryEvent_PreservesLegacyTraceContextFormat()
+        {
+            DateTime timestamp = new DateTime(2026, 04, 15, 22, 45, 00, DateTimeKind.Utc);
+            const string traceParent = "00-0123456789abcdef0123456789abcdef-0123456789abcdef-01";
+            const string traceState = "rojo=00f067aa0ba902b7,congo=t61rcWkgMzE";
+
+            using var reader = CreateExecutionStartedReader($"{traceParent}\n{traceState}", timestamp);
+            Assert.True(reader.Read());
+
+            var roundTrippedEvent = Assert.IsType<ExecutionStartedEvent>(reader.GetHistoryEvent());
+            Assert.NotNull(roundTrippedEvent.ParentTraceContext);
+            Assert.Equal(traceParent, roundTrippedEvent.ParentTraceContext.TraceParent);
+            Assert.Equal(traceState, roundTrippedEvent.ParentTraceContext.TraceState);
+            Assert.Null(roundTrippedEvent.ParentTraceContext.Id);
+            Assert.Null(roundTrippedEvent.ParentTraceContext.SpanId);
+            Assert.Equal(new DateTimeOffset(timestamp), roundTrippedEvent.ParentTraceContext.ActivityStartTime);
+        }
+
+        [Fact]
+        public void GetHistoryEvent_RoundTripsSubOrchestrationClientSpanId()
+        {
+            DateTime timestamp = new DateTime(2026, 04, 15, 23, 00, 00, DateTimeKind.Utc);
+            const string clientSpanId = "fedcba9876543210";
+
+            var createdEvent = new SubOrchestrationInstanceCreatedEvent(eventId: 7)
+            {
+                ClientSpanId = clientSpanId,
+                Input = "{}",
+                Name = "MySubOrchestration",
+                Timestamp = timestamp,
+            };
+
+            SqlString serialized = SqlUtils.GetTraceContext(createdEvent);
+            Assert.False(serialized.IsNull);
+            Assert.Equal("@clientspanid=fedcba9876543210", serialized.Value);
+
+            using var reader = CreateSubOrchestrationCreatedReader(serialized.Value, timestamp);
+            Assert.True(reader.Read());
+
+            var roundTrippedEvent = Assert.IsType<SubOrchestrationInstanceCreatedEvent>(reader.GetHistoryEvent());
+            Assert.Equal(clientSpanId, roundTrippedEvent.ClientSpanId);
+        }
+
+        static DataTableReader CreateExecutionStartedReader(string traceContext, DateTime timestamp)
+        {
+            var table = new DataTable();
+            table.Columns.Add("EventType", typeof(string));
+            table.Columns.Add("TaskID", typeof(int));
+            table.Columns.Add("PayloadText", typeof(string));
+            table.Columns.Add("Name", typeof(string));
+            table.Columns.Add("InstanceID", typeof(string));
+            table.Columns.Add("ExecutionID", typeof(string));
+            table.Columns.Add("Tags", typeof(string));
+            table.Columns.Add("Version", typeof(string));
+            table.Columns.Add("TraceContext", typeof(string));
+            table.Columns.Add("ParentInstanceID", typeof(string));
+            table.Columns.Add("Timestamp", typeof(DateTime));
+            table.Columns.Add("RuntimeStatus", typeof(string));
+
+            DataRow row = table.NewRow();
+            row["EventType"] = EventType.ExecutionStarted.ToString();
+            row["TaskID"] = -1;
+            row["PayloadText"] = DBNull.Value;
+            row["Name"] = "TestOrchestration";
+            row["InstanceID"] = "instance";
+            row["ExecutionID"] = "execution";
+            row["Tags"] = DBNull.Value;
+            row["Version"] = DBNull.Value;
+            row["TraceContext"] = traceContext;
+            row["ParentInstanceID"] = DBNull.Value;
+            row["Timestamp"] = timestamp;
+            row["RuntimeStatus"] = OrchestrationStatus.Running.ToString();
+            table.Rows.Add(row);
+
+            return table.CreateDataReader();
+        }
+
+        static DataTableReader CreateSubOrchestrationCreatedReader(string traceContext, DateTime timestamp)
+        {
+            var table = new DataTable();
+            table.Columns.Add("EventType", typeof(string));
+            table.Columns.Add("TaskID", typeof(int));
+            table.Columns.Add("PayloadText", typeof(string));
+            table.Columns.Add("Name", typeof(string));
+            table.Columns.Add("TraceContext", typeof(string));
+            table.Columns.Add("Timestamp", typeof(DateTime));
+
+            DataRow row = table.NewRow();
+            row["EventType"] = EventType.SubOrchestrationInstanceCreated.ToString();
+            row["TaskID"] = 7;
+            row["PayloadText"] = "{}";
+            row["Name"] = "MySubOrchestration";
+            row["TraceContext"] = traceContext;
+            row["Timestamp"] = timestamp;
+            table.Rows.Add(row);
+
+            return table.CreateDataReader();
+        }
+    }
+}

--- a/test/DurableTask.SqlServer.Tests/Unit/SqlUtilsTraceContextTests.cs
+++ b/test/DurableTask.SqlServer.Tests/Unit/SqlUtilsTraceContextTests.cs
@@ -1,6 +1,6 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
-
+#nullable enable
 namespace DurableTask.SqlServer.Tests.Unit
 {
     using System;
@@ -13,6 +13,18 @@ namespace DurableTask.SqlServer.Tests.Unit
 
     public class SqlUtilsTraceContextTests
     {
+        // The legacy reader on `main` uses this exact split. Tests that claim to exercise
+        // backwards-compat must mirror it byte-for-byte, otherwise they prove nothing.
+        static readonly char[] LegacyTraceContextSeparators = new char[] { '\n' };
+
+        static (string? traceParent, string? traceState) SimulateLegacyReader(string payload)
+        {
+            string[] parts = payload.Split(LegacyTraceContextSeparators, count: 2, StringSplitOptions.RemoveEmptyEntries);
+            string? traceParent = parts.Length > 0 ? parts[0] : null;
+            string? traceState = parts.Length > 1 ? parts[1] : null;
+            return (traceParent, traceState);
+        }
+
         [Fact]
         public void GetTraceContext_RoundTripsExtendedTraceContextFields()
         {
@@ -39,11 +51,16 @@ namespace DurableTask.SqlServer.Tests.Unit
 
             SqlString serialized = SqlUtils.GetTraceContext(startedEvent);
             Assert.False(serialized.IsNull);
-            // Wire format is rolling-upgrade safe: line 2 is RAW tracestate (no @tracestate= prefix)
-            // so older workers reading new rows continue to extract tracestate correctly. Newer
-            // @-prefixed fields go on lines 3+ and are ignored by older readers.
+            // Wire format:
+            //   line 1: traceparent
+            //   line 2: tracestate, with our "durabletask-mssql=id:...;span:..." vendor key
+            //           prepended (W3C tracestate is comma-separated key=value entries).
+            // The legacy reader will see line 2 as the tracestate string verbatim and propagate
+            // it through OpenTelemetry; W3C-compliant systems preserve unknown vendor keys.
             Assert.Equal(
-                "00-0123456789abcdef0123456789abcdef-0123456789abcdef-01\nvendor=value\n@id=00-0123456789abcdef0123456789abcdef-fedcba9876543210-01\n@spanid=fedcba9876543210",
+                "00-0123456789abcdef0123456789abcdef-0123456789abcdef-01\n" +
+                "durabletask-mssql=id:00-0123456789abcdef0123456789abcdef-fedcba9876543210-01;span:fedcba9876543210," +
+                "vendor=value",
                 serialized.Value);
 
             using var reader = CreateExecutionStartedReader(serialized.Value, timestamp);
@@ -58,14 +75,21 @@ namespace DurableTask.SqlServer.Tests.Unit
             Assert.Equal(new DateTimeOffset(timestamp), roundTrippedEvent.ParentTraceContext.ActivityStartTime);
         }
 
-        // Rolling-upgrade safety: a worker running the old code (which only knows about
-        // line 1 = traceparent and line 2 = raw tracestate) must still extract the correct
-        // traceparent and tracestate when it reads a row written by a worker running the
-        // new code. The new code adds @id= / @spanid= on lines 3+, but those lines must NOT
-        // contaminate the tracestate slot on line 2. This test asserts the wire-format
-        // contract that protects that invariant.
+        // ROLLING-UPGRADE SAFETY — case 1: tracestate + Id/SpanId
+        // Simulates what the pre-PR reader on `main` (Split('\n', 2, RemoveEmptyEntries)) sees
+        // when a new worker writes the trace context for an event whose DistributedTraceContext
+        // has both Id/SpanId and a user tracestate.
+        //
+        // The legacy reader must produce:
+        //   - A clean W3C traceparent for parts[0] (no extra characters).
+        //   - A single-line W3C-valid tracestate for parts[1] (no embedded newlines), so the
+        //     value can flow into Activity.TraceStateString and propagate downstream unchanged.
+        //
+        // Our durabletask-mssql vendor key is allowed to appear inside parts[1] — that is the
+        // whole point of using a W3C vendor key: legacy workers preserve unknown vendor keys
+        // and propagate them downstream where newer workers can decode them.
         [Fact]
-        public void GetTraceContext_NewWriterPlacesRawTraceStateOnLineTwo_ForOldReaderCompat()
+        public void GetTraceContext_LegacyReaderSeesCleanTraceParentAndTraceState_TraceStatePlusIds()
         {
             var traceContext = new DistributedTraceContext(
                 traceParent: "00-0123456789abcdef0123456789abcdef-0123456789abcdef-01",
@@ -87,20 +111,31 @@ namespace DurableTask.SqlServer.Tests.Unit
             };
 
             string payload = SqlUtils.GetTraceContext(startedEvent).Value;
-            string[] parts = payload.Split('\n');
+            (string? legacyTraceParent, string? legacyTraceState) = SimulateLegacyReader(payload);
 
-            // Simulate the legacy reader: parts[0] = traceparent, parts[1] = tracestate (raw).
-            Assert.Equal("00-0123456789abcdef0123456789abcdef-0123456789abcdef-01", parts[0]);
-            Assert.Equal("vendor=value", parts[1]);
-            // The legacy reader stops at parts[1]; everything beyond is ignored.
-            Assert.DoesNotContain(parts[1], "@");
+            // Legacy reader receives a clean traceparent...
+            Assert.Equal(
+                "00-0123456789abcdef0123456789abcdef-0123456789abcdef-01",
+                legacyTraceParent);
+
+            // ...and a single-line tracestate value with no embedded newlines.
+            Assert.NotNull(legacyTraceState);
+            Assert.DoesNotContain('\n', legacyTraceState!);
+
+            // The tracestate carries our vendor key (legacy workers preserve it) and the
+            // user-supplied vendor entry.
+            Assert.Contains("durabletask-mssql=id:", legacyTraceState!);
+            Assert.Contains("vendor=value", legacyTraceState!);
         }
 
-        // Rolling-upgrade safety for the empty-tracestate case: when the new writer has no
-        // tracestate but does have Id/SpanId, line 2 must still exist as an empty placeholder
-        // so the @-prefixed lines that follow never land in the tracestate slot.
+        // ROLLING-UPGRADE SAFETY — case 2: only Id/SpanId, no user tracestate.
+        // Without a user tracestate, line 2 must still be a single line containing only the
+        // vendor key. An older reader assigns that whole line to TraceState and propagates it.
+        // CRITICALLY: line 2 must not contain embedded newlines or be missing entirely —
+        // either failure mode would have leaked '@id=' garbage into TraceState in the prior
+        // attempt at this PR.
         [Fact]
-        public void GetTraceContext_NewWriterEmitsEmptyTraceStateLine_WhenOnlyIdAndSpanIdSet()
+        public void GetTraceContext_LegacyReaderSeesCleanTraceState_IdsOnly()
         {
             var traceContext = new DistributedTraceContext(
                 traceParent: "00-0123456789abcdef0123456789abcdef-0123456789abcdef-01")
@@ -121,16 +156,45 @@ namespace DurableTask.SqlServer.Tests.Unit
             };
 
             string payload = SqlUtils.GetTraceContext(startedEvent).Value;
-            string[] parts = payload.Split('\n');
+            (string? legacyTraceParent, string? legacyTraceState) = SimulateLegacyReader(payload);
 
-            Assert.Equal("00-0123456789abcdef0123456789abcdef-0123456789abcdef-01", parts[0]);
-            // Line 2 is an empty placeholder. An older reader will set TraceState = string.Empty,
-            // which is functionally indistinguishable from "no tracestate". Without this empty
-            // placeholder, the older reader would see "@id=..." on line 2 and store that bogus
-            // value as the tracestate.
-            Assert.Equal(string.Empty, parts[1]);
-            Assert.StartsWith("@id=", parts[2]);
-            Assert.StartsWith("@spanid=", parts[3]);
+            Assert.Equal(
+                "00-0123456789abcdef0123456789abcdef-0123456789abcdef-01",
+                legacyTraceParent);
+
+            Assert.NotNull(legacyTraceState);
+            Assert.DoesNotContain('\n', legacyTraceState!);
+            Assert.Equal(
+                "durabletask-mssql=id:00-0123456789abcdef0123456789abcdef-fedcba9876543210-01;span:fedcba9876543210",
+                legacyTraceState);
+        }
+
+        // ROLLING-UPGRADE SAFETY — case 3: legacy payload format (no Id/SpanId).
+        // A worker on the new code writing a trace context that has no Id/SpanId emits the
+        // exact same bytes as the pre-PR code. There is no compatibility cliff for these rows.
+        [Fact]
+        public void GetTraceContext_TraceStateOnlyPayload_MatchesLegacyByteForByte()
+        {
+            var traceContext = new DistributedTraceContext(
+                traceParent: "00-0123456789abcdef0123456789abcdef-0123456789abcdef-01",
+                traceState: "vendor=value");
+
+            var startedEvent = new ExecutionStartedEvent(-1, input: null)
+            {
+                Name = "TestOrchestration",
+                OrchestrationInstance = new OrchestrationInstance
+                {
+                    InstanceId = "instance",
+                    ExecutionId = "execution",
+                },
+                ParentTraceContext = traceContext,
+            };
+
+            string payload = SqlUtils.GetTraceContext(startedEvent).Value;
+
+            Assert.Equal(
+                "00-0123456789abcdef0123456789abcdef-0123456789abcdef-01\nvendor=value",
+                payload);
         }
 
         [Fact]
@@ -168,12 +232,13 @@ namespace DurableTask.SqlServer.Tests.Unit
 
             SqlString serialized = SqlUtils.GetTraceContext(createdEvent);
             Assert.False(serialized.IsNull);
-            // Wire format is rolling-upgrade safe:
-            //   line 1: empty (no traceparent for a sub-orch-only payload)
-            //   line 2: empty placeholder (reserved tracestate slot — older readers see "",
-            //           not "@clientspanid=", so they don't misinterpret it as tracestate)
-            //   line 3: @clientspanid=...
-            Assert.Equal("\n\n@clientspanid=fedcba9876543210", serialized.Value);
+            // Sub-orchestration rows had no TraceContext column populated on `main`, so the
+            // legacy reader never inspects this column for SubOrchestrationInstanceCreated
+            // events. The wire format is therefore optimized for the new reader and uses the
+            // same vendor-key encoding so that all readers share a single parser.
+            Assert.Equal(
+                "durabletask-mssql=client:fedcba9876543210",
+                serialized.Value);
 
             using var reader = CreateSubOrchestrationCreatedReader(serialized.Value, timestamp);
             Assert.True(reader.Read());
@@ -182,24 +247,81 @@ namespace DurableTask.SqlServer.Tests.Unit
             Assert.Equal(clientSpanId, roundTrippedEvent.ClientSpanId);
         }
 
-        // Older histories may still contain the legacy single-line "@clientspanid=..." payload
-        // that was written before line 1 was reserved for traceparent. This regression makes sure
-        // the reader keeps parsing such rows correctly, so an upgrade does not break running
-        // orchestrations whose history was persisted by an older build.
+        // New-reader-on-new-row: when both a user tracestate and our vendor key are present,
+        // the parser must split them cleanly so user tracestate flows through unchanged and
+        // Id/SpanId are recovered from the vendor key.
         [Fact]
-        public void GetHistoryEvent_ParsesLegacyClientSpanIdPayloadWithoutLeadingNewline()
+        public void GetHistoryEvent_NewReader_SeparatesVendorKeyFromUserTraceState()
         {
-            DateTime timestamp = new DateTime(2026, 04, 15, 23, 00, 00, DateTimeKind.Utc);
-            const string clientSpanId = "abcdef0123456789";
+            DateTime timestamp = new DateTime(2026, 04, 15, 23, 30, 00, DateTimeKind.Utc);
+            string payload =
+                "00-0123456789abcdef0123456789abcdef-0123456789abcdef-01\n" +
+                "durabletask-mssql=id:00-0123456789abcdef0123456789abcdef-fedcba9876543210-01;span:fedcba9876543210," +
+                "vendor=value,other=thing";
 
-            // Legacy on-the-wire format: the @clientspanid= prefix sits on line 1.
-            string legacyPayload = "@clientspanid=" + clientSpanId;
-
-            using var reader = CreateSubOrchestrationCreatedReader(legacyPayload, timestamp);
+            using var reader = CreateExecutionStartedReader(payload, timestamp);
             Assert.True(reader.Read());
 
-            var roundTrippedEvent = Assert.IsType<SubOrchestrationInstanceCreatedEvent>(reader.GetHistoryEvent());
-            Assert.Equal(clientSpanId, roundTrippedEvent.ClientSpanId);
+            var roundTrippedEvent = Assert.IsType<ExecutionStartedEvent>(reader.GetHistoryEvent());
+            Assert.NotNull(roundTrippedEvent.ParentTraceContext);
+
+            Assert.Equal(
+                "00-0123456789abcdef0123456789abcdef-0123456789abcdef-01",
+                roundTrippedEvent.ParentTraceContext.TraceParent);
+            Assert.Equal(
+                "00-0123456789abcdef0123456789abcdef-fedcba9876543210-01",
+                roundTrippedEvent.ParentTraceContext.Id);
+            Assert.Equal(
+                "fedcba9876543210",
+                roundTrippedEvent.ParentTraceContext.SpanId);
+
+            // The vendor key has been stripped, but every user-supplied tracestate entry is
+            // preserved in original order.
+            Assert.Equal("vendor=value,other=thing", roundTrippedEvent.ParentTraceContext.TraceState);
+        }
+
+        // The user's tracestate may already contain entries that the legacy code propagated
+        // through unmodified. A row where someone (any worker, old or new) has prepended our
+        // vendor key must round-trip cleanly even if user entries appear before or after.
+        [Theory]
+        [InlineData(
+            "durabletask-mssql=id:abc;span:def",
+            "",
+            "abc",
+            "def")]
+        [InlineData(
+            "durabletask-mssql=id:abc;span:def,user=val",
+            "user=val",
+            "abc",
+            "def")]
+        [InlineData(
+            "user=val,durabletask-mssql=id:abc;span:def",
+            "user=val",
+            "abc",
+            "def")]
+        [InlineData(
+            "user=val, durabletask-mssql=id:abc;span:def ,other=thing",
+            "user=val,other=thing",
+            "abc",
+            "def")]
+        public void GetHistoryEvent_NewReader_ExtractsVendorKeyRegardlessOfPosition(
+            string tracestate,
+            string expectedUserTraceState,
+            string expectedId,
+            string expectedSpanId)
+        {
+            DateTime timestamp = new DateTime(2026, 04, 15, 23, 45, 00, DateTimeKind.Utc);
+            string payload = $"00-0123456789abcdef0123456789abcdef-0123456789abcdef-01\n{tracestate}";
+
+            using var reader = CreateExecutionStartedReader(payload, timestamp);
+            Assert.True(reader.Read());
+
+            var ev = Assert.IsType<ExecutionStartedEvent>(reader.GetHistoryEvent());
+            Assert.Equal(expectedId, ev.ParentTraceContext.Id);
+            Assert.Equal(expectedSpanId, ev.ParentTraceContext.SpanId);
+            Assert.Equal(
+                string.IsNullOrEmpty(expectedUserTraceState) ? null : expectedUserTraceState,
+                ev.ParentTraceContext.TraceState);
         }
 
         static DataTableReader CreateExecutionStartedReader(string traceContext, DateTime timestamp)

--- a/test/DurableTask.SqlServer.Tests/Unit/SqlUtilsTraceContextTests.cs
+++ b/test/DurableTask.SqlServer.Tests/Unit/SqlUtilsTraceContextTests.cs
@@ -202,7 +202,7 @@ namespace DurableTask.SqlServer.Tests.Unit
         {
             DateTime timestamp = new DateTime(2026, 04, 15, 22, 45, 00, DateTimeKind.Utc);
             const string traceParent = "00-0123456789abcdef0123456789abcdef-0123456789abcdef-01";
-            const string traceState = "rojo=00f067aa0ba902b7,congo=t61rcWkgMzE";
+            const string traceState = "rojo=00f067aa0ba902b7, congo=t61rcWkgMzE";
 
             using var reader = CreateExecutionStartedReader($"{traceParent}\n{traceState}", timestamp);
             Assert.True(reader.Read());
@@ -232,10 +232,10 @@ namespace DurableTask.SqlServer.Tests.Unit
 
             SqlString serialized = SqlUtils.GetTraceContext(createdEvent);
             Assert.False(serialized.IsNull);
-            // Sub-orchestration rows had no TraceContext column populated on `main`, so the
-            // legacy reader never inspects this column for SubOrchestrationInstanceCreated
-            // events. The wire format is therefore optimized for the new reader and uses the
-            // same vendor-key encoding so that all readers share a single parser.
+            // The SQL history row keeps EventType=SubOrchestrationInstanceCreated next to this
+            // TraceContext value. Legacy readers dispatch on that event type and never call their
+            // DistributedTraceContext parser for this row, so they do not treat this single-line
+            // vendor key as a traceparent.
             Assert.Equal(
                 "durabletask-mssql=client:fedcba9876543210",
                 serialized.Value);
@@ -300,8 +300,8 @@ namespace DurableTask.SqlServer.Tests.Unit
             "abc",
             "def")]
         [InlineData(
-            "user=val, durabletask-mssql=id:abc;span:def ,other=thing",
-            "user=val,other=thing",
+            "user=val, durabletask-mssql=id:abc;span:def, other=thing",
+            "user=val, other=thing",
             "abc",
             "def")]
         public void GetHistoryEvent_NewReader_ExtractsVendorKeyRegardlessOfPosition(
@@ -317,6 +317,7 @@ namespace DurableTask.SqlServer.Tests.Unit
             Assert.True(reader.Read());
 
             var ev = Assert.IsType<ExecutionStartedEvent>(reader.GetHistoryEvent());
+            Assert.NotNull(ev.ParentTraceContext);
             Assert.Equal(expectedId, ev.ParentTraceContext.Id);
             Assert.Equal(expectedSpanId, ev.ParentTraceContext.SpanId);
             Assert.Equal(

--- a/test/DurableTask.SqlServer.Tests/Unit/SqlUtilsTraceContextTests.cs
+++ b/test/DurableTask.SqlServer.Tests/Unit/SqlUtilsTraceContextTests.cs
@@ -39,8 +39,11 @@ namespace DurableTask.SqlServer.Tests.Unit
 
             SqlString serialized = SqlUtils.GetTraceContext(startedEvent);
             Assert.False(serialized.IsNull);
+            // Wire format is rolling-upgrade safe: line 2 is RAW tracestate (no @tracestate= prefix)
+            // so older workers reading new rows continue to extract tracestate correctly. Newer
+            // @-prefixed fields go on lines 3+ and are ignored by older readers.
             Assert.Equal(
-                "00-0123456789abcdef0123456789abcdef-0123456789abcdef-01\n@tracestate=vendor=value\n@id=00-0123456789abcdef0123456789abcdef-fedcba9876543210-01\n@spanid=fedcba9876543210",
+                "00-0123456789abcdef0123456789abcdef-0123456789abcdef-01\nvendor=value\n@id=00-0123456789abcdef0123456789abcdef-fedcba9876543210-01\n@spanid=fedcba9876543210",
                 serialized.Value);
 
             using var reader = CreateExecutionStartedReader(serialized.Value, timestamp);
@@ -53,6 +56,81 @@ namespace DurableTask.SqlServer.Tests.Unit
             Assert.Equal(traceContext.Id, roundTrippedEvent.ParentTraceContext.Id);
             Assert.Equal(traceContext.SpanId, roundTrippedEvent.ParentTraceContext.SpanId);
             Assert.Equal(new DateTimeOffset(timestamp), roundTrippedEvent.ParentTraceContext.ActivityStartTime);
+        }
+
+        // Rolling-upgrade safety: a worker running the old code (which only knows about
+        // line 1 = traceparent and line 2 = raw tracestate) must still extract the correct
+        // traceparent and tracestate when it reads a row written by a worker running the
+        // new code. The new code adds @id= / @spanid= on lines 3+, but those lines must NOT
+        // contaminate the tracestate slot on line 2. This test asserts the wire-format
+        // contract that protects that invariant.
+        [Fact]
+        public void GetTraceContext_NewWriterPlacesRawTraceStateOnLineTwo_ForOldReaderCompat()
+        {
+            var traceContext = new DistributedTraceContext(
+                traceParent: "00-0123456789abcdef0123456789abcdef-0123456789abcdef-01",
+                traceState: "vendor=value")
+            {
+                Id = "00-0123456789abcdef0123456789abcdef-fedcba9876543210-01",
+                SpanId = "fedcba9876543210",
+            };
+
+            var startedEvent = new ExecutionStartedEvent(-1, input: null)
+            {
+                Name = "TestOrchestration",
+                OrchestrationInstance = new OrchestrationInstance
+                {
+                    InstanceId = "instance",
+                    ExecutionId = "execution",
+                },
+                ParentTraceContext = traceContext,
+            };
+
+            string payload = SqlUtils.GetTraceContext(startedEvent).Value;
+            string[] parts = payload.Split('\n');
+
+            // Simulate the legacy reader: parts[0] = traceparent, parts[1] = tracestate (raw).
+            Assert.Equal("00-0123456789abcdef0123456789abcdef-0123456789abcdef-01", parts[0]);
+            Assert.Equal("vendor=value", parts[1]);
+            // The legacy reader stops at parts[1]; everything beyond is ignored.
+            Assert.DoesNotContain(parts[1], "@");
+        }
+
+        // Rolling-upgrade safety for the empty-tracestate case: when the new writer has no
+        // tracestate but does have Id/SpanId, line 2 must still exist as an empty placeholder
+        // so the @-prefixed lines that follow never land in the tracestate slot.
+        [Fact]
+        public void GetTraceContext_NewWriterEmitsEmptyTraceStateLine_WhenOnlyIdAndSpanIdSet()
+        {
+            var traceContext = new DistributedTraceContext(
+                traceParent: "00-0123456789abcdef0123456789abcdef-0123456789abcdef-01")
+            {
+                Id = "00-0123456789abcdef0123456789abcdef-fedcba9876543210-01",
+                SpanId = "fedcba9876543210",
+            };
+
+            var startedEvent = new ExecutionStartedEvent(-1, input: null)
+            {
+                Name = "TestOrchestration",
+                OrchestrationInstance = new OrchestrationInstance
+                {
+                    InstanceId = "instance",
+                    ExecutionId = "execution",
+                },
+                ParentTraceContext = traceContext,
+            };
+
+            string payload = SqlUtils.GetTraceContext(startedEvent).Value;
+            string[] parts = payload.Split('\n');
+
+            Assert.Equal("00-0123456789abcdef0123456789abcdef-0123456789abcdef-01", parts[0]);
+            // Line 2 is an empty placeholder. An older reader will set TraceState = string.Empty,
+            // which is functionally indistinguishable from "no tracestate". Without this empty
+            // placeholder, the older reader would see "@id=..." on line 2 and store that bogus
+            // value as the tracestate.
+            Assert.Equal(string.Empty, parts[1]);
+            Assert.StartsWith("@id=", parts[2]);
+            Assert.StartsWith("@spanid=", parts[3]);
         }
 
         [Fact]
@@ -90,9 +168,12 @@ namespace DurableTask.SqlServer.Tests.Unit
 
             SqlString serialized = SqlUtils.GetTraceContext(createdEvent);
             Assert.False(serialized.IsNull);
-            // Line 1 is reserved for traceparent (empty for sub-orchestration payloads)
-            // so all TraceContext payloads share the same parsing contract.
-            Assert.Equal("\n@clientspanid=fedcba9876543210", serialized.Value);
+            // Wire format is rolling-upgrade safe:
+            //   line 1: empty (no traceparent for a sub-orch-only payload)
+            //   line 2: empty placeholder (reserved tracestate slot — older readers see "",
+            //           not "@clientspanid=", so they don't misinterpret it as tracestate)
+            //   line 3: @clientspanid=...
+            Assert.Equal("\n\n@clientspanid=fedcba9876543210", serialized.Value);
 
             using var reader = CreateSubOrchestrationCreatedReader(serialized.Value, timestamp);
             Assert.True(reader.Read());

--- a/test/DurableTask.SqlServer.Tests/Unit/SqlUtilsTraceContextTests.cs
+++ b/test/DurableTask.SqlServer.Tests/Unit/SqlUtilsTraceContextTests.cs
@@ -90,9 +90,31 @@ namespace DurableTask.SqlServer.Tests.Unit
 
             SqlString serialized = SqlUtils.GetTraceContext(createdEvent);
             Assert.False(serialized.IsNull);
-            Assert.Equal("@clientspanid=fedcba9876543210", serialized.Value);
+            // Line 1 is reserved for traceparent (empty for sub-orchestration payloads)
+            // so all TraceContext payloads share the same parsing contract.
+            Assert.Equal("\n@clientspanid=fedcba9876543210", serialized.Value);
 
             using var reader = CreateSubOrchestrationCreatedReader(serialized.Value, timestamp);
+            Assert.True(reader.Read());
+
+            var roundTrippedEvent = Assert.IsType<SubOrchestrationInstanceCreatedEvent>(reader.GetHistoryEvent());
+            Assert.Equal(clientSpanId, roundTrippedEvent.ClientSpanId);
+        }
+
+        // Older histories may still contain the legacy single-line "@clientspanid=..." payload
+        // that was written before line 1 was reserved for traceparent. This regression makes sure
+        // the reader keeps parsing such rows correctly, so an upgrade does not break running
+        // orchestrations whose history was persisted by an older build.
+        [Fact]
+        public void GetHistoryEvent_ParsesLegacyClientSpanIdPayloadWithoutLeadingNewline()
+        {
+            DateTime timestamp = new DateTime(2026, 04, 15, 23, 00, 00, DateTimeKind.Utc);
+            const string clientSpanId = "abcdef0123456789";
+
+            // Legacy on-the-wire format: the @clientspanid= prefix sits on line 1.
+            string legacyPayload = "@clientspanid=" + clientSpanId;
+
+            using var reader = CreateSubOrchestrationCreatedReader(legacyPayload, timestamp);
             Assert.True(reader.Read());
 
             var roundTrippedEvent = Assert.IsType<SubOrchestrationInstanceCreatedEvent>(reader.GetHistoryEvent());


### PR DESCRIPTION
## Summary
- preserve orchestration replay span identity when SQL round-trips `DistributedTraceContext`
- preserve sub-orchestration `ClientSpanId` so parent-side client spans can be recreated with the same span ID the child execution points to
- add regression tests for continuation stability and listener-observed parent/child hierarchy

## Why this is needed
`DurableTask.SqlServer` flattens history-event trace data into the `TraceContext` SQL column instead of serializing the full data contract graph. Before this change, that projection only preserved W3C `traceparent` and optional `tracestate`.

That was not enough for the Activity-based tracing contract in `DurableTask.Core`:
- `DistributedTraceContext.Id` and `DistributedTraceContext.SpanId` are used to restore the same orchestration execution span across reloads/replays/continuations.
- `SubOrchestrationInstanceCreatedEvent.ClientSpanId` is used to recreate the parent-side client span for a sub-orchestration with the exact span ID that the child orchestration server span references as its parent.

When SQL dropped those values:
- later activity-completion and timer spans could parent themselves to orchestration span IDs that no longer matched the replayed orchestration span visible in the exported trace
- child sub-orchestration spans could carry a `parentSpanId` that the parent side never actually emitted, which shows up as a missing parent/orphaned span in trace viewers

## What changed
- extend the SQL `TraceContext` encoding to preserve extra durable trace fields without a schema change
  - normal trace-context rows remain `traceparent\ntracestate`; the extra fields are embedded in a W3C tracestate vendor key: `durabletask-mssql=id:<durable-id>;span:<durable-spanid>[;client:<client-span-id>]`
  - sub-orchestration-created history rows store the parent-side client span as `durabletask-mssql=client:<client-span-id>`; legacy readers materialize these rows as `SubOrchestrationInstanceCreatedEvent` and do not parse this value as a `DistributedTraceContext`
- keep the legacy trace-context format readable for backward compatibility and preserve user tracestate entries when removing the MSSQL vendor key
- rehydrate `ClientSpanId` when materializing `SubOrchestrationInstanceCreatedEvent`
- add unit tests for:
  - extended `DistributedTraceContext` round-tripping
  - legacy compatibility and rolling-upgrade reader behavior
  - sub-orchestration `ClientSpanId` round-tripping
- add integration tests for:
  - stable orchestration span IDs across continuations
  - nested sub-orchestration hierarchies
  - repeated sibling sub-orchestrations
  - no emitted `ParentSpanId` pointing to a missing span in the captured Activity graph

## Scope note
This change fixes newly persisted SQL histories. It does not retroactively backfill older in-flight histories that were already stored in the legacy trace-context format before the provider change.

## Validation
```powershell
dotnet test .\test\DurableTask.SqlServer.Tests\DurableTask.SqlServer.Tests.csproj --filter "FullyQualifiedName~SqlUtilsTraceContextTests" --nologo
```

Sample screenshot for illustration of the problem - spans with incorrect parent IDs.

<img width="992" height="397" alt="image" src="https://github.com/user-attachments/assets/76ff488b-41be-442e-94af-5a741619b4ce" />