### PR TITLE
Support separate entity work-item dispatch

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -20,10 +20,12 @@ jobs:
     steps:
     - uses: actions/checkout@v4
 
-    - name: Setup .NET 6
-      uses: actions/setup-dotnet@v3
+    - name: Setup .NET
+      uses: actions/setup-dotnet@v4
       with:
-        dotnet-version: '6.0.x'
+        dotnet-version: |
+          6.0.x
+          8.0.x
       env:
         NUGET_AUTH_TOKEN: RequiredButNotUsed
 

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -6,7 +6,6 @@ on:
       - v* #version is cut
 
 env:
-  DOTNET_VERSION: "6.0.x"
   GITHUB_SOURCE: "https://nuget.pkg.github.com/microsoft/index.json"
   CONFIGURATION: Release
 
@@ -17,10 +16,12 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
-    - name: Setup .NET Core ${{ env.DOTNET_VERSION }}
-      uses: actions/setup-dotnet@v1
+    - name: Setup .NET
+      uses: actions/setup-dotnet@v4
       with:
-        dotnet-version: ${{ env.DOTNET_VERSION }}
+        dotnet-version: |
+          6.0.x
+          8.0.x
     - name: Install dependencies
       run: dotnet restore
     - name: Build

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## v1.8.0
+
+### Updates
+
+* Add separate entity work-item dispatch support for gRPC-based Durable Functions workers.
+
 ## v1.7.0
 
 ### Updates

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -11,7 +11,8 @@
   <ItemGroup>
     <PackageVersion Include="Microsoft.Azure.DurableTask.Core" Version="3.9.0" />
     <PackageVersion Include="Microsoft.Azure.Functions.Worker.Extensions.Abstractions" Version="1.3.0" />
-    <PackageVersion Include="Microsoft.Azure.WebJobs.Extensions.DurableTask" Version="3.0.3" />
+    <PackageVersion Include="Microsoft.Azure.WebJobs.Extensions.DurableTask" Version="3.0.3" Condition="'$(TargetFramework)' == 'net6.0'" />
+    <PackageVersion Include="Microsoft.Azure.WebJobs.Extensions.DurableTask" Version="3.10.0" Condition="'$(TargetFramework)' == 'net8.0'" />
     <PackageVersion Include="Microsoft.Data.SqlClient" Version="3.1.7" />
     <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="1.1.1" />
     <PackageVersion Include="SemanticVersion" Version="2.1.0" />

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -20,6 +20,12 @@ steps:
     packageType: 'sdk'
     version: '6.0.x'
 
+- task: UseDotNet@2
+  displayName: 'Use the .NET 8 SDK'
+  inputs:
+    packageType: 'sdk'
+    version: '8.0.x'
+
 # Start by restoring all the dependencies. This needs to be its own task
 # from what I can tell.
 - task: DotNetCoreCLI@2

--- a/eng/templates/build.yml
+++ b/eng/templates/build.yml
@@ -16,6 +16,12 @@ jobs:
             packageType: 'sdk'
             version: '6.0.x'
 
+        - task: UseDotNet@2
+          displayName: 'Use the .NET 8 SDK'
+          inputs:
+            packageType: 'sdk'
+            version: '8.0.x'
+
         # Start by restoring all the dependencies. This needs to be its own task
         # from what I can tell.
         - task: DotNetCoreCLI@2

--- a/src/DurableTask.SqlServer.AzureFunctions/DurableTask.SqlServer.AzureFunctions.csproj
+++ b/src/DurableTask.SqlServer.AzureFunctions/DurableTask.SqlServer.AzureFunctions.csproj
@@ -4,10 +4,10 @@
   <Import Project="../common.props" />
   
   <PropertyGroup>
-    <TargetFrameworks>net6.0</TargetFrameworks>
+    <TargetFrameworks>net6.0;net8.0</TargetFrameworks>
   </PropertyGroup>
 
-  <PropertyGroup Condition="'$(TargetFramework)' == 'net6.0'">
+  <PropertyGroup Condition="'$(TargetFramework)' == 'net6.0' Or '$(TargetFramework)' == 'net8.0'">
     <DefineConstants>$(DefineConstants);FUNCTIONS_V4</DefineConstants>
   </PropertyGroup>
   

