### PR TITLE
Build with the installed .NET SDK

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -37,16 +37,14 @@ steps:
     verbosityRestore: Minimal
     projects: '**/*.csproj'
 
-# Build the entire solution. This will also build all the tests, which
-# isn't strictly necessary...
-- task: VSBuild@1
+# Build the entire solution with the installed .NET SDK. This will also build
+# all the tests, which isn't strictly necessary...
+- task: DotNetCoreCLI@2
   displayName: 'Build'
   inputs:
-    solution: '**/*.sln'
-    vsVersion: 'latest'
-    logFileVerbosity: minimal
-    configuration: Release
-    msbuildArgs: /p:FileVersionRevision=$(Build.BuildId) /p:ContinuousIntegrationBuild=true
+    command: build
+    projects: '**/*.sln'
+    arguments: '--configuration Release --no-restore --verbosity minimal /p:FileVersionRevision=$(Build.BuildId) /p:ContinuousIntegrationBuild=true'
 
 # Authenticode sign all the DLLs with the Microsoft certificate.
 # This appears to be an in-place signing job, which is convenient.

--- a/eng/templates/build.yml
+++ b/eng/templates/build.yml
@@ -33,16 +33,14 @@ jobs:
             verbosityRestore: Minimal
             projects: '**/*.csproj'
 
-        # Build the entire solution. This will also build all the tests, which
-        # isn't strictly necessary...
-        - task: VSBuild@1
+        # Build the entire solution with the installed .NET SDK. This will also
+        # build all the tests, which isn't strictly necessary...
+        - task: DotNetCoreCLI@2
           displayName: 'Build'
           inputs:
-            solution: '**/*.sln'
-            vsVersion: 'latest'
-            logFileVerbosity: minimal
-            configuration: Release
-            msbuildArgs: /p:FileVersionRevision=$(Build.BuildId) /p:ContinuousIntegrationBuild=true
+            command: build
+            projects: '**/*.sln'
+            arguments: '--configuration Release --no-restore --verbosity minimal /p:FileVersionRevision=$(Build.BuildId) /p:ContinuousIntegrationBuild=true'
 
         - template: ci/sign-files.yml@eng
           parameters:


### PR DESCRIPTION
## Summary
- replace `VSBuild@1` with `DotNetCoreCLI@2` in both ADO build definitions
- build through the installed .NET 10 SDK instead of Visual Studio 2022's incompatible MSBuild 17.14
- preserve the explicit CFS restore boundary with `--no-restore` and existing version properties

## Root cause
ADO run 20260731.4 restored successfully through CFS, then failed because .NET SDK 10.0.302 requires MSBuild 18 while `VSBuild@1` selected Visual Studio 2022 MSBuild 17.14.

## Validation
- official ADO pipeline run [20260731.5](https://dev.azure.com/azfunc/internal/_build/results?buildId=294766) succeeded against this branch
- all seven projects restored successfully through the repository CFS configuration
- SDK-native Release build succeeded with zero errors
- Network Isolation recorded no blocked connections and reported `CFSClean`, `CFSClean2`, `CFSClean3`, and Default Deny compliant