### PR TITLE
Pin System.Drawing.Common for 1.8.1

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -33,6 +33,14 @@ jobs:
     - name: NuGet Restore
       run: dotnet restore --configfile "$GITHUB_WORKSPACE/nuget.config" -v n
 
+    - name: Check vulnerable NuGet dependencies
+      run: |
+        output=$(dotnet list DurableTask.SqlServer.sln package --vulnerable --include-transitive --no-restore)
+        echo "$output"
+        if echo "$output" | grep --quiet "has the following vulnerable packages"; then
+          exit 1
+        fi
+
     - name: Build
       run: dotnet build --no-restore
 

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -24,7 +24,7 @@
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
     <PackageVersion Include="Microsoft.SqlServer.SqlManagementObjects" Version="172.52.0" />
     <PackageVersion Include="Moq" Version="4.20.72" />
-    <PackageVersion Include="OpenTelemetry.Exporter.InMemory" Version="1.9.0" />
+    <PackageVersion Include="OpenTelemetry.Exporter.InMemory" Version="1.15.3" />
     <PackageVersion Include="xunit" Version="2.9.3" />
     <PackageVersion Include="xunit.runner.visualstudio" Version="3.0.1" />
   </ItemGroup>
@@ -37,6 +37,7 @@
     <PackageVersion Include="Azure.Identity" Version="1.12.1" />
     <PackageVersion Include="Microsoft.IdentityModel.JsonWebTokens" Version="6.35.0" />
     <PackageVersion Include="System.IdentityModel.Tokens.Jwt" Version="6.35.0" />
+    <PackageVersion Include="System.Drawing.Common" Version="4.7.2" />
     <PackageVersion Include="System.Text.Json" Version="6.0.11" />
   </ItemGroup>
 </Project>

--- a/eng/templates/build.yml
+++ b/eng/templates/build.yml
@@ -33,6 +33,21 @@ jobs:
             verbosityRestore: Minimal
             projects: '**/*.csproj'
 
+        - task: PowerShell@2
+          displayName: 'Check vulnerable NuGet dependencies'
+          inputs:
+            targetType: inline
+            script: |
+              $output = dotnet list DurableTask.SqlServer.sln package --vulnerable --include-transitive --no-restore
+              $output | Write-Host
+              if ($LASTEXITCODE -ne 0) {
+                exit $LASTEXITCODE
+              }
+
+              if ($output -match 'has the following vulnerable packages') {
+                throw 'Vulnerable NuGet dependencies were found.'
+              }
+
         # Build the entire solution with the installed .NET SDK. This will also
         # build all the tests, which isn't strictly necessary...
         - task: DotNetCoreCLI@2

--- a/src/DurableTask.SqlServer/DurableTask.SqlServer.csproj
+++ b/src/DurableTask.SqlServer/DurableTask.SqlServer.csproj
@@ -32,6 +32,7 @@
     <PackageReference Include="Azure.Identity" />
     <PackageReference Include="Microsoft.IdentityModel.JsonWebTokens" />
     <PackageReference Include="System.IdentityModel.Tokens.Jwt" />
+    <PackageReference Include="System.Drawing.Common" />
     <PackageReference Include="System.Text.Json" />
   </ItemGroup>
 

--- a/src/common.props
+++ b/src/common.props
@@ -17,7 +17,7 @@
   <PropertyGroup>
     <MajorVersion>1</MajorVersion>
     <MinorVersion>8</MinorVersion>
-    <PatchVersion>0</PatchVersion>
+    <PatchVersion>1</PatchVersion>
     <VersionPrefix>$(MajorVersion).$(MinorVersion).$(PatchVersion)</VersionPrefix>
     <VersionSuffix></VersionSuffix>
     <AssemblyVersion>$(MajorVersion).$(MinorVersion).0.0</AssemblyVersion>


### PR DESCRIPTION
## Summary
- Pin `System.Drawing.Common` to 4.7.2 in the shipping package and set the patch version to 1.8.1.
- Update the test-only OpenTelemetry exporter to 1.15.3 so the solution has no reported vulnerable transitive packages.
- Add vulnerability gates to GitHub Actions and the official Azure DevOps build.

## Validation
- `dotnet list DurableTask.SqlServer.sln package --vulnerable --include-transitive --no-restore`
- `dotnet test test/DurableTask.SqlServer.Tests/DurableTask.SqlServer.Tests.csproj --no-restore --configuration Release --filter "FullyQualifiedName!~Integration"`