--- a/src/DurableTask.SqlServer.AzureFunctions/SqlDurabilityOptions.cs
+++ b/src/DurableTask.SqlServer.AzureFunctions/SqlDurabilityOptions.cs
@@ -77,6 +77,13 @@ namespace DurableTask.SqlServer.AzureFunctions
                 settings.MaxActiveOrchestrations = extensionOptions.MaxConcurrentOrchestratorFunctions.Value;
             }
 
+            if (extensionOptions.MaxConcurrentEntityFunctions.HasValue)
+            {
+                settings.MaxActiveEntities = extensionOptions.MaxConcurrentEntityFunctions.Value;
+            }
+
+            settings.MaxEntityOperationBatchSize = extensionOptions.MaxEntityOperationBatchSize;
+
             return settings;
         }
     }

--- a/src/DurableTask.SqlServer.AzureFunctions/SqlDurabilityProvider.cs
+++ b/src/DurableTask.SqlServer.AzureFunctions/SqlDurabilityProvider.cs
@@ -46,7 +46,7 @@ namespace DurableTask.SqlServer.AzureFunctions
 #if NET8_0_OR_GREATER
         public override void SetUseSeparateQueueForEntityWorkItems(bool newValue)
         {
-            // SQL stores entity and orchestration work items together, so both modes use the same dequeue path.
+            this.service.UseSeparateQueuesForEntityWorkItems = newValue;
         }
 #endif
 

--- a/src/DurableTask.SqlServer.AzureFunctions/SqlDurabilityProvider.cs
+++ b/src/DurableTask.SqlServer.AzureFunctions/SqlDurabilityProvider.cs
@@ -43,6 +43,13 @@ namespace DurableTask.SqlServer.AzureFunctions
 
         public override string EventSourceName =>  "DurableTask-SqlServer";
 
