### PR TITLE
Update MSSQL publish.yml NuGet release step

### DIFF
--- a/eng/ci/publish.yml
+++ b/eng/ci/publish.yml
@@ -70,30 +70,72 @@ extends:
               instructions: Confirm you want to push to NuGet
               onTimeout: 'reject'
 
-      # NuGet release
-      - job: nugetRelease
-        displayName: NuGet Release
-        dependsOn:
-        - nugetApproval
-        - adoRelease
-        condition: succeeded('nugetApproval', 'adoRelease')
+      # NuGet release (Microsoft.DurableTask.Client.Grpc)
+      - job: nugetRelease_Microsoft_DurableTask_SqlServer
+        displayName: NuGet Release (Microsoft.DurableTask.SqlServer)
+        dependsOn: nugetApproval
+        condition: succeeded('nugetApproval') # nuget packages need to be on ADO first
         templateContext:
+          type: releaseJob
+          isProduction: true
           inputs:
           - input: pipelineArtifact
             pipeline: officialPipeline  # Pipeline reference as defined in the resources section
             artifactName: drop
             targetPath: $(System.DefaultWorkingDirectory)/drop
-        # Ideally, we would push to NuGet using the 1ES "template output" syntax, like we do for ADO.
-        # Unfortunately, that syntax does not allow for skipping duplicates when pushing to NuGet feeds
-        # (i.e; not failing the job when trying to push a package version that already exists on NuGet).
-        # This is a problem for us because our pipelines often produce multiple packages, and we want to be able to
-        # perform a 'nuget push *.nupkg' that skips packages already on NuGet while pushing the rest.
-        # Therefore, we use a regular .NET Core ADO Task to publish the packages until that usability gap is addressed.
         steps:
-        - task: DotNetCoreCLI@2
-          displayName: 'Push to nuget.org'
+        - task: 1ES.PublishNuget@1
+          displayName: 'NuGet push (Microsoft.DurableTask.SqlServer)'
           inputs:
-            command: custom
-            custom: nuget
-            arguments: 'push "*.nupkg" --api-key $(nuget_api_key) --skip-duplicate --source https://api.nuget.org/v3/index.json'
-            workingDirectory: '$(System.DefaultWorkingDirectory)/drop'
+            command: push
+            nuGetFeedType: external
+            publishFeedCredentials: 'DurableTask org NuGet API Key'
+            packagesToPush: '$(System.DefaultWorkingDirectory)/drop/Microsoft.DurableTask.SqlServer.*.nupkg;!$(System.DefaultWorkingDirectory)/drop/Microsoft.DurableTask.SqlServer.AzureFunctions*.nupkg;!$(System.DefaultWorkingDirectory)/**/*.symbols.nupkg' # Excludes Microsoft.DurableTask.SqlServer.AzureFunctions.nupkg
+            packageParentPath: $(System.DefaultWorkingDirectory) # This needs to be set to some prefix of the `packagesToPush` parameter. Apparently it helps with SDL tooling
+
+      # NuGet release (Microsoft.DurableTask.SqlServer.AzureFunctions)
+      - job: nugetRelease_Microsoft_DurableTask_SqlServer_AzureFunctions
+        displayName: NuGet Release (Microsoft.DurableTask.SqlServer.AzureFunctions)
+        dependsOn: nugetApproval
+        condition: succeeded('nugetApproval') # nuget packages need to be on ADO first
+        templateContext:
+          type: releaseJob
+          isProduction: true
+          inputs:
+          - input: pipelineArtifact
+            pipeline: officialPipeline  # Pipeline reference as defined in the resources section
+            artifactName: drop
+            targetPath: $(System.DefaultWorkingDirectory)/drop
+        steps:
+        - task: 1ES.PublishNuget@1
+          displayName: 'NuGet push (Microsoft.DurableTask.SqlServer.AzureFunctions)'
+          inputs:
+            command: push
+            nuGetFeedType: external
+            publishFeedCredentials: 'DurableTask org NuGet API Key'
+            packagesToPush: '$(System.DefaultWorkingDirectory)/drop/Microsoft.DurableTask.SqlServer.AzureFunctions.*.nupkg;!$(System.DefaultWorkingDirectory)/**/*.symbols.nupkg' # Despite this being a custom command, we need to keep this for 1ES validation
+            packageParentPath: $(System.DefaultWorkingDirectory) # This needs to be set to some prefix of the `packagesToPush` parameter. Apparently it helps with SDL tooling
+
+
+      # NuGet release (Microsoft.Azure.Functions.Worker.Extensions.DurableTask.SqlServer)
+      - job: nugetRelease_Microsoft_Azure_Functions_Worker_Extensions_DurableTask_SqlServer
+        displayName: NuGet Release (Microsoft.Azure.Functions.Worker.Extensions.DurableTask.SqlServer)
+        dependsOn: nugetApproval
+        condition: succeeded('nugetApproval') # nuget packages need to be on ADO first
+        templateContext:
+          type: releaseJob
+          isProduction: true
+          inputs:
+          - input: pipelineArtifact
+            pipeline: officialPipeline  # Pipeline reference as defined in the resources section
+            artifactName: drop
+            targetPath: $(System.DefaultWorkingDirectory)/drop
+        steps:
+        - task: 1ES.PublishNuget@1
+          displayName: 'NuGet push (Microsoft.Azure.Functions.Worker.Extensions.DurableTask.SqlServer)'
+          inputs:
+            command: push
+            nuGetFeedType: external
+            publishFeedCredentials: 'DurableTask org NuGet API Key'
+            packagesToPush: '$(System.DefaultWorkingDirectory)/drop/Microsoft.Azure.Functions.Worker.Extensions.DurableTask.SqlServer.*.nupkg;!$(System.DefaultWorkingDirectory)/**/*.symbols.nupkg' # Despite this being a custom command, we need to keep this for 1ES validation
+            packageParentPath: $(System.DefaultWorkingDirectory) # This needs to be set to some prefix of the `packagesToPush` parameter. Apparently it helps with SDL tooling

--- a/eng/ci/publish.yml
+++ b/eng/ci/publish.yml
@@ -70,7 +70,7 @@ extends:
               instructions: Confirm you want to push to NuGet
               onTimeout: 'reject'
 
-      # NuGet release (Microsoft.DurableTask.Client.Grpc)
+      # NuGet release (Microsoft.DurableTask.SqlServer)
       - job: nugetRelease_Microsoft_DurableTask_SqlServer
         displayName: NuGet Release (Microsoft.DurableTask.SqlServer)
         dependsOn: nugetApproval


### PR DESCRIPTION
This pull request updates the NuGet release process in the `eng/ci/publish.yml` pipeline to support publishing multiple specific packages with improved control and validation. The changes replace the previous single release job with three separate jobs, each targeting a different package, and switch to using the `1ES.PublishNuget@1` task for publishing. This enhances maintainability, compliance, and package selection granularity.

**NuGet Release Pipeline Improvements:**

* Replaced the single `nugetRelease` job with three dedicated jobs: one each for `Microsoft.DurableTask.SqlServer`, `Microsoft.DurableTask.SqlServer.AzureFunctions`, and `Microsoft.Azure.Functions.Worker.Extensions.DurableTask.SqlServer`.
* Updated each job to use the `1ES.PublishNuget@1` task instead of the generic `DotNetCoreCLI@2` task, improving compliance and validation.
* Added fine-grained package selection in each job using the `packagesToPush` parameter, ensuring only the intended package is published and symbol packages are excluded.
* Ensured each release job runs only after `nugetApproval` and uses the correct credentials for publishing to NuGet.org.