### PR TITLE
Route NuGet restores through CFS

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -31,10 +31,10 @@ jobs:
           8.0.x
 
     - name: NuGet Restore
-      run: dotnet restore -v n
+      run: dotnet restore --configfile "$GITHUB_WORKSPACE/nuget.config" -v n
 
     - name: Build
-      run: dotnet build
+      run: dotnet build --no-restore
 
     - name: Setup SQL Server container
       run: test/setup.ps1

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -32,6 +32,8 @@ steps:
   displayName: 'Restore nuget dependencies'
   inputs:
     command: restore
+    feedsToUse: config
+    nugetConfigPath: 'nuget.config'
     verbosityRestore: Minimal
     projects: '**/*.csproj'
 

--- a/eng/templates/build.yml
+++ b/eng/templates/build.yml
@@ -28,6 +28,8 @@ jobs:
           displayName: 'Restore nuget dependencies'
           inputs:
             command: restore
+            feedsToUse: config
+            nugetConfigPath: 'nuget.config'
             verbosityRestore: Minimal
             projects: '**/*.csproj'
 

--- a/nuget.config
+++ b/nuget.config
@@ -1,8 +1,12 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-
 <configuration>
   <packageSources>
-    <clear/>
-    <add key="nuget.org" value="https://www.nuget.org/api/v2/" />
+    <clear />
+    <add key="CFS" value="https://pkgs.dev.azure.com/azfunc/public/_packaging/upstream-public/nuget/v3/index.json" />
   </packageSources>
+  <packageSourceMapping>
+    <packageSource key="CFS">
+      <package pattern="*" />
+    </packageSource>
+  </packageSourceMapping>
 </configuration>

--- a/test/PerformanceTests/Dockerfile
+++ b/test/PerformanceTests/Dockerfile
@@ -6,7 +6,8 @@ FROM mcr.microsoft.com/dotnet/sdk:6.0 AS installer-env
 COPY . /durabletask-mssql
 RUN cd /durabletask-mssql/test/PerformanceTests && \
     mkdir -p /home/site/wwwroot && \
-    dotnet publish -c Release *.csproj --output /home/site/wwwroot
+    dotnet restore "PerformanceTests.csproj" --configfile "/durabletask-mssql/nuget.config" && \
+    dotnet publish -c Release "PerformanceTests.csproj" --no-restore --output /home/site/wwwroot
 
 # To enable ssh & remote debugging on app service change the base image to the one below
 # FROM mcr.microsoft.com/azure-functions/dotnet:3.0-appservice


### PR DESCRIPTION
## Summary
- replace the direct NuGet.org source with the public Central Feed Service endpoint and wildcard package source mapping
- make both Azure Pipelines restore tasks consume the repository `nuget.config`
- make GitHub Actions and the performance-test container perform one explicit configured restore, then build/publish without restoring again

## Validation
- restored all 7 projects from an empty, isolated NuGet global-packages, HTTP, plugin, scratch, and CLI-home cache under .NET SDK 8.0.423
- exercised the detached checkout from a path containing spaces with PowerShell argument arrays; 256 package IDs restored across 1,396 observable CFS request lines with no direct NuGet.org/npmjs/PyPI traffic
- built the solution in Release, passed 30 non-database tests, packed all 3 shipping projects, and published the performance-test app without another restore
- audited all 3 `.nupkg` files and 78 publish-output files: no feed config, credential-like file, lockfile, or `node_modules` content was shipped
- ran the transitive vulnerability listing through the repository CFS config; existing advisories remain visible and were not suppressed

## Caveat
The local Docker daemon was unavailable. The Docker restore/publish commands were exercised directly; the repository's existing `sdk:6.0` builder image also predates the performance project's `net8.0` target and is outside this feed-routing change.