+#if NET8_0_OR_GREATER
+        public override void SetUseSeparateQueueForEntityWorkItems(bool newValue)
+        {
+            // SQL stores entity and orchestration work items together, so both modes use the same dequeue path.
+        }
+#endif
+
         public override async Task<IList<OrchestrationState>> GetOrchestrationStateWithInputsAsync(string instanceId, bool showInput = true)
         {
             OrchestrationState? state = await this.service.GetOrchestrationStateAsync(instanceId, executionId: null);

--- a/src/DurableTask.SqlServer.AzureFunctions/SqlDurabilityProviderFactory.cs
+++ b/src/DurableTask.SqlServer.AzureFunctions/SqlDurabilityProviderFactory.cs
@@ -21,6 +21,7 @@ namespace DurableTask.SqlServer.AzureFunctions
         readonly DurableTaskOptions extensionOptions;
         readonly ILoggerFactory loggerFactory;
         readonly IConnectionInfoResolver connectionInfoResolver;
+        bool useSeparateQueueForEntityWorkItems;
 
         SqlDurabilityOptions? defaultOptions;
         SqlDurabilityProvider? defaultProvider;
@@ -49,7 +50,7 @@ namespace DurableTask.SqlServer.AzureFunctions
 
         public void SetUseSeparateQueueForEntityWorkItems(bool newValue)
         {
-            // SQL providers do not require different construction for separate entity queue mode.
+            this.useSeparateQueueForEntityWorkItems = newValue;
         }
 
         // Called by the Durable trigger binding infrastructure
@@ -90,9 +91,11 @@ namespace DurableTask.SqlServer.AzureFunctions
 
         SqlOrchestrationService GetOrchestrationService(SqlDurabilityOptions clientOptions)
         {
-            return new (clientOptions.GetOrchestrationServiceSettings(
+            SqlOrchestrationServiceSettings settings = clientOptions.GetOrchestrationServiceSettings(
                 this.extensionOptions,
-                this.connectionInfoResolver));
+                this.connectionInfoResolver);
+            settings.UseSeparateQueueForEntityWorkItems = this.useSeparateQueueForEntityWorkItems;
+            return new SqlOrchestrationService(settings);
         }
 
         static string GetDurabilityProviderKey(DurableClientAttribute attribute)

--- a/src/DurableTask.SqlServer.AzureFunctions/SqlDurabilityProviderFactory.cs
+++ b/src/DurableTask.SqlServer.AzureFunctions/SqlDurabilityProviderFactory.cs
@@ -47,6 +47,11 @@ namespace DurableTask.SqlServer.AzureFunctions
         // Called by the Durable trigger binding infrastructure
         public string Name => SqlDurabilityProvider.Name;
 
+        public void SetUseSeparateQueueForEntityWorkItems(bool newValue)
+        {
+            // SQL providers do not require different construction for separate entity queue mode.
+        }
+
         // Called by the Durable trigger binding infrastructure
         public DurabilityProvider GetDurabilityProvider()
         {

--- a/src/DurableTask.SqlServer/Scripts/logic.sql
+++ b/src/DurableTask.SqlServer/Scripts/logic.sql
@@ -635,7 +635,8 @@ GO
 CREATE OR ALTER PROCEDURE __SchemaNamePlaceholder__._LockNextOrchestration
     @BatchSize int,
     @LockedBy varchar(100),
-    @LockExpiration datetime2
+    @LockExpiration datetime2,
+    @IsEntity bit = NULL
 AS
 BEGIN
     DECLARE @now datetime2 = SYSUTCDATETIME()
@@ -672,7 +673,12 @@ BEGIN
     WHERE
         I.TaskHub = @TaskHub AND
 	    (I.[LockExpiration] IS NULL OR I.[LockExpiration] < @now) AND
-        (E.[VisibleTime] IS NULL OR E.[VisibleTime] < @now)
+        (E.[VisibleTime] IS NULL OR E.[VisibleTime] < @now) AND
+        (
+            @IsEntity IS NULL OR
+            (@IsEntity = 1 AND LEFT(I.[InstanceID], 1) = '@' AND CHARINDEX('@', I.[InstanceID], 2) > 2) OR
+            (@IsEntity = 0 AND NOT (LEFT(I.[InstanceID], 1) = '@' AND CHARINDEX('@', I.[InstanceID], 2) > 2))
+        )
 
     -- Result #1: The list of new events to fetch.
     -- IMPORTANT: DO NOT CHANGE THE ORDER OF RETURNED COLUMNS!
@@ -705,6 +711,7 @@ BEGIN
         N.[TaskHub] = @TaskHub AND
         N.[InstanceID] = @instanceID AND
         (N.[VisibleTime] IS NULL OR N.[VisibleTime] < @now)
+    ORDER BY N.[SequenceNumber]
 
     -- Bail if no events are returned - this implies that another thread already took them (???)
     IF @@ROWCOUNT = 0

--- a/src/DurableTask.SqlServer/SqlOrchestrationService.cs
+++ b/src/DurableTask.SqlServer/SqlOrchestrationService.cs
@@ -14,6 +14,7 @@ namespace DurableTask.SqlServer
     using System.Threading.Tasks;
     using DurableTask.Core;
     using DurableTask.Core.Common;
+    using DurableTask.Core.Entities;
     using DurableTask.Core.Exceptions;
     using DurableTask.Core.History;
     using DurableTask.Core.Query;
@@ -22,10 +23,11 @@ namespace DurableTask.SqlServer
     using Microsoft.Data.SqlClient;
 
 
-    public class SqlOrchestrationService : OrchestrationServiceBase
+    public class SqlOrchestrationService : OrchestrationServiceBase, IEntityOrchestrationService
     {
         readonly SqlOrchestrationServiceSettings settings;
         readonly BackoffPollingHelper orchestrationBackoffHelper;
+        readonly BackoffPollingHelper entityBackoffHelper;
         readonly BackoffPollingHelper activityBackoffHelper;
         readonly LogHelper traceHelper;
         readonly SqlDbManager dbManager;
@@ -36,6 +38,10 @@ namespace DurableTask.SqlServer
         {
             this.settings = ValidateSettings(settings) ?? throw new ArgumentNullException(nameof(settings));
             this.orchestrationBackoffHelper = new BackoffPollingHelper(
+                this.settings.MinOrchestrationPollingInterval,
+                this.settings.MaxOrchestrationPollingInterval,
+                this.settings.DeltaBackoffOrchestrationPollingInterval);
+            this.entityBackoffHelper = new BackoffPollingHelper(
                 this.settings.MinOrchestrationPollingInterval,
                 this.settings.MaxOrchestrationPollingInterval,
                 this.settings.DeltaBackoffOrchestrationPollingInterval);
@@ -52,6 +58,24 @@ namespace DurableTask.SqlServer
         public override int MaxConcurrentTaskOrchestrationWorkItems => this.settings.MaxActiveOrchestrations;
 
         public override int MaxConcurrentTaskActivityWorkItems => this.settings.MaxConcurrentActivities;
+
+        EntityBackendProperties IEntityOrchestrationService.EntityBackendProperties => new EntityBackendProperties
+        {
+            EntityMessageReorderWindow = TimeSpan.Zero,
+            MaxEntityOperationBatchSize = this.settings.MaxEntityOperationBatchSize,
+            MaxConcurrentTaskEntityWorkItems = this.settings.MaxActiveEntities,
+            SupportsImplicitEntityDeletion = true,
+            MaximumSignalDelayTime = TimeSpan.MaxValue,
+            UseSeparateQueueForEntityWorkItems = this.settings.UseSeparateQueueForEntityWorkItems,
+        };
+
+        EntityBackendQueries? IEntityOrchestrationService.EntityBackendQueries => null;
+
+        public bool UseSeparateQueuesForEntityWorkItems
+        {
+            get => this.settings.UseSeparateQueueForEntityWorkItems;
+            set => this.settings.UseSeparateQueueForEntityWorkItems = value;
+        }
 
         static SqlOrchestrationServiceSettings? ValidateSettings(SqlOrchestrationServiceSettings? settings)
         {
@@ -112,8 +136,51 @@ namespace DurableTask.SqlServer
             return this.dbManager.DeleteSchemaAsync();
         }
 
-        public override async Task<TaskOrchestrationWorkItem?> LockNextTaskOrchestrationWorkItemAsync(
+        public override Task<TaskOrchestrationWorkItem?> LockNextTaskOrchestrationWorkItemAsync(
             TimeSpan receiveTimeout,
+            CancellationToken cancellationToken)
+            => this.LockNextTaskOrchestrationWorkItemAsync(
+                receiveTimeout,
+                isEntity: null,
+                this.orchestrationBackoffHelper,
+                cancellationToken);
+
+        async Task<TaskOrchestrationWorkItem> IEntityOrchestrationService.LockNextOrchestrationWorkItemAsync(
+            TimeSpan receiveTimeout,
+            CancellationToken cancellationToken)
+        {
+            if (!this.settings.UseSeparateQueueForEntityWorkItems)
+            {
+                throw new InvalidOperationException("Separate entity dispatch is not enabled.");
+            }
+
+            return (await this.LockNextTaskOrchestrationWorkItemAsync(
+                receiveTimeout,
+                isEntity: false,
+                this.orchestrationBackoffHelper,
+                cancellationToken))!;
+        }
+
+        async Task<TaskOrchestrationWorkItem> IEntityOrchestrationService.LockNextEntityWorkItemAsync(
+            TimeSpan receiveTimeout,
+            CancellationToken cancellationToken)
+        {
+            if (!this.settings.UseSeparateQueueForEntityWorkItems)
+            {
+                throw new InvalidOperationException("Separate entity dispatch is not enabled.");
+            }
+
+            return (await this.LockNextTaskOrchestrationWorkItemAsync(
+                receiveTimeout,
+                isEntity: true,
+                this.entityBackoffHelper,
+                cancellationToken))!;
+        }
+
+        async Task<TaskOrchestrationWorkItem?> LockNextTaskOrchestrationWorkItemAsync(
+            TimeSpan receiveTimeout,
+            bool? isEntity,
+            BackoffPollingHelper backoffHelper,
             CancellationToken cancellationToken)
         {
             bool isWaiting = false;
@@ -129,6 +196,7 @@ namespace DurableTask.SqlServer
                 command.Parameters.Add("@BatchSize", SqlDbType.Int).Value = batchSize;
                 command.Parameters.Add("@LockedBy", SqlDbType.VarChar, 100).Value = this.lockedByValue;
                 command.Parameters.Add("@LockExpiration", SqlDbType.DateTime2).Value = lockExpiration;
+                command.Parameters.Add("@IsEntity", SqlDbType.Bit).Value = (object?)isEntity ?? DBNull.Value;
 
                 DbDataReader reader;
 
@@ -183,11 +251,11 @@ namespace DurableTask.SqlServer
                         }
 
                         // TODO: Make this dynamic based on the number of readers
-                        await this.orchestrationBackoffHelper.WaitAsync(cancellationToken);
+                        await backoffHelper.WaitAsync(cancellationToken);
                         continue;
                     }
 
-                    this.orchestrationBackoffHelper.Reset();
+                    backoffHelper.Reset();
                     isWaiting = false;
 
                     // Result #2: The runtime status of the orchestration instance
@@ -410,6 +478,7 @@ namespace DurableTask.SqlServer
             if (orchestratorMessages.Count > 0 || timerMessages.Count > 0)
             {
                 this.orchestrationBackoffHelper.Reset();
+                this.entityBackoffHelper.Reset();
             }
 
             this.traceHelper.CheckpointCompleted(orchestrationState, sw);

--- a/src/DurableTask.SqlServer/SqlOrchestrationServiceSettings.cs
+++ b/src/DurableTask.SqlServer/SqlOrchestrationServiceSettings.cs
@@ -94,6 +94,25 @@ namespace DurableTask.SqlServer
         public int MaxActiveOrchestrations { get; set; } = Environment.ProcessorCount;
 
         /// <summary>
+        /// Gets or sets the maximum number of entities that can be loaded in memory at a time by a single worker.
+        /// The default value is the value of <see cref="Environment.ProcessorCount"/>.
+        /// </summary>
+        [JsonProperty("maxActiveEntities")]
+        public int MaxActiveEntities { get; set; } = Environment.ProcessorCount;
+
+        /// <summary>
+        /// Gets or sets the maximum number of entity operations that can be processed in a single batch.
+        /// </summary>
+        [JsonProperty("maxEntityOperationBatchSize")]
+        public int? MaxEntityOperationBatchSize { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether entities and orchestrations are dispatched separately.
+        /// </summary>
+        [JsonProperty("useSeparateQueueForEntityWorkItems")]
+        public bool UseSeparateQueueForEntityWorkItems { get; set; }
+
+        /// <summary>
         /// Gets or sets the minimum interval to poll for orchestrations.
         /// Polling interval increases when no orchestrations or activities are found.
         /// The default value is 50 milliseconds.

--- a/src/common.props
+++ b/src/common.props
@@ -16,7 +16,7 @@
   <!-- Version settings: https://andrewlock.net/version-vs-versionsuffix-vs-packageversion-what-do-they-all-mean/ -->
   <PropertyGroup>
     <MajorVersion>1</MajorVersion>
-    <MinorVersion>7</MinorVersion>
+    <MinorVersion>8</MinorVersion>
     <PatchVersion>0</PatchVersion>
     <VersionPrefix>$(MajorVersion).$(MinorVersion).$(PatchVersion)</VersionPrefix>
     <VersionSuffix></VersionSuffix>

--- a/test/DurableTask.SqlServer.AzureFunctions.Tests/DurableTask.SqlServer.AzureFunctions.Tests.csproj
+++ b/test/DurableTask.SqlServer.AzureFunctions.Tests/DurableTask.SqlServer.AzureFunctions.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <IsPackable>false</IsPackable>
     <SignAssembly>true</SignAssembly>
     <LangVersion>9.0</LangVersion>

--- a/test/DurableTask.SqlServer.AzureFunctions.Tests/QueueModeTests.cs
+++ b/test/DurableTask.SqlServer.AzureFunctions.Tests/QueueModeTests.cs
@@ -1,0 +1,54 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+namespace DurableTask.SqlServer.AzureFunctions.Tests
+{
+    using System;
+    using System.Collections.Generic;
+    using Microsoft.Azure.WebJobs.Extensions.DurableTask;
+    using Microsoft.Extensions.Configuration;
+    using Microsoft.Extensions.DependencyInjection;
+    using Xunit;
+
+    public class QueueModeTests
+    {
+        [Fact]
+        public void CanSwitchEntityQueueModes()
+        {
+            var services = new ServiceCollection();
+            services.AddLogging();
+            services.AddOptions();
+            services.Configure<DurableTaskOptions>(options => options.HubName = "QueueModeTests");
+            services.AddSingleton<IConnectionInfoResolver>(
+                new TestConnectionInfoResolver("Server=(local);Database=DurableTask;Integrated Security=true"));
+            services.AddDurableTaskSqlProvider();
+
+            using ServiceProvider serviceProvider = services.BuildServiceProvider();
+            IDurabilityProviderFactory factory = serviceProvider.GetRequiredService<IDurabilityProviderFactory>();
+
+            factory.SetUseSeparateQueueForEntityWorkItems(true);
+            DurabilityProvider provider = factory.GetDurabilityProvider();
+            provider.SetUseSeparateQueueForEntityWorkItems(true);
+
+            factory.SetUseSeparateQueueForEntityWorkItems(false);
+            provider.SetUseSeparateQueueForEntityWorkItems(false);
+        }
+
+        class TestConnectionInfoResolver : IConnectionInfoResolver
+        {
+            readonly IConfiguration configuration;
+
+            public TestConnectionInfoResolver(string connectionString)
+            {
+                this.configuration = new ConfigurationBuilder()
+                    .AddInMemoryCollection(new Dictionary<string, string?>
+                    {
+                        ["SQLDB_Connection"] = connectionString,
+                    })
+                    .Build();
+            }
+
+            public IConfigurationSection Resolve(string name) => this.configuration.GetSection(name);
+        }
+    }
+}

--- a/test/DurableTask.SqlServer.AzureFunctions.Tests/QueueModeTests.cs
+++ b/test/DurableTask.SqlServer.AzureFunctions.Tests/QueueModeTests.cs
@@ -28,6 +28,7 @@ namespace DurableTask.SqlServer.AzureFunctions.Tests
 
             factory.SetUseSeparateQueueForEntityWorkItems(true);
             DurabilityProvider provider = factory.GetDurabilityProvider();
+            Assert.True(provider.SupportsEntities);
             provider.SetUseSeparateQueueForEntityWorkItems(true);
 
             factory.SetUseSeparateQueueForEntityWorkItems(false);

--- a/test/DurableTask.SqlServer.Tests/Integration/EntityQueueModes.cs
+++ b/test/DurableTask.SqlServer.Tests/Integration/EntityQueueModes.cs
@@ -1,0 +1,121 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+namespace DurableTask.SqlServer.Tests.Integration
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using DurableTask.Core;
+    using DurableTask.Core.Common;
+    using DurableTask.Core.Entities;
+    using DurableTask.SqlServer.Tests.Utils;
+    using Xunit;
+    using Xunit.Abstractions;
+
+    [Collection("Integration")]
+    public class EntityQueueModes : IAsyncLifetime
+    {
+        readonly TestService testService;
+
+        public EntityQueueModes(ITestOutputHelper output)
+        {
+            this.testService = new TestService(output);
+        }
+
+        Task IAsyncLifetime.InitializeAsync() => this.testService.InitializeAsync(startWorker: false);
+
+        Task IAsyncLifetime.DisposeAsync() => this.testService.DisposeAsync();
+
+        [Fact]
+        public async Task SwitchingToSeparateQueuesPartitionsExistingWork()
+        {
+            string orchestrationInstanceId = Guid.NewGuid().ToString("N");
+            string entityInstanceId = $"@Counter@{Guid.NewGuid():N}";
+            await this.EnqueueOrchestrationAndEntity(orchestrationInstanceId, entityInstanceId);
+
+            this.testService.OrchestrationServiceOptions.UseSeparateQueueForEntityWorkItems = true;
+            var entityService = (IEntityOrchestrationService)this.testService.OrchestrationServiceMock.Object;
+
+            TaskOrchestrationWorkItem orchestration = await entityService.LockNextOrchestrationWorkItemAsync(
+                TimeSpan.FromSeconds(5),
+                CancellationToken.None);
+            TaskOrchestrationWorkItem entity = await entityService.LockNextEntityWorkItemAsync(
+                TimeSpan.FromSeconds(5),
+                CancellationToken.None);
+
+            Assert.Equal(orchestrationInstanceId, orchestration.InstanceId);
+            Assert.False(Entities.IsEntityInstance(orchestration.InstanceId));
+            Assert.Equal(entityInstanceId, entity.InstanceId);
+            Assert.True(Entities.IsEntityInstance(entity.InstanceId));
+        }
+
+        [Fact]
+        public async Task SwitchingToSharedQueueDrainsExistingEntityWork()
+        {
+            string entityInstanceId = $"@Counter@{Guid.NewGuid():N}";
+            this.testService.OrchestrationServiceOptions.UseSeparateQueueForEntityWorkItems = true;
+            await this.EnqueueOrchestrationAndEntity(Guid.NewGuid().ToString("N"), entityInstanceId);
+
+            this.testService.OrchestrationServiceOptions.UseSeparateQueueForEntityWorkItems = false;
+            TaskOrchestrationWorkItem firstWorkItem =
+                await this.testService.OrchestrationServiceMock.Object.LockNextTaskOrchestrationWorkItemAsync(
+                    TimeSpan.FromSeconds(5),
+                    CancellationToken.None);
+            TaskOrchestrationWorkItem secondWorkItem =
+                await this.testService.OrchestrationServiceMock.Object.LockNextTaskOrchestrationWorkItemAsync(
+                    TimeSpan.FromSeconds(5),
+                    CancellationToken.None);
+
+            Assert.Contains(
+                entityInstanceId,
+                new[] { firstWorkItem.InstanceId, secondWorkItem.InstanceId });
+        }
+
+        [Fact]
+        public async Task SharedAndSeparateWorkersDoNotDoubleLockEntityWork()
+        {
+            string entityInstanceId = $"@Counter@{Guid.NewGuid():N}";
+            await this.EnqueueOrchestrationAndEntity(Guid.NewGuid().ToString("N"), entityInstanceId);
+
+            this.testService.OrchestrationServiceOptions.UseSeparateQueueForEntityWorkItems = true;
+            var entityService = (IEntityOrchestrationService)this.testService.OrchestrationServiceMock.Object;
+
+            Task<TaskOrchestrationWorkItem> sharedWorker = this.testService.OrchestrationServiceMock.Object
+                .LockNextTaskOrchestrationWorkItemAsync(TimeSpan.FromSeconds(2), CancellationToken.None);
+            Task<TaskOrchestrationWorkItem> separateEntityWorker = entityService.LockNextEntityWorkItemAsync(
+                TimeSpan.FromSeconds(2),
+                CancellationToken.None);
+            Task<TaskOrchestrationWorkItem> separateOrchestrationWorker =
+                entityService.LockNextOrchestrationWorkItemAsync(
+                    TimeSpan.FromSeconds(2),
+                    CancellationToken.None);
+
+            await Task.WhenAll(sharedWorker, separateEntityWorker, separateOrchestrationWorker);
+
+            TaskOrchestrationWorkItem[] lockedWorkItems =
+            {
+                sharedWorker.Result,
+                separateEntityWorker.Result,
+                separateOrchestrationWorker.Result,
+            };
+            Assert.Equal(2, lockedWorkItems.Count(item => item != null));
+            Assert.Single(lockedWorkItems, item => item?.InstanceId == entityInstanceId);
+        }
+
+        Task<IReadOnlyList<TestInstance<string>>> EnqueueOrchestrationAndEntity(
+            string orchestrationInstanceId,
+            string entityInstanceId)
+        {
+            return this.testService.RunOrchestrations<string, string>(
+                count: 2,
+                instanceIdGenerator: i => i == 0 ? orchestrationInstanceId : entityInstanceId,
+                inputGenerator: i => i.ToString(),
+                orchestrationName: "QueueModeOrchestration",
+                version: string.Empty,
+                implementation: (context, input) => Task.FromResult(input));
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- implement `IEntityOrchestrationService` in the SQL backend with independent entity and orchestration dequeue paths
- partition entity work at lock time using the existing `@name@key` instance ID convention
- keep the existing combined dequeue path for shared mode and older workers
- make the provider and factory apply `UseSeparateQueueForEntityWorkItems` before `TaskHubWorker` construction
- preserve .NET 6 support while adding a .NET 8 target using Durable Functions extension 3.10.0
- update CI/release SDK installation and advance the package version to 1.8.0 so existing databases reapply the stored procedure update

This supplies the storage-provider behavior required by Azure/azure-functions-durable-extension#3260. Entity and orchestration messages continue to share `NewEvents`; switching modes changes only the atomic lock-time filter, so queued work is not moved or stranded.

## Compatibility

`_LockNextOrchestration` adds an optional `@IsEntity` parameter:

- `NULL`: combined entity/orchestration dispatch used by shared mode and older workers
- `0`: orchestration-only dispatch
- `1`: entity-only dispatch

All three paths lock the same `Instances` row in one transaction. This preserves exactly-once locking during rolling upgrades where shared-mode and separate-mode workers use the same task hub. Events are returned in `SequenceNumber` order so the backend's zero entity reorder window remains valid.

## Validation

- restored and built the complete solution for all target frameworks
- verified provider/factory mode switching and native entity support
- verified false-to-true migration with already-enqueued work
- verified true-to-false migration drains existing entity work through the combined path
- verified concurrent shared and separate workers cannot lock the same entity instance
- verified the final stored procedure against SQL Server 2019