### PR TITLE
Fix entity cleanup paging

### DIFF
--- a/src/DurableTask.SqlServer/EntitySqlBackendQueries.cs
+++ b/src/DurableTask.SqlServer/EntitySqlBackendQueries.cs
@@ -92,6 +92,7 @@ namespace DurableTask.SqlServer
 
             int retrievedResults = 0;
             IEnumerable<OrchestrationState> allResults = Array.Empty<OrchestrationState>();
+            var lockReleaseRequests = new HashSet<(string EntityId, string LockOwner)>();
             var stopwatch = new Stopwatch();
             stopwatch.Start();
             do
@@ -105,10 +106,8 @@ namespace DurableTask.SqlServer
                     CreatedTimeTo = DateTime.MaxValue,
                     FetchInput = true,
                 };
-
                 IReadOnlyCollection<OrchestrationState> page = await this.orchestrationService.GetManyOrchestrationsAsync(entityInstancesQuery, cancellation);
 
-                pageNumber++;
                 retrievedResults = page.Count;
                 if (retrievedResults == 0)
                 {
@@ -124,9 +123,12 @@ namespace DurableTask.SqlServer
                     EntityStatus? status = ClientEntityHelpers.GetEntityStatus(state.Status);
                     if (status != null)
                     {
-                        if (request.ReleaseOrphanedLocks && status.LockedBy != null)
+                        string? lockOwner = status.LockedBy;
+                        if (request.ReleaseOrphanedLocks &&
+                            lockOwner != null &&
+                            lockReleaseRequests.Add((state.OrchestrationInstance.InstanceId, lockOwner)))
                         {
-                            tasks.Add(CheckForOrphanedLockAndFixIt(state, status.LockedBy));
+                            tasks.Add(CheckForOrphanedLockAndFixIt(state, lockOwner));
                         }
 
                         if (request.RemoveEmptyEntities)
@@ -161,6 +163,10 @@ namespace DurableTask.SqlServer
 
                 await Task.WhenAll(tasks);
                 emptyEntitiesRemoved += await this.orchestrationService.PurgeOrchestrationHistoryAsync(emptyEntityIds);
+                if (emptyEntityIds.Count == 0)
+                {
+                    pageNumber++;
+                }
 
             } while (retrievedResults > 0 && stopwatch.Elapsed <= TimeLimitForCleanEntityStorageLoop);
 

--- a/src/DurableTask.SqlServer/EntitySqlBackendQueries.cs
+++ b/src/DurableTask.SqlServer/EntitySqlBackendQueries.cs
@@ -104,7 +104,7 @@ namespace DurableTask.SqlServer
                     InstanceIdPrefix = "@",
                     CreatedTimeFrom = DateTime.MinValue,
                     CreatedTimeTo = DateTime.MaxValue,
-                    FetchInput = true,
+                    FetchInput = false,
                 };
                 IReadOnlyCollection<OrchestrationState> page = await this.orchestrationService.GetManyOrchestrationsAsync(entityInstancesQuery, cancellation);
 

--- a/test/DurableTask.SqlServer.Tests/Integration/EntitySqlBackendQueriesTests.cs
+++ b/test/DurableTask.SqlServer.Tests/Integration/EntitySqlBackendQueriesTests.cs
@@ -1,0 +1,102 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+namespace DurableTask.SqlServer.Tests.Integration
+{
+    using System.Threading.Tasks;
+    using DurableTask.Core.Entities;
+    using DurableTask.SqlServer.Tests.Utils;
+    using Xunit;
+    using Xunit.Abstractions;
+
+    [Collection("Integration")]
+    public class EntitySqlBackendQueriesTests : IAsyncLifetime
+    {
+        readonly TestService testService;
+        readonly ITestOutputHelper output;
+
+        public EntitySqlBackendQueriesTests(ITestOutputHelper output)
+        {
+            this.testService = new TestService(output);
+            this.output = output;
+        }
+
+        Task IAsyncLifetime.InitializeAsync() => this.testService.InitializeAsync(startWorker: false);
+
+        Task IAsyncLifetime.DisposeAsync() => this.testService.DisposeAsync();
+
+        [Fact]
+        public async Task CleansMultiplePages()
+        {
+            const int EntityCount = 150;
+            const string InstanceIdPrefix = "@CleanupPaging@";
+            string taskHubName = await this.testService.GetTaskHubNameAsync();
+
+            int insertedCount = (int)await SharedTestHelpers.ExecuteSqlAsync(
+                this.output,
+                $@"
+DECLARE @Entities TABLE (
+    [InstanceID] varchar(100) NOT NULL,
+    [PayloadID] uniqueidentifier NOT NULL,
+    [CreatedTime] datetime2 NOT NULL);
+
+WITH Numbers AS (
+    SELECT 0 AS [Number]
+    UNION ALL
+    SELECT [Number] + 1 FROM Numbers WHERE [Number] + 1 < {EntityCount}
+)
+INSERT INTO @Entities
+SELECT
+    CONCAT('{InstanceIdPrefix}', FORMAT([Number], '000')),
+    NEWID(),
+    DATEADD(second, [Number], DATEADD(day, -1, SYSUTCDATETIME()))
+FROM Numbers
+OPTION (MAXRECURSION {EntityCount});
+
+INSERT INTO dt.[Payloads] ([TaskHub], [InstanceID], [PayloadID], [Text])
+SELECT '{taskHubName}', [InstanceID], [PayloadID], '{{""entityExists"":false}}'
+FROM @Entities;
+
+INSERT INTO dt.[Instances] (
+    [TaskHub],
+    [InstanceID],
+    [ExecutionID],
+    [Name],
+    [Version],
+    [CreatedTime],
+    [LastUpdatedTime],
+    [RuntimeStatus],
+    [CustomStatusPayloadID])
+SELECT
+    '{taskHubName}',
+    [InstanceID],
+    CONVERT(varchar(50), NEWID()),
+    'CleanupPaging',
+    '',
+    [CreatedTime],
+    DATEADD(day, -1, SYSUTCDATETIME()),
+    'Running',
+    [PayloadID]
+FROM @Entities;
+
+SELECT COUNT(*) FROM @Entities;");
+            Assert.Equal(EntityCount, insertedCount);
+
+            EntityBackendQueries.CleanEntityStorageResult result =
+                await this.testService.OrchestrationServiceMock.Object.EntityBackendQueries.CleanEntityStorageAsync(
+                    new EntityBackendQueries.CleanEntityStorageRequest
+                    {
+                        RemoveEmptyEntities = true,
+                    });
+
+            Assert.Equal(EntityCount, result.EmptyEntitiesRemoved);
+            Assert.Null(result.ContinuationToken);
+
+            int remainingCount = (int)await SharedTestHelpers.ExecuteSqlAsync(
+                this.output,
+                $@"SELECT COUNT(*) FROM dt.[Instances]
+WHERE [TaskHub] = '{taskHubName}' AND [InstanceID] LIKE '{InstanceIdPrefix}%';");
+            Assert.Equal(0, remainingCount);
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- Re-query the current entity cleanup page after deleting empty entities so shifted rows are not skipped.
- Advance to the next page only when the current page contains no deletable entities.
- Deduplicate orphaned-lock release requests when cleanup revisits a page.
- Add an integration regression test covering 150 empty entities across multiple pages.

## Validation

- `dotnet build DurableTask.SqlServer.sln --no-restore --nologo --verbosity minimal`
- The targeted regression test builds but cannot complete locally because SQL Server rejects dynamically created integration-test logins; the pre-existing `EntityQueueModes.SwitchingToSeparateQueuesPartitionsExistingWork` test fails with the same login